### PR TITLE
Add launch menu before chat interface

### DIFF
--- a/core/agent_base.py
+++ b/core/agent_base.py
@@ -73,6 +73,7 @@ class AgentBase:
         *,
         data_dir: str = "core/data",
         chroma_path: str = "./chroma_db",
+        llm_provider: str = "byteplus",
     ) -> None:
         # persistence & memory
         self.db_interface = self._build_db_interface(
@@ -80,7 +81,7 @@ class AgentBase:
         )
 
         # LLM + prompt plumbing
-        self.llm = LLMInterface(provider='byteplus', db_interface=self.db_interface)
+        self.llm = LLMInterface(provider=llm_provider, db_interface=self.db_interface)
         self.vlm = VLMInterface()
         self.context_engine = ContextEngine()
         self.context_engine.set_role_info_hook(self._generate_role_info_prompt)

--- a/core/main.py
+++ b/core/main.py
@@ -11,18 +11,58 @@ Run this before the core directory, using 'python -m core.main'
 
 import asyncio
 import os
+
 from dotenv import load_dotenv
-load_dotenv()
 
 from core.agent_base import AgentBase
+from core.menu import launch_menu
+
+load_dotenv()
 
 
-def main() -> None:
+def _initial_settings() -> tuple[str, str]:
+    provider = os.getenv("LLM_PROVIDER", "byteplus")
+    key_lookup = {
+        "openai": "OPENAI_API_KEY",
+        "gemini": "GOOGLE_API_KEY",
+        "byteplus": "BYTEPLUS_API_KEY",
+    }
+    key_name = key_lookup.get(provider, "")
+    api_key = os.getenv(key_name, "") if key_name else ""
+    return provider, api_key
+
+
+def _apply_api_key(provider: str, api_key: str) -> None:
+    key_lookup = {
+        "openai": "OPENAI_API_KEY",
+        "gemini": "GOOGLE_API_KEY",
+        "byteplus": "BYTEPLUS_API_KEY",
+    }
+    key_name = key_lookup.get(provider)
+    if key_name and api_key:
+        os.environ[key_name] = api_key
+    os.environ["LLM_PROVIDER"] = provider
+
+
+async def main_async() -> None:
+    provider, api_key = _initial_settings()
+    selection = await launch_menu(provider, api_key)
+
+    if not selection or selection.action == "exit":
+        return
+
+    _apply_api_key(selection.provider, selection.api_key)
+
     agent = AgentBase(
         data_dir=os.getenv("DATA_DIR", "core/data"),
         chroma_path=os.getenv("CHROMA_PATH", "./chroma_db"),
+        llm_provider=selection.provider,
     )
-    asyncio.run(agent.run())
+    await agent.run()
+
+
+def main() -> None:
+    asyncio.run(main_async())
 
 
 if __name__ == "__main__":

