### PR TITLE
Align VLM provider selection with LLM and add BytePlus support

### DIFF
--- a/core/agent_base.py
+++ b/core/agent_base.py
@@ -82,7 +82,7 @@ class AgentBase:
 
         # LLM + prompt plumbing
         self.llm = LLMInterface(provider=llm_provider, db_interface=self.db_interface)
-        self.vlm = VLMInterface()
+        self.vlm = VLMInterface(provider=llm_provider)
         self.context_engine = ContextEngine()
         self.context_engine.set_role_info_hook(self._generate_role_info_prompt)
 


### PR DESCRIPTION
## Summary
- pass the configured LLM provider through to the VLM so both components stay consistent
- add BytePlus VLM support, using the shared API key/base URL and OpenAI-compatible payloads

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693cee99b3c08324b423216cef29ea6b)