### PR TITLE
Colorize 'AGENT' in TUI logo to #FF4F18

### DIFF
--- a/core/tui_interface.py
+++ b/core/tui_interface.py
@@ -362,14 +362,21 @@ class _CraftApp(App):
     # ────────────────────────────── menu helpers ─────────────────────────────
 
     def _logo_text(self) -> Text:
-        return Text(
-            """
-░█░█░█░█░▀█▀░▀█▀░█▀▀░░░█▀▀░█▀█░█░░░█░░░█▀█░█▀▄░░░█▀█░█▀▀░█▀▀░█▀█░▀█▀
-░█▄█░█▀█░░█░░░█░░█▀▀░░░█░░░█░█░█░░░█░░░█▀█░█▀▄░░░█▀█░█░█░█▀▀░█░█░░█░
-░▀░▀░▀░▀░▀▀▀░░▀░░▀▀▀░░░▀▀▀░▀▀▀░▀▀▀░▀▀▀░▀░▀░▀░▀░░░▀░▀░▀▀▀░▀▀▀░▀░▀░░▀░
-            """.rstrip("\n"),
-            justify="center",
-        )
+        lines = [
+            "░█░█░█░█░▀█▀░▀█▀░█▀▀░░░█▀▀░█▀█░█░░░█░░░█▀█░█▀▄░░░█▀█░█▀▀░█▀▀░█▀█░▀█▀",
+            "░█▄█░█▀█░░█░░░█░░█▀▀░░░█░░░█░█░█░░░█░░░█▀█░█▀▄░░░█▀█░█░█░█▀▀░█░█░░█░",
+            "░▀░▀░▀░▀░▀▀▀░░▀░░▀▀▀░░░▀▀▀░▀▀▀░▀▀▀░▀▀▀░▀░▀░▀░▀░░░▀░▀░▀▀▀░▀▀▀░▀░▀░░▀░",
+        ]
+        logo_text = "\n".join(lines)
+        text = Text(logo_text, justify="center")
+        agent_start = 49
+        agent_len = 19
+        line_len = len(lines[0])
+        for idx in range(len(lines)):
+            start = idx * (line_len + 1) + agent_start
+            end = start + agent_len
+            text.stylize("#FF4F18", start, end)
+        return text
 
     def _open_settings(self) -> None:
         if self.query("#settings-card"):


### PR DESCRIPTION
### Motivation
- Make the "AGENT" portion of the TUI menu title visually distinct by highlighting it with the color `#FF4F18` so the brand/role stands out in the menu.

### Description
- Replace the raw multiline logo literal in `_logo_text` with an explicit `lines` list joined into `logo_text` and wrapped in a `Text` object with center justification.
- Compute the character offsets for the "AGENT" segment (`agent_start = 49`, `agent_len = 19`) and apply `text.stylize("#FF4F18", start, end)` for each logo line to colorize that span.
- Preserve the original ASCII-art layout and return the stylized `Text` for rendering in the menu.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969e8b2d62c8324990ec479b1c1b7f8)