--- a/core/menu.py
+++ b/core/menu.py
@@ -1,0 +1,187 @@
+"""Launch menu for White Collar Agent before entering the chat interface."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+from rich.text import Text
+from textual import events
+from textual.app import App, ComposeResult
+from textual.containers import Container, Vertical
+from textual.reactive import var
+from textual.widgets import Button, Input, Select, Static
+
+MenuAction = Literal["start", "exit"]
+
+
+@dataclass
+class MenuResult:
+    """Result returned when leaving the menu screen."""
+
+    action: MenuAction
+    provider: str
+    api_key: str
+
+
+class SettingsScreen(Container):
+    """Simple settings form to choose provider and API key."""
+
+    CSS = """
+    SettingsScreen {
+        width: 60;
+        border: solid #444444;
+        padding: 2 3;
+        background: #0f0f0f;
+    }
+
+    #form-title {
+        margin-bottom: 1;
+        text-style: bold;
+    }
+
+    #provider-label, #apikey-label {
+        margin-bottom: 1;
+    }
+
+    #provider-select, #apikey-input {
+        margin-bottom: 2;
+    }
+
+    #actions {
+        height: auto;
+        content-align: center middle;
+        column-gap: 2;
+    }
+    """
+
+    def __init__(self, provider: str, api_key: str) -> None:
+        super().__init__(id="settings")
+        self.provider = provider
+        self.api_key = api_key
+
+    def compose(self) -> ComposeResult:
+        yield Static("Settings", id="form-title")
+        yield Static("LLM Provider", id="provider-label")
+        yield Select(
+            (
+                ("OpenAI", "openai"),
+                ("Google Gemini", "gemini"),
+                ("BytePlus", "byteplus"),
+                ("Ollama (remote)", "remote"),
+            ),
+            id="provider-select",
+            value=self.provider,
+        )
+        yield Static("API Key", id="apikey-label")
+        yield Input(
+            placeholder="Enter API key",
+            password=True,
+            id="apikey-input",
+            value=self.api_key,
+        )
+        yield Container(
+            Button("Save", id="save"),
+            Button("Cancel", id="cancel"),
+            id="actions",
+        )
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "cancel":
+            self.remove()
+            return
+
+        if event.button.id == "save":
+            select = self.query_one("#provider-select", Select[str])
+            api_key_input = self.query_one("#apikey-input", Input)
+            provider = select.value or "byteplus"
+            api_key = api_key_input.value
+            if hasattr(self.app, "save_settings"):
+                self.app.save_settings(provider, api_key)
+            self.remove()
+
+
+class MainMenuApp(App[MenuResult | None]):
+    """Main menu displayed before launching the chat interface."""
+
+    CSS = """
+    Screen {
+        align: center middle;
+        background: #0b0b0b;
+        color: #f5f5f5;
+    }
+
+    #menu-panel {
+        width: 80;
+        border: solid #333333;
+        padding: 3 5;
+        background: #111111;
+        content-align: center middle;
+    }
+
+    #logo {
+        margin-bottom: 2;
+        text-style: bold;
+    }
+
+    #buttons {
+        height: auto;
+        row-gap: 1;
+    }
+
+    Button {
+        width: 24;
+    }
+    """
+
+    status_message = var("Use the menu to start the agent.")
+
+    def __init__(self, provider: str, api_key: str) -> None:
+        super().__init__()
+        self.provider = provider
+        self.api_key = api_key
+
+    def compose(self) -> ComposeResult:
+        logo_text = Text(
+            """
+ __        __    _     _         ____      _ _                _             
+ \ \      / / __(_) __| | ___   / ___|___ | | | ___ _ __   __| | ___  _ __  
+  \ \ /\ / / '_ \ |/ _` |/ _ \ | |   / _ \| | |/ _ \ '_ \ / _` |/ _ \| '_ \ 
+   \ V  V /| | | | | (_| |  __/ | |__| (_) | | |  __/ | | | (_| | (_) | | | |
+    \_/\_/ |_| |_|_|\__,_|\___|  \____\___/|_|_|\___|_| |_|\__,_|\___/|_| |_|
+            """.rstrip("\n"),
+            justify="center",
+        )
+
+        yield Container(
+            Static(logo_text, id="logo"),
+            Vertical(
+                Button("Start", id="start"),
+                Button("Setting", id="settings"),
+                Button("Exit", id="exit"),
+                id="buttons",
+            ),
+            id="menu-panel",
+        )
+
+    def save_settings(self, provider: str, api_key: str) -> None:
+        self.provider = provider
+        self.api_key = api_key
+
+    def action_quit(self) -> None:
+        self.exit(None)
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "start":
+            self.exit(MenuResult(action="start", provider=self.provider, api_key=self.api_key))
+        elif event.button.id == "settings":
+            if not self.query(SettingsScreen):
+                self.mount(SettingsScreen(self.provider, self.api_key))
+        elif event.button.id == "exit":
+            self.exit(MenuResult(action="exit", provider=self.provider, api_key=self.api_key))
+
+
+async def launch_menu(default_provider: str, api_key: str) -> Optional[MenuResult]:
+    """Launch the menu and return the selected action."""
+
+    app = MainMenuApp(default_provider, api_key)
+    return await app.run_async()


### PR DESCRIPTION
## Summary
- add a textual start menu with logo, start, settings, and exit controls before launching the chat interface
- allow selecting the LLM provider and capturing API keys before creating the agent
- let the agent accept a configurable provider when constructing the LLM interface

## Testing
- python -m compileall core/menu.py core/main.py core/agent_base.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932aec1b6e48324bc5295e8adde274c)