### PR TITLE
feature/clear conversation and task function and buttons

### DIFF
--- a/app/ui_layer/adapters/browser_adapter.py
+++ b/app/ui_layer/adapters/browser_adapter.py
@@ -644,6 +644,57 @@ class BrowserActionPanelComponent(ActionPanelProtocol):
             "type": "action_clear",
         })
 
+    async def clear_terminal_tasks(self) -> int:
+        """
+        Remove tasks whose status is completed/error/cancelled, along with
+        their child actions. Running/waiting tasks remain visible.
+
+        Returns:
+            Number of tasks removed (does not count child actions).
+        """
+        terminal_statuses = {"completed", "error", "cancelled"}
+
+        # Find terminal task IDs in the in-memory list
+        terminal_task_ids = {
+            item.id
+            for item in self._items
+            if item.item_type == "task" and item.status in terminal_statuses
+        }
+
+        if not terminal_task_ids:
+            return 0
+
+        # Remove the tasks themselves and any actions that belong to them
+        removed_ids = [
+            item.id
+            for item in self._items
+            if item.id in terminal_task_ids or item.parent_id in terminal_task_ids
+        ]
+        self._items = [
+            item
+            for item in self._items
+            if item.id not in terminal_task_ids and item.parent_id not in terminal_task_ids
+        ]
+
+        # Mirror in storage so a refresh doesn't bring them back. We let
+        # storage compute its own ID set rather than pass our list, since
+        # storage may carry tasks not currently loaded in memory.
+        if self._storage:
+            try:
+                self._storage.clear_terminal_tasks()
+            except Exception:
+                pass
+
+        # Tell each connected client to drop the removed items individually,
+        # so any other (running) tasks they're watching stay in place.
+        for item_id in removed_ids:
+            await self._adapter._broadcast({
+                "type": "action_remove",
+                "data": {"id": item_id},
+            })
+
+        return len(terminal_task_ids)
+
     def select_task(self, task_id: Optional[str]) -> None:
         """Select task - handled by frontend."""
         pass
@@ -1313,6 +1364,12 @@ A quick Q&A will now begin to understand your objectives to serve you better:"""
 
         elif msg_type == "reset":
             await self._handle_reset()
+
+        elif msg_type == "clear_conversation":
+            await self._handle_clear_conversation()
+
+        elif msg_type == "clear_tasks":
+            await self._handle_clear_tasks()
 
         # Scheduler/Proactive operations
         elif msg_type == "scheduler_config_get":
@@ -2851,6 +2908,47 @@ A quick Q&A will now begin to understand your objectives to serve you better:"""
                     "success": False,
                     "error": result.get("error", "Unknown error"),
                 },
+            })
+
+    async def _handle_clear_conversation(self) -> None:
+        """
+        Clear the chat conversation log only.
+
+        Drops chat messages from the panel and from chat_storage. The
+        action panel (tasks/actions) is left alone so running tasks are
+        not disrupted. Dashboard usage/task metrics live in a separate
+        database and are not touched.
+        """
+        try:
+            await self._chat.clear()
+            await self._broadcast({
+                "type": "clear_conversation",
+                "data": {"success": True},
+            })
+        except Exception as e:
+            await self._broadcast({
+                "type": "clear_conversation",
+                "data": {"success": False, "error": str(e)},
+            })
+
+    async def _handle_clear_tasks(self) -> None:
+        """
+        Clear only finished tasks (completed/error/cancelled) and their
+        child actions from the panel. Running/waiting tasks are preserved.
+
+        Dashboard usage/task metrics are persisted in a separate database
+        and are not affected.
+        """
+        try:
+            removed = await self._action_panel.clear_terminal_tasks()
+            await self._broadcast({
+                "type": "clear_tasks",
+                "data": {"success": True, "removed": removed},
+            })
+        except Exception as e:
+            await self._broadcast({
+                "type": "clear_tasks",
+                "data": {"success": False, "error": str(e)},
             })
 
     # ─────────────────────────────────────────────────────────────────────

