### PR TITLE
Set TUI chat and action panel borders and titles to white

### DIFF
--- a/core/tui_interface.py
+++ b/core/tui_interface.py
@@ -115,8 +115,9 @@ class _CraftApp(App):
 
     #chat-panel, #action-panel {
         height: 100%;
-        border: solid #444444;
+        border: solid #ffffff;
         border-title-align: left;
+        border-title-color: #ffffff;
         margin: 0 1;
         min-width: 0;  /* allow panels to shrink with the terminal */
     }


### PR DESCRIPTION
### Motivation
- Improve visibility of the TUI panels so the "Chat" and "Action" labels and their borders are easier to read against the dark background.

### Description
- Update CSS in `core/tui_interface.py` to set `#chat-panel, #action-panel` border to `#ffffff` and add `border-title-color: #ffffff` so panel frames and titles render in white.

### Testing
- No automated tests were run for this UI styling change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969faea04248324bbb1f86272d5e6a5)