### PR TITLE
Bug/save state write errors

### DIFF
--- a/agent_core/core/impl/onboarding/manager.py
+++ b/agent_core/core/impl/onboarding/manager.py
@@ -88,7 +88,7 @@ class OnboardingManager:
         user_name: Optional[str] = None,
         agent_name: Optional[str] = None,
         agent_profile_picture: Optional[str] = None,
-    ) -> None:
+    ) -> bool:
         """
         Mark hard onboarding as complete.
 
@@ -107,22 +107,35 @@ class OnboardingManager:
             state.agent_name = agent_name
         if agent_profile_picture is not None:
             state.agent_profile_picture = agent_profile_picture
-        save_state(state)
-        logger.info("[ONBOARDING] Hard onboarding marked complete")
+        
+        try:
+            save_state(state)
+            logger.info("[ONBOARDING] Hard onboarding marked complete")
+            return True
+        except Exception:
+            return False
 
-    def save(self) -> None:
+    def save(self) -> bool:
         """Persist the current state to disk."""
-        save_state(self._ensure_state_loaded())
+        try:
+            save_state(self._ensure_state_loaded())
+            return True
+        except Exception:
+            return False
 
-    def mark_soft_complete(self) -> None:
+    def mark_soft_complete(self) -> bool:
         """Mark soft onboarding as complete."""
         state = self._ensure_state_loaded()
         state.soft_completed = True
         state.soft_completed_at = datetime.utcnow().isoformat()
-        save_state(state)
-        logger.info("[ONBOARDING] Soft onboarding marked complete")
+        try:
+            save_state(state)
+            logger.info("[ONBOARDING] Soft onboarding marked complete")
+            return True
+        except Exception:
+            return False
 
-    def reset_soft_onboarding(self) -> None:
+    def reset_soft_onboarding(self) -> bool:
         """
         Reset soft onboarding to allow re-run via /onboarding command.
         Does not affect hard onboarding state.
@@ -130,16 +143,24 @@ class OnboardingManager:
         state = self._ensure_state_loaded()
         state.soft_completed = False
         state.soft_completed_at = None
-        save_state(state)
-        logger.info("[ONBOARDING] Soft onboarding reset for re-run")
+        try:
+            save_state(state)
+            logger.info("[ONBOARDING] Soft onboarding reset for re-run")
+            return True
+        except Exception:
+            return False
 
-    def reset_all(self) -> None:
+    def reset_all(self) -> bool:
         """
         Reset all onboarding state (for testing/debugging).
         """
         self._state = OnboardingState()
-        save_state(self._state)
-        logger.info("[ONBOARDING] All onboarding state reset")
+        try:
+            save_state(self._state)
+            logger.info("[ONBOARDING] All onboarding state reset")
+            return True
+        except Exception:
+            return False
 
     def reload_state(self) -> None:
         """Reload state from disk (useful after external modifications)."""

--- a/agent_core/core/impl/onboarding/state.py
+++ b/agent_core/core/impl/onboarding/state.py
@@ -103,7 +103,7 @@ def load_state(state_file: Optional[Path] = None) -> OnboardingState:
         return OnboardingState()
 
 
-def save_state(state: OnboardingState, state_file: Optional[Path] = None) -> bool:
+def save_state(state: OnboardingState, state_file: Optional[Path] = None) -> None:
     """
     Save onboarding state to JSON file.
 
@@ -111,8 +111,8 @@ def save_state(state: OnboardingState, state_file: Optional[Path] = None) -> boo
         state: OnboardingState object to save
         state_file: Path to the state file (defaults to configured path)
 
-    Returns:
-        True if save succeeded, False otherwise
+    Raises:
+        Exception: If the state file cannot be written (permissions, disk full, etc.)
     """
     if state_file is None:
         state_file = get_onboarding_config_file()
@@ -127,7 +127,6 @@ def save_state(state: OnboardingState, state_file: Optional[Path] = None) -> boo
             encoding="utf-8"
         )
         logger.debug(f"[ONBOARDING] Saved state: hard={state.hard_completed}, soft={state.soft_completed}")
-        return True
     except Exception as e:
         logger.error(f"[ONBOARDING] Failed to save state: {e}")
-        return False
+        raise

--- a/app/tui/onboarding/hard_onboarding.py
+++ b/app/tui/onboarding/hard_onboarding.py
@@ -133,9 +133,15 @@ class TUIHardOnboarding(OnboardingInterface):
         # Mark hard onboarding as complete
         agent_name = self._collected_data.get("agent_name", "Agent")
         user_name = profile_data.get("user_name") if profile_data else None
-        onboarding_manager.mark_hard_complete(user_name=user_name, agent_name=agent_name)
-
-        logger.info("[ONBOARDING] Hard onboarding completed successfully")
+        success = onboarding_manager.mark_hard_complete(user_name=user_name, agent_name=agent_name)
+        if success:
+            logger.info("[ONBOARDING] Hard onboarding completed successfully")
+        else:
+            logger.error(
+                "[ONBOARDING] Hard onboarding state could not be persisted — "
+                "onboarding will re-trigger on next launch. "
+                "Check disk space or file permissions."
+            )
 
         # Trigger soft onboarding now that hard onboarding is done
         # This is needed because the soft onboarding check in agent.run() happens

--- a/app/ui_layer/onboarding/controller.py
+++ b/app/ui_layer/onboarding/controller.py
@@ -308,11 +308,18 @@ class OnboardingFlowController:
         # persisted via the immediate-upload websocket handler; the
         # authoritative value is onboarding_manager.state.agent_profile_picture.
         user_name = user_profile.get("user_name") if user_profile else None
-        onboarding_manager.mark_hard_complete(
+        success = onboarding_manager.mark_hard_complete(
             user_name=user_name,
             agent_name=agent_name,
             agent_profile_picture=onboarding_manager.state.agent_profile_picture,
         )
+        if not success:
+            from agent_core.utils.logger import logger
+            logger.error(
+                "[ONBOARDING] Failed to persist hard onboarding state — "
+                "onboarding will re-trigger on next launch. "
+                "Check disk space or file permissions."
+            )
 
         # Trigger soft onboarding now that hard onboarding is done
         # This is needed because the soft onboarding check in agent.run() happens


### PR DESCRIPTION
## What and Why

`save_state()` (aliased as `save_onboarding_state` in `agent_core`) was catching
all exceptions internally and returning `False` on failure. Every callsite in
`OnboardingManager` discarded that return value — any write failure (disk full,
permissions error, bad path) was swallowed silently. The user saw no error,
state never persisted, and hard onboarding re-triggered on next launch with no
indication of why.

Closes #197

## Items Changed

`agent_core/core/impl/onboarding/state.py`
- Changed `save_state()` return type from `bool` → `None`
- Now re-raises after logging instead of returning `False`
- Updated docstring: removed stale `Returns: True/False`,
  replaced with `Raises: Exception on write failure`

`agent_core/core/impl/onboarding/manager.py`
- Changed return type of all 5 methods from `-> None` to `-> bool`:
  `mark_hard_complete()`, `mark_soft_complete()`, `save()`,
  `reset_soft_onboarding()`, `reset_all()`
- Each method now wraps `save_state()` in `try/except`, returns `True/False`
- Moved `logger.info()` success logs inside `try` — no longer fires on failed write

Follow-up: UI caller of `mark_hard_complete()` still needs to check the returned
`bool` and surface a message to the user. Out of scope for this PR — tracked as
follow-up to #197.

## Test

Checklist
[ ] Tests pass locally
[ ] Format checks pass
[ ] Security checks pass
[ ] Relevant docs or screenshot updated (if applicable)