### PR TITLE
Add GitHub Actions workflow to build PyInstaller binaries and publish releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,86 @@
+name: Build and Release with PyInstaller
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build (${{ matrix.os_label }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            os_label: linux
+            data_sep: ":"
+            ext: ""
+          - os: windows-latest
+            os_label: windows
+            data_sep: ";"
+            ext: ".exe"
+          - os: macos-latest
+            os_label: macos
+            data_sep: ":"
+            ext: ""
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pyinstaller
+
+      - name: Build with PyInstaller
+        shell: bash
+        run: |
+          pyinstaller \
+            --noconfirm \
+            --clean \
+            --onefile \
+            --name WhiteCollarAgent \
+            --add-data "assets${{ matrix.data_sep }}assets" \
+            --add-data "config.json${{ matrix.data_sep }}config.json" \
+            start.py
+
+      - name: Rename artifact
+        shell: bash
+        run: |
+          mv "dist/WhiteCollarAgent${{ matrix.ext }}" "dist/WhiteCollarAgent-${{ matrix.os_label }}${{ matrix.ext }}"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.os_label }}
+          path: dist/WhiteCollarAgent-${{ matrix.os_label }}${{ matrix.ext }}
+
+  release:
+    name: Publish release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release
+          merge-multiple: true
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: release/**
+          generate_release_notes: true


### PR DESCRIPTION
### Motivation
- Automate building distributable single-file binaries for Linux, macOS, and Windows when a version tag (`v*`) is pushed. 
- Provide a repeatable release pipeline that collects platform artifacts and publishes them as a GitHub release.

### Description
- Adds `.github/workflows/release.yml` which triggers on tag pushes matching `v*` and grants `contents: write` permission.
- Implements a matrix job for `ubuntu-latest`, `windows-latest`, and `macos-latest` that sets up Python `3.10`, installs Python requirements and `pyinstaller`, and runs `pyinstaller` with `--onefile`, `--add-data` for `assets` and `config.json`, and names the binary `WhiteCollarAgent`.
- Renames the generated artifact per-OS (handles different path separators and file extensions via matrix variables) and uploads each platform artifact with `actions/upload-artifact@v4`.
- Adds a follow-up job that downloads all artifacts and publishes a GitHub release using `softprops/action-gh-release@v2` with `generate_release_notes: true`.

### Testing
- No automated tests were executed for this change because it only adds a CI workflow file and the workflow has not yet been run in CI.
- The workflow file was added and formatted; runtime verification requires pushing a `v*` tag to trigger the pipeline in GitHub Actions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979c1bb974c8324927f27316366c1c1)