--- a/app/ui_layer/adapters/tui_adapter.py
+++ b/app/ui_layer/adapters/tui_adapter.py
@@ -216,6 +216,45 @@ class TUIActionPanelComponent(ActionPanelProtocol):
         self._order.clear()
         await self._adapter.action_updates.put(ActionPanelUpdate("clear", None))
 
+    async def clear_terminal_tasks(self) -> int:
+        """
+        Remove tasks whose status is completed/error/cancelled, along with
+        their child actions. Running/waiting tasks remain visible.
+
+        Returns:
+            Number of tasks removed (does not count child actions).
+        """
+        terminal_statuses = {"completed", "error", "cancelled"}
+
+        terminal_task_ids = {
+            item_id
+            for item_id, item in self._items.items()
+            if item.item_type == "task" and item.status in terminal_statuses
+        }
+
+        if not terminal_task_ids:
+            return 0
+
+        removed_ids = [
+            item_id
+            for item_id, item in list(self._items.items())
+            if item_id in terminal_task_ids or item.task_id in terminal_task_ids
+        ]
+
+        for item_id in removed_ids:
+            self._items.pop(item_id, None)
+        self._order = [iid for iid in self._order if iid not in removed_ids]
+
+        for item_id in removed_ids:
+            await self._adapter.action_updates.put(
+                ActionPanelUpdate(
+                    "remove",
+                    TUIActionItem(id=item_id, display_name="", item_type="", status=""),
+                )
+            )
+
+        return len(terminal_task_ids)
+
     def select_task(self, task_id: Optional[str]) -> None:
         """Select a task for detail view."""
         self._adapter._selected_task_id = task_id

--- a/app/ui_layer/browser/frontend/src/pages/Settings/GeneralSettings.tsx
+++ b/app/ui_layer/browser/frontend/src/pages/Settings/GeneralSettings.tsx
@@ -11,6 +11,8 @@ import {
   RefreshCw,
   Upload,
   Trash2,
+  Eraser,
+  ListChecks,
 } from 'lucide-react'
 import { Button, Badge, ConfirmModal } from '../../components/ui'
 import { useTheme } from '../../contexts/ThemeContext'
@@ -57,6 +59,15 @@ export function GeneralSettings() {
   const [resetStatus, setResetStatus] = useState<'idle' | 'success' | 'error'>('idle')
   const [isSaving, setIsSaving] = useState(false)
   const [saveStatus, setSaveStatus] = useState<'idle' | 'success' | 'error'>('idle')
+
+  // Clear Conversation / Clear Tasks state
+  const [isClearingConversation, setIsClearingConversation] = useState(false)
+  const [clearConversationStatus, setClearConversationStatus] =
+    useState<'idle' | 'success' | 'error'>('idle')
+  const [isClearingTasks, setIsClearingTasks] = useState(false)
+  const [clearTasksStatus, setClearTasksStatus] =
+    useState<'idle' | 'success' | 'error'>('idle')
+  const [clearTasksRemoved, setClearTasksRemoved] = useState<number | null>(null)
 
   // Agent profile picture
   const [profilePictureUrl, setProfilePictureUrl] = useState<string>(agentProfilePictureUrl)
@@ -204,6 +215,22 @@ export function GeneralSettings() {
         setIsResetting(false)
         setResetStatus(d.success ? 'success' : 'error')
         setTimeout(() => setResetStatus('idle'), 3000)
+      }),
+      onMessage('clear_conversation', (data: unknown) => {
+        const d = data as { success: boolean }
+        setIsClearingConversation(false)
+        setClearConversationStatus(d.success ? 'success' : 'error')
+        setTimeout(() => setClearConversationStatus('idle'), 3000)
+      }),
+      onMessage('clear_tasks', (data: unknown) => {
+        const d = data as { success: boolean; removed?: number }
+        setIsClearingTasks(false)
+        setClearTasksStatus(d.success ? 'success' : 'error')
+        setClearTasksRemoved(typeof d.removed === 'number' ? d.removed : null)
+        setTimeout(() => {
+          setClearTasksStatus('idle')
+          setClearTasksRemoved(null)
+        }, 3000)
       }),
       onMessage('agent_file_read', (data: unknown) => {
         const d = data as { filename: string; content: string; success: boolean }
@@ -388,6 +415,30 @@ export function GeneralSettings() {
     }, () => {
       setIsResetting(true)
       send('reset')
+    })
+  }
+
+  const handleClearConversation = () => {
+    confirm({
+      title: 'Clear Conversation',
+      message: 'Clear the chat history? Tasks (including running ones) and dashboard data are preserved.',
+      confirmText: 'Clear',
+      variant: 'danger',
+    }, () => {
+      setIsClearingConversation(true)
+      send('clear_conversation')
+    })
+  }
+
+  const handleClearTasks = () => {
+    confirm({
+      title: 'Clear Tasks',
+      message: 'Remove completed, failed, and aborted tasks from the panel? Running tasks remain visible. Dashboard usage data and task statistics will be preserved.',
+      confirmText: 'Clear',
+      variant: 'danger',
+    }, () => {
+      setIsClearingTasks(true)
+      send('clear_tasks')
     })
   }
 
