### PR TITLE
Add command handling for TUI reset and clear

### DIFF
--- a/core/state_manager.py
+++ b/core/state_manager.py
@@ -151,6 +151,20 @@ class StateManager:
         End the session, clearing session context so the next user input starts fresh.
         """
         StateSession.end()
+
+    def clear_conversation_history(self) -> None:
+        """Drop all stored conversation messages for the active user."""
+        self._conversation.clear()
+        self._update_session_conversation_state()
+
+    def reset(self) -> None:
+        """Fully reset runtime state, including tasks and session context."""
+        self.tasks.clear()
+        self.agent_properties = {}
+        self.clear_conversation_history()
+        if self.event_stream_manager:
+            self.event_stream_manager.clear_all()
+        self.end_session()
         
     def _format_conversation_state(self) -> str:
         if not self._conversation:

--- a/core/task/task_manager.py
+++ b/core/task/task_manager.py
@@ -35,6 +35,10 @@ class TaskManager:
     def attach_state_manager(self, state_manager: "StateManager") -> None:
         self.state_manager = state_manager
 
+    def reset(self) -> None:
+        """Clear all active tasks and detach any session-linked state."""
+        self.active.clear()
+
     # ─────────────────────── Creation ─────────────────────────────────
     async def create_task(self, task_name: str, task_instruction: str) -> str:
         task_id = f"{task_name}_{uuid.uuid4().hex[:6]}"

--- a/core/trigger.py
+++ b/core/trigger.py
@@ -113,6 +113,13 @@ class TriggerQueue:
         ]
 
         return "\n\n".join([section for section in sections if section])
+
+    async def clear(self) -> None:
+        """Remove all pending triggers from the queue."""
+
+        async with self._cv:
+            self._heap.clear()
+            self._cv.notify_all()
         
     # =================================================================
     # PUT


### PR DESCRIPTION
## Summary
- add a command registry for the agent and TUI with handlers for exit, reset, and clear
- implement /reset to refresh agent state, clearing triggers, tasks, and session data
- implement /clear to wipe chat/action logs and expose clearer startup messaging

## Testing
- python -m compileall core agents

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932495ce40c8324bae0f92f6a757fc5)