### PR TITLE
Propagate structured `status` through event stream and drive TUI from it

### DIFF
--- a/core/action/action_manager.py
+++ b/core/action/action_manager.py
@@ -162,6 +162,7 @@ class ActionManager:
                 f"Running action {action.name} with input: {input_data}.",
                 display_message=f"Running {action.name}",
                 action_name=action.name,
+                status="running",
             )
         else:
             logger.warning(f"Action {action.name} no event stream manager to log to.")
@@ -238,11 +239,21 @@ class ActionManager:
         
         if is_running_task and self.event_stream_manager:
             display_status = "failed" if status == "error" else "completed"
+            display_message = f"{action.name} → {display_status}"
+            event_status = display_status
+            if (
+                action.name == "send message"
+                and isinstance(input_data, dict)
+                and input_data.get("wait_for_user_reply")
+            ):
+                display_message = f"{action.name} → wait for user response"
+                event_status = "waiting_for_user"
             self.event_stream_manager.log(
                 "action",
                 f"Action {action.name} completed with output: {outputs}.",
-                display_message=f"{action.name} → {display_status}",
+                display_message=display_message,
                 action_name=action.name,
+                status=event_status,
             )
 
 

--- a/core/event_stream/event.py
+++ b/core/event_stream/event.py
@@ -38,6 +38,7 @@ class Event:
     message: str
     kind: str
     severity: str
+    status: Optional[str] = None
     display_message: Optional[str] = None
     ts: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
 

--- a/core/event_stream/event_stream.py
+++ b/core/event_stream/event_stream.py
@@ -68,6 +68,7 @@ class EventStream:
         message: str,
         severity: str = "INFO",
         *,
+        status: str | None = None,
         display_message: str | None = None,
         action_name: str | None = None,
     ) -> int:
@@ -94,7 +95,13 @@ class EventStream:
             severity = "INFO"
         msg = self._externalize_message(message.strip(), action_name=action_name)
         display = display_message.strip() if display_message is not None else None
-        ev = Event(message=msg, kind=kind.strip(), severity=severity, display_message=display)
+        ev = Event(
+            message=msg,
+            kind=kind.strip(),
+            severity=severity,
+            status=status,
+            display_message=display,
+        )
         rec = EventRecord(event=ev)
 
         self.tail_events.append(rec)
@@ -109,7 +116,7 @@ class EventStream:
         msg = f"{name} -> {status}"
         if extra:
             msg += f" ({extra})"
-        return self.log("action_end", msg)
+        return self.log("action_end", msg, status=status)
 
     # ───────────────────── summarization & pruning ───────────────────────
 

--- a/core/event_stream/event_stream_manager.py
+++ b/core/event_stream/event_stream_manager.py
@@ -39,6 +39,7 @@ class EventStreamManager:
         message: str,
         severity: str = "INFO",
         *,
+        status: str | None = None,
         display_message: str | None = None,
         action_name: str | None = None,
     ) -> int:
@@ -68,6 +69,7 @@ class EventStreamManager:
             kind,
             message,
             severity,
+            status=status,
             display_message=display_message,
             action_name=action_name,
         )

--- a/core/task/task_manager.py
+++ b/core/task/task_manager.py
@@ -371,6 +371,7 @@ class TaskManager:
             "task",
             f"Task ended with status '{status}'. {note or ''}",
             display_message=f"Task {wf.name} → {status}",
+            status=status,
         )
         STATE.set_agent_property("current_task_id", "")
         STATE.set_agent_property("action_count", 0)


### PR DESCRIPTION
### Motivation
- The TUI previously relied on parsing display text to infer status (e.g. looking for `→ completed`), which is brittle if messages change; the change introduces a stable field to avoid ad-hoc string parsing.  
- Provide reliable, explicit lifecycle signals for actions and tasks so downstream consumers (TUI and others) can make decisions without parsing human-facing text.  

### Description
- Add an optional `status` field to the `Event` dataclass (`Event.status`) and populate it from logging calls by extending `EventStream.log` and `EventStreamManager.log` to accept a `status` parameter.  
- Propagate structured statuses from producers: `ActionManager` now emits `status=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a053dc09c8324b191b32c55ccf061)