### PR TITLE
Integrate agent loop for GAIA benchmark runs

### DIFF
--- a/benchmark/GAIA/run_gaia.py
+++ b/benchmark/GAIA/run_gaia.py
@@ -30,6 +30,21 @@ import logging
 
 GAIA_BASE_URL = "https://huggingface.co/datasets/gaia-benchmark/GAIA/resolve/main/2023/validation/"
 OUTPUT_FILE = "benchmark/GAIA/results.jsonl"
+MAX_STEPS = 30
+TRIGGER_TIMEOUT_SEC = 120
+
+def _latest_send_message(agent, task_id):
+    history = agent.db_interface.find_action_history(
+        session_id=task_id,
+        name="send message",
+        status="success",
+        limit=1,
+    )
+    if not history:
+        return None
+    outputs = history[0].get("outputs") or {}
+    message = outputs.get("message")
+    return message.strip() if isinstance(message, str) else None
 
 async def run_agent_cycle(agent, task_id, question, file_path=None):
     """
@@ -45,7 +60,7 @@ async def run_agent_cycle(agent, task_id, question, file_path=None):
         tuple: (final_answer, status)
     """
     
-    # Need change to accept question
+    agent.state_manager.record_user_message(question)
     await agent.triggers.put(
         Trigger(
             fire_at=0,
@@ -59,12 +74,28 @@ async def run_agent_cycle(agent, task_id, question, file_path=None):
     final_answer = None
     status = "failed"
     step_count = 0
-    MAX_STEPS = 30 
     
     try:
         while agent.is_running and step_count < MAX_STEPS:
-            # main agent cycle
-            final_answer = ""
+            try:
+                trigger = await asyncio.wait_for(
+                    agent.triggers.get(),
+                    timeout=TRIGGER_TIMEOUT_SEC,
+                )
+            except asyncio.TimeoutError:
+                status = "timeout"
+                break
+
+            await agent.react(trigger)
+            step_count += 1
+
+            final_answer = _latest_send_message(agent, task_id) or final_answer
+
+            if not agent.state_manager.is_running_task():
+                pending = await agent.triggers.size()
+                if pending == 0:
+                    status = "completed" if final_answer else "no_answer"
+                    break
         
         if step_count >= MAX_STEPS:
             status = "timeout"
@@ -75,7 +106,7 @@ async def run_agent_cycle(agent, task_id, question, file_path=None):
         status = "exception"
         final_answer = str(e)
         
-    return final_answer, status
+    return final_answer or "", status
 
 async def run_benchmark(limit: int | None = None):
     # 1. Load Dataset

--- a/core/database_interface.py
+++ b/core/database_interface.py
@@ -274,6 +274,52 @@ class DatabaseInterface:
         )
         return history[:limit]
 
+    def find_action_history(
+        self,
+        *,
+        session_id: str | None = None,
+        name: str | None = None,
+        status: str | None = None,
+        limit: int | None = None,
+        newest_first: bool = True,
+    ) -> List[Dict[str, Any]]:
+        """
+        Query action history with optional filters.
+
+        Args:
+            session_id: Optional session identifier to filter by.
+            name: Optional action name to filter by.
+            status: Optional status value to filter by (e.g., ``"success"``).
+            limit: Optional maximum number of entries to return.
+            newest_first: Whether to sort in reverse chronological order.
+
+        Returns:
+            List of action history dictionaries matching the filters.
+        """
+        def entry_sort_key(entry: Dict[str, Any]) -> datetime.datetime:
+            ts = entry.get("endedAt") or entry.get("startedAt")
+            if not ts:
+                return datetime.datetime.min
+            try:
+                return datetime.datetime.fromisoformat(ts)
+            except ValueError:
+                return datetime.datetime.min
+
+        filtered = []
+        for entry in self._iter_action_history():
+            if session_id is not None and entry.get("sessionId") != session_id:
+                continue
+            if name is not None and entry.get("name") != name:
+                continue
+            if status is not None and entry.get("status") != status:
+                continue
+            filtered.append(entry)
+
+        filtered.sort(key=entry_sort_key, reverse=newest_first)
+        if limit is not None:
+            return filtered[:limit]
+        return filtered
+
     # ------------------------------------------------------------------
     # Task logging helpers
     # ------------------------------------------------------------------
@@ -674,4 +720,3 @@ class DatabaseInterface:
                 break
         if updated:
             self._write_log_entries(entries)
-


### PR DESCRIPTION
### Motivation
- Allow the GAIA benchmark runner to actually drive the agent's trigger/react loop so questions are executed by the agent rather than being no-ops.
- Capture the agent-facing final response (the user-facing `send message`) for each GAIA task so the benchmark can record `model_answer` and completion status.

### Description
- Add `DatabaseInterface.find_action_history` to query action history with filters (`session_id`, `name`, `status`, `limit`) to support session-scoped lookups.
- In `benchmark/GAIA/run_gaia.py` introduce `MAX_STEPS` and `TRIGGER_TIMEOUT_SEC`, add helper `_latest_send_message` that uses the new DB helper to read the most recent successful `send message` output for a task, and record the question into the conversation state via `agent.state_manager.record_user_message(question)`.
- Replace the placeholder cycle with a real agent loop inside `run_agent_cycle` that enqueues a `Trigger`, repeatedly awaits `agent.triggers.get()` (with timeout), calls `await agent.react(trigger)`, updates `final_answer` from action history, and sets `status` based on task completion, pending triggers, timeouts, and a step cap.
- Keep existing dataset handling and attachment download logic; the runner now writes `model_answer` and `status` to `benchmark/GAIA/results.jsonl` as before.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c59ada6608324831f8f9073e1dc2f)