@@ -630,6 +681,84 @@ export function GeneralSettings() {
             ))}
           </div>
         )}
+      </div>
+
+      {/* Clear Data Section — compact */}
+      <div className={styles.dangerZone}>
+        <div className={styles.dangerRowList}>
+          <div className={styles.dangerRow}>
+            <Eraser size={16} className={styles.dangerRowIcon} />
+            <div className={styles.dangerRowInfo}>
+              <h4 className={styles.dangerRowTitle}>Clear Conversation</h4>
+              <p className={styles.dangerRowHint}>
+                Remove chat messages. Tasks and dashboard data are preserved.
+              </p>
+            </div>
+            <div className={styles.dangerRowAction}>
+              {clearConversationStatus === 'success' && (
+                <span className={styles.statusSuccess}>
+                  <Check size={14} /> Cleared
+                </span>
+              )}
+              {clearConversationStatus === 'error' && (
+                <span className={styles.statusError}>
+                  <X size={14} /> Failed
+                </span>
+              )}
+              <Button
+                variant="danger"
+                size="sm"
+                onClick={handleClearConversation}
+                disabled={isClearingConversation}
+                icon={
+                  isClearingConversation
+                    ? <Loader2 size={14} className={styles.spinning} />
+                    : <Eraser size={14} />
+                }
+              >
+                {isClearingConversation ? 'Clearing...' : 'Clear'}
+              </Button>
+            </div>
+          </div>
+
+          <div className={styles.dangerRow}>
+            <ListChecks size={16} className={styles.dangerRowIcon} />
+            <div className={styles.dangerRowInfo}>
+              <h4 className={styles.dangerRowTitle}>Clear Tasks</h4>
+              <p className={styles.dangerRowHint}>
+                Remove completed, failed, and aborted tasks. Running tasks and dashboard data are preserved.
+              </p>
+            </div>
+            <div className={styles.dangerRowAction}>
+              {clearTasksStatus === 'success' && (
+                <span className={styles.statusSuccess}>
+                  <Check size={14} />
+                  {clearTasksRemoved !== null
+                    ? ` ${clearTasksRemoved} cleared`
+                    : ' Cleared'}
+                </span>
+              )}
+              {clearTasksStatus === 'error' && (
+                <span className={styles.statusError}>
+                  <X size={14} /> Failed
+                </span>
+              )}
+              <Button
+                variant="danger"
+                size="sm"
+                onClick={handleClearTasks}
+                disabled={isClearingTasks}
+                icon={
+                  isClearingTasks
+                    ? <Loader2 size={14} className={styles.spinning} />
+                    : <ListChecks size={14} />
+                }
+              >
+                {isClearingTasks ? 'Clearing...' : 'Clear'}
+              </Button>
+            </div>
+          </div>
+        </div>
       </div>
 
       {/* Reset Section */}

