### PR TITLE
Highlight "AGENT" in TUI menu logo using #FF4F18

### DIFF
--- a/core/tui_interface.py
+++ b/core/tui_interface.py
@@ -362,14 +362,20 @@ class _CraftApp(App):
     # ────────────────────────────── menu helpers ─────────────────────────────
 
     def _logo_text(self) -> Text:
-        return Text(
-            """
-░█░█░█░█░▀█▀░▀█▀░█▀▀░░░█▀▀░█▀█░█░░░█░░░█▀█░█▀▄░░░█▀█░█▀▀░█▀▀░█▀█░▀█▀
-░█▄█░█▀█░░█░░░█░░█▀▀░░░█░░░█░█░█░░░█░░░█▀█░█▀▄░░░█▀█░█░█░█▀▀░█░█░░█░
-░▀░▀░▀░▀░▀▀▀░░▀░░▀▀▀░░░▀▀▀░▀▀▀░▀▀▀░▀▀▀░▀░▀░▀░▀░░░▀░▀░▀▀▀░▀▀▀░▀░▀░░▀░
-            """.rstrip("\n"),
-            justify="center",
-        )
+        logo_lines = [
+            "░█░█░█░█░▀█▀░▀█▀░█▀▀░░░█▀▀░█▀█░█░░░█░░░█▀█░█▀▄░░░█▀█░█▀▀░█▀▀░█▀█░▀█▀",
+            "░█▄█░█▀█░░█░░░█░░█▀▀░░░█░░░█░█░█░░░█░░░█▀█░█▀▄░░░█▀█░█░█░█▀▀░█░█░░█░",
+            "░▀░▀░▀░▀░▀▀▀░░▀░░▀▀▀░░░▀▀▀░▀▀▀░▀▀▀░▀▀▀░▀░▀░▀░▀░░░▀░▀░▀▀▀░▀▀▀░▀░▀░░▀░",
+        ]
+        text = Text("\n".join(logo_lines), justify="center")
+        agent_len = len(logo_lines[0][-19:])
+        highlight_style = "#FF4F18"
+        offset = 0
+        for line in logo_lines:
+            start_col = len(line) - agent_len
+            text.stylize(highlight_style, offset + start_col, offset + start_col + agent_len)
+            offset += len(line) + 1
+        return text
 
     def _open_settings(self) -> None:
         if self.query("#settings-card"):


### PR DESCRIPTION
### Motivation
- Improve the visibility/branding of the TUI main menu by coloring the "AGENT" portion of the ASCII logo with the requested orange (#FF4F18). 

### Description
- Replace the hard-coded multi-line logo string in `core/tui_interface.py::_logo_text` with a list of lines assembled into a `rich.text.Text`, then stylize the trailing "AGENT" segment on each line using `Text.stylize` and the `#FF4F18` color. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969f338a4048324a5d1cdbea76209c2)