### PR TITLE
Add ChromaDB init recovery and improve GAIA benchmark logging

### DIFF
--- a/benchmark/GAIA/run_gaia.py
+++ b/benchmark/GAIA/run_gaia.py
@@ -70,6 +70,7 @@ async def run_agent_cycle(agent, task_id, question, file_path=None):
             status = "timeout"
             
     except Exception as e:
+        logger.error("Error in agent cycle.", exc_info=True)
         print(f"Error in agent cycle: {e}")
         traceback.print_exc()
         status = "exception"
@@ -84,6 +85,7 @@ async def run_benchmark(limit: int | None = None):
         ds = load_dataset("gaia-benchmark/GAIA", "2023_all", split="validation")
         print(f"Loaded {len(ds)} questions.")
     except Exception as e:
+        logger.error("Failed to load dataset.", exc_info=True)
         print(f"Failed to load dataset: {e}")
         return
 
@@ -98,6 +100,7 @@ async def run_benchmark(limit: int | None = None):
         agent = PersonalAssistantAgent(cfg, bundle_dir)
         agent.is_running = True
     except Exception as e:
+        logger.error("Failed to initialize agent.", exc_info=True)
         print(f"Failed to initialize agent: {e}")
         return
 
@@ -150,6 +153,12 @@ async def run_benchmark(limit: int | None = None):
                     f.write(r.content)
                 question += f"\n\n(Attachment downloaded to: {local_path})"
             except Exception as e:
+                logger.warning(
+                    "Failed to download attachment %s from %s.",
+                    file_name,
+                    file_url,
+                    exc_info=True,
+                )
                 print(f"Failed to download attachment {file_name}: {e}")
                 question += f"\n\n(Failed to download attachment {file_name})"
 
@@ -167,8 +176,8 @@ async def run_benchmark(limit: int | None = None):
         if local_path and os.path.exists(local_path):
              try:
                  os.remove(local_path)
-             except:
-                 pass
+             except Exception:
+                 logger.warning("Failed to remove attachment %s.", local_path, exc_info=True)
 
         result_entry = {
             "task_id": task_id,


### PR DESCRIPTION
### Motivation

- Agent startup can fail when persisted ChromaDB storage is corrupted or incompatible (manifesting as errors like `'_type'`) and the GAIA benchmark had limited exception information to diagnose these failures.

### Description

- Add a ChromaDB initialization wrapper in `core/database_interface.py` that attempts initialization in `_initialize_chroma` and, on failure, logs the traceback and calls `_reset_chroma_storage` to remove local Chroma files and retry initialization. 
- Implement `_reset_chroma_storage` to remove the on-disk Chroma directories (`<chroma_path>_actions` and `<chroma_path>_taskdocs`) using `shutil.rmtree` so the agent can recover from corrupted persistence. 
- Improve GAIA benchmark error handling in `benchmark/GAIA/run_gaia.py` by logging full tracebacks with `logger.error(..., exc_info=True)` when dataset loading or agent initialization fail. 
- Harden attachment handling and agent-cycle error reporting in `benchmark/GAIA/run_gaia.py` by logging warnings with `exc_info=True` for download/remove failures and adding `logger.error` when the agent cycle raises an exception.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c8d3dc0b0832481c62ab1a8e23516)