--- a/app/ui_layer/browser/frontend/src/pages/Settings/SettingsPage.module.css
+++ b/app/ui_layer/browser/frontend/src/pages/Settings/SettingsPage.module.css
@@ -603,6 +603,65 @@
   line-height: 1.5;
 }
 
+/* Compact danger row — for low-risk maintenance actions */
+.dangerRowList {
+  display: flex;
+  flex-direction: column;
+}
+
+.dangerRow {
+  display: grid;
+  grid-template-columns: 18px 1fr auto;
+  align-items: center;
+  column-gap: var(--space-3);
+  padding: var(--space-3) 0;
+}
+
+.dangerRow:first-child {
+  padding-top: var(--space-1);
+}
+
+.dangerRow:last-child {
+  padding-bottom: var(--space-1);
+}
+
+.dangerRow + .dangerRow {
+  border-top: 1px solid rgba(239, 68, 68, 0.15);
+}
+
+.dangerRowIcon {
+  align-self: start;
+  margin-top: 2px;
+  color: var(--color-red);
+}
+
+.dangerRowInfo {
+  min-width: 0;
+}
+
+.dangerRowTitle {
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  color: var(--color-red);
+  margin: 0 0 2px 0;
+  line-height: 1.2;
+}
+
+.dangerRowHint {
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+  margin: 0;
+  line-height: 1.4;
+}
+
+.dangerRowAction {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-2);
+  min-width: 96px;
+}
+
 /* Status Messages */
 .statusSuccess {
   display: inline-flex;

--- a/app/ui_layer/commands/builtin/__init__.py
+++ b/app/ui_layer/commands/builtin/__init__.py
@@ -2,6 +2,7 @@
 
 from app.ui_layer.commands.builtin.help import HelpCommand
 from app.ui_layer.commands.builtin.clear import ClearCommand
+from app.ui_layer.commands.builtin.clear_tasks import ClearTasksCommand
 from app.ui_layer.commands.builtin.reset import ResetCommand
 from app.ui_layer.commands.builtin.exit import ExitCommand
 from app.ui_layer.commands.builtin.menu import MenuCommand
@@ -17,6 +18,7 @@ from app.ui_layer.commands.builtin.skill_invoke import SkillInvokeCommand
 __all__ = [
     "HelpCommand",
     "ClearCommand",
+    "ClearTasksCommand",
     "ResetCommand",
     "ExitCommand",
     "MenuCommand",

--- a/app/ui_layer/commands/builtin/clear_tasks.py
+++ b/app/ui_layer/commands/builtin/clear_tasks.py
@@ -1,0 +1,58 @@
+"""Clear-tasks command implementation."""
+
+from __future__ import annotations
+
+from typing import List
+
+from app.ui_layer.commands.base import Command, CommandResult
+
+
+class ClearTasksCommand(Command):
+    """Clear finished tasks (completed/failed/aborted) from the action panel."""
+
+    @property
+    def name(self) -> str:
+        return "/clear-tasks"
+
+    @property
+    def aliases(self) -> List[str]:
+        return ["/cleartasks"]
+
+    @property
+    def description(self) -> str:
+        return "Remove completed, failed, and aborted tasks from the panel"
+
+    @property
+    def help_text(self) -> str:
+        return (
+            "Remove tasks whose status is completed, error, or cancelled "
+            "(failed/aborted) from the action panel, along with their child "
+            "actions. Running and waiting tasks are preserved.\n\n"
+            "Dashboard usage data and task history are not affected."
+        )
+
+    async def execute(
+        self,
+        args: List[str],
+        adapter_id: str = "",
+    ) -> CommandResult:
+        """Execute the clear-tasks command."""
+        adapter = self._controller.active_adapter
+        if not adapter or not adapter.action_panel:
+            self.emit_message(
+                "No action panel is available in this interface.",
+                "error",
+            )
+            return CommandResult(success=False)
+
+        removed = await adapter.action_panel.clear_terminal_tasks()
+
+        if removed:
+            self.emit_message(
+                f"Cleared {removed} finished task{'s' if removed != 1 else ''} from the panel.",
+                "system",
+            )
+        else:
+            self.emit_message("No finished tasks to clear.", "system")
+
+        return CommandResult(success=True)

--- a/app/ui_layer/components/protocols.py
+++ b/app/ui_layer/components/protocols.py
@@ -125,6 +125,16 @@ class ActionPanelProtocol(Protocol):
         """Clear all items from the panel."""
         ...
 
+    async def clear_terminal_tasks(self) -> int:
+        """
+        Remove tasks whose status is completed/error/cancelled, along with
+        their child actions. Running/waiting tasks are preserved.
+
+        Returns:
+            Number of items removed.
+        """
+        ...
+
     def select_task(self, task_id: Optional[str]) -> None:
         """
         Select a task for detail view.

--- a/app/ui_layer/controller/ui_controller.py
+++ b/app/ui_layer/controller/ui_controller.py
@@ -540,6 +540,7 @@ class UIController:
         from app.ui_layer.commands.builtin import (
             HelpCommand,
             ClearCommand,
+            ClearTasksCommand,
             ResetCommand,
             ExitCommand,
             MenuCommand,
@@ -552,6 +553,7 @@ class UIController:
 
         self._command_registry.register(HelpCommand(self))
         self._command_registry.register(ClearCommand(self))
+        self._command_registry.register(ClearTasksCommand(self))
         self._command_registry.register(ResetCommand(self))
         self._command_registry.register(ExitCommand(self))
         self._command_registry.register(MenuCommand(self))

--- a/app/usage/action_storage.py
+++ b/app/usage/action_storage.py
@@ -335,6 +335,52 @@ class ActionStorage:
             conn.commit()
             return count
 
+    def clear_terminal_tasks(self) -> List[str]:
+        """
+        Delete tasks whose status is completed/error/cancelled, plus all
+        their child actions. Running/waiting tasks are preserved so the
+        user can keep monitoring active work.
+
+        Returns:
+            List of removed item IDs (terminal tasks + their child actions).
+        """
+        terminal_statuses = ("completed", "error", "cancelled")
+        with sqlite3.connect(self._db_path) as conn:
+            cursor = conn.cursor()
+
+            placeholders = ",".join("?" for _ in terminal_statuses)
+            cursor.execute(
+                f"""
+                SELECT id FROM action_items
+                WHERE item_type = 'task' AND status IN ({placeholders})
+                """,
+                terminal_statuses,
+            )
+            terminal_task_ids = [row[0] for row in cursor.fetchall()]
+
+            if not terminal_task_ids:
+                return []
+
+            id_placeholders = ",".join("?" for _ in terminal_task_ids)
+            cursor.execute(
+                f"""
+                SELECT id FROM action_items
+                WHERE id IN ({id_placeholders}) OR parent_id IN ({id_placeholders})
+                """,
+                terminal_task_ids + terminal_task_ids,
+            )
+            removed_ids = [row[0] for row in cursor.fetchall()]
+
+            cursor.execute(
+                f"""
+                DELETE FROM action_items
+                WHERE id IN ({id_placeholders}) OR parent_id IN ({id_placeholders})
+                """,
+                terminal_task_ids + terminal_task_ids,
+            )
+            conn.commit()
+            return removed_ids
+
     def delete_item(self, item_id: str) -> bool:
         """
         Delete an item by ID.


### PR DESCRIPTION
What and why?
Browser interface had no way to clear chat (without using command) or finished tasks without using full agent reset. Added scoped buttons + a /clear-tasks command so users can tidy up without disrupting running tasks or dashboard data.

Items/features added
- /clear-tasks command. Removes only completed/failed/aborted tasks. Tasks inprogress/waiting for reply does not get removed
- Backend cleanup in ActionStorage and the browser/TUI action panels.
- Buttons for "Clear Conversation" + "Clear Tasks" in settings page.