### PR TITLE
feature:skill creation/improved from completed task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,7 @@ app/config/settings.json
 **/CONVERSATION_HISTORY.md
 **/EVENT_UNPROCESSED.md
 **/EVENT.md
-**/TASK_HISTORY.md
+agent_file_system/TASK_HISTORY.md
 **/USER.md
 **/onboarding_config.json
 **/config.json

--- a/agent_core/core/impl/skill/manager.py
+++ b/agent_core/core/impl/skill/manager.py
@@ -189,8 +189,12 @@ class SkillManager:
         }
 
     # Maximum tokens for skill instructions (approximate: ~4 chars per token)
-    # This prevents skill instructions from overwhelming the context
-    MAX_SKILL_INSTRUCTIONS_TOKENS = 2000
+    # This prevents skill instructions from overwhelming the context.
+    # 16000 tokens (~64 KB of text) comfortably fits the largest single skill
+    # in the repo (~8200 tokens) plus headroom for multi-skill combos. The
+    # earlier 2000-token cap was truncating most non-trivial skills,
+    # including the workflow ones (memory-processor, craftbot-skill-*).
+    MAX_SKILL_INSTRUCTIONS_TOKENS = 16000
 
     def get_skill_instructions(self, skill_names: List[str], max_tokens: Optional[int] = None) -> str:
         """

--- a/agent_core/core/impl/task/manager.py
+++ b/agent_core/core/impl/task/manager.py
@@ -701,6 +701,86 @@ class TaskManager:
             except Exception as e:
                 logger.warning(f"[ONBOARDING] Failed to mark soft onboarding complete: {e}")
 
+        # Skill creator/improver workflow finished — reload SkillManager so
+        # the new (or edited) skill is invocable immediately, and delete the
+        # per-task SKILL_SOURCE markdown the handler wrote.
+        if (task.workflow_id or "") in {"skill_creation", "skill_improvement"}:
+            # Always clean up the SOURCE file, regardless of completion status
+            try:
+                if self.agent_file_system_path:
+                    src_path = self.agent_file_system_path / f"SKILL_SOURCE_{task.id}.md"
+                    if src_path.exists():
+                        src_path.unlink()
+                        logger.info(f"[SKILL_CREATOR] Removed {src_path.name}")
+            except Exception as e:
+                logger.warning(f"[SKILL_CREATOR] Failed to remove SKILL_SOURCE for {task.id}: {e}")
+
+            # Reload skills only on success — a failed/cancelled task is
+            # unlikely to have left the skill in a useful state, but reloading
+            # is harmless either way. Restrict to completed for clarity.
+            if status == "completed":
+                try:
+                    from agent_core.core.impl.skill.manager import SkillManager
+                    skill_manager = SkillManager()
+                    await skill_manager.reload()
+                    logger.info(
+                        f"[SKILL_CREATOR] Reloaded skills after {task.workflow_id} task {task.id}"
+                    )
+
+                    # The freshly-discovered skill is loaded but NOT enabled
+                    # by default: skills_config.json has a non-empty
+                    # `enabled_skills` whitelist, so any skill not in that
+                    # list (or in `disabled_skills`) is treated as disabled.
+                    # Enable it so it shows up in the settings list and as a
+                    # slash command. `enable_skill` saves the config, which
+                    # the file watcher in agent_base picks up and uses to
+                    # call `sync_skill_commands` automatically.
+                    target_skill = self._extract_target_skill_name(task.instruction)
+                    if target_skill:
+                        if task.workflow_id == "skill_creation":
+                            try:
+                                if skill_manager.enable_skill(target_skill):
+                                    logger.info(
+                                        f"[SKILL_CREATOR] Enabled new skill '{target_skill}'"
+                                    )
+                                else:
+                                    logger.warning(
+                                        f"[SKILL_CREATOR] enable_skill('{target_skill}') "
+                                        f"returned False — skill may not have been written"
+                                    )
+                            except Exception as e:
+                                logger.warning(
+                                    f"[SKILL_CREATOR] enable_skill('{target_skill}') failed: {e}"
+                                )
+                        else:
+                            # improve mode: skill is already enabled; force a
+                            # config save anyway so the file watcher re-syncs
+                            # slash commands (the description / arg-hint may
+                            # have changed during the improve workflow).
+                            try:
+                                skill_manager.enable_skill(target_skill)
+                            except Exception:
+                                pass
+                except Exception as e:
+                    logger.warning(f"[SKILL_CREATOR] Skill reload failed: {e}")
+
+    @staticmethod
+    def _extract_target_skill_name(instruction: Optional[str]) -> Optional[str]:
+        """Pull the `Skill name: <name>` value out of a skill-workflow task
+        instruction. The handler in browser_adapter formats the instruction
+        with a fixed `Skill name: <name>` line; this parser is the inverse.
+        Returns None if the line is missing or malformed.
+        """
+        if not instruction:
+            return None
+        for line in instruction.splitlines():
+            stripped = line.strip()
+            if stripped.lower().startswith("skill name:"):
+                value = stripped.split(":", 1)[1].strip()
+                # Defensive — keep only kebab-case characters
+                return value or None
+        return None
+
     def _sync_state_manager(self, task: Optional[Task]) -> None:
         """Sync task state to the state manager and persist to disk."""
         if self.state_manager:
@@ -713,16 +793,20 @@ class TaskManager:
                 logger.warning(f"[TaskManager] Failed to persist task {task.id}: {e}")
 
     def _log_to_task_history(self, task: Task, note: Optional[str] = None) -> None:
-        """Log completed task to TASK_HISTORY.md."""
+        """Log completed task to TASK_HISTORY.md.
+
+        Mirrors the EVENT.md / CONVERSATION_HISTORY.md pattern: just append
+        with open(..., "a"), which auto-creates the file if missing. The
+        template at app/data/agent_file_system_template/TASK_HISTORY.md
+        provides a header for users who hit Reset; users without the
+        template still get a working append-only log starting from the
+        first task completion.
+        """
         if not self.agent_file_system_path:
             return
 
         try:
             task_history_path = self.agent_file_system_path / "TASK_HISTORY.md"
-
-            if not task_history_path.exists():
-                logger.warning(f"[TaskManager] TASK_HISTORY.md not found at {task_history_path}")
-                return
 
             entry_lines = [
                 f"### Task: {task.name}",

--- a/app/agent_base.py
+++ b/app/agent_base.py
@@ -3047,10 +3047,24 @@ class AgentBase:
                 from app.skill import skill_manager
 
                 async def _reload_skills_and_sync():
-                    """Reload skills and sync skill slash commands."""
+                    """Reload skills, sync slash commands, and broadcast the
+                    refreshed skill list so the Settings page UI updates
+                    without a manual reload."""
                     result = await skill_manager.reload()
                     if self.ui_controller:
                         self.ui_controller.sync_skill_commands()
+                        # Broadcast the refreshed list to the active adapter
+                        # (e.g. browser) so any open Settings page sees the
+                        # new / re-enabled skill immediately.
+                        adapter = getattr(self.ui_controller, "_adapter", None)
+                        broadcast_handler = getattr(adapter, "_handle_skill_list", None)
+                        if broadcast_handler is not None:
+                            try:
+                                await broadcast_handler()
+                            except Exception as e:
+                                logger.debug(
+                                    f"[SKILLS] Failed to broadcast skill list update: {e}"
+                                )
                     return result
 
                 config_watcher.register(

--- a/app/ui_layer/adapters/base.py
+++ b/app/ui_layer/adapters/base.py
@@ -348,6 +348,20 @@ class InterfaceAdapter(ABC):
         if not task_id:
             return
 
+        # Look up the source Task to capture skill/workflow context for the UI
+        selected_skills: List[str] = []
+        workflow_id: Optional[str] = None
+        try:
+            agent = getattr(self._controller, "agent", None)
+            task_manager = getattr(agent, "task_manager", None) if agent else None
+            if task_manager is not None:
+                task = task_manager.get_task_by_id(task_id)
+                if task is not None:
+                    selected_skills = list(task.selected_skills or [])
+                    workflow_id = task.workflow_id
+        except Exception:
+            pass
+
         if self.action_panel:
             asyncio.create_task(
                 self.action_panel.add_item(
@@ -356,6 +370,8 @@ class InterfaceAdapter(ABC):
                         name=event.data.get("task_name", "Task"),
                         status="running",
                         item_type="task",
+                        selected_skills=selected_skills,
+                        workflow_id=workflow_id,
                     )
                 )
             )

--- a/app/ui_layer/adapters/browser_adapter.py
+++ b/app/ui_layer/adapters/browser_adapter.py
@@ -1178,6 +1178,10 @@ A quick Q&A will now begin to understand your objectives to serve you better:"""
                 "type": "init",
                 "data": initial_state,
             })
+            await ws.send_json({
+                "type": "skill_meta",
+                "data": self._get_skill_meta(),
+            })
         except (ConnectionResetError, ClientConnectionResetError, RuntimeError) as e:
             # Gracefully handle connection closing
             self._ws_clients.discard(ws)
@@ -2967,26 +2971,33 @@ A quick Q&A will now begin to understand your objectives to serve you better:"""
     # Skill creation from a completed task
     # ─────────────────────────────────────────────────────────────────────
 
-    # Tasks belonging to these workflow_ids must NEVER be eligible as
-    # source tasks — they ARE the skill / memory infrastructure.
-    # Some internal workflows set workflow_id, some don't (only set
-    # selected_skills) — see _INTERNAL_SKILL_NAMES below for the rest.
+    # `workflow_id` is functional infrastructure, NOT a "this task is
+    # internal" tag. It is set only on workflows that need:
+    #   1. WorkflowLockManager serialization (memory_processing — only
+    #      one memory pass at a time; the lock is auto-released in
+    #      TaskManager._end_task by keying off task.workflow_id).
+    #   2. Post-completion side effects (skill_creation / skill_improvement
+    #      trigger SkillManager.reload() and auto-enable the new skill in
+    #      TaskManager._end_task).
+    # Tasks tagged with one of these are internal by definition (they ARE
+    # the skill / memory infrastructure) and must never be eligible as
+    # source tasks for the "Create Skill" flow. Heartbeats, planners, and
+    # the onboarding interview don't need either of those two services, so
+    # they don't set workflow_id — _INTERNAL_SKILL_NAMES covers them.
     _INTERNAL_WORKFLOW_IDS = frozenset({
         "skill_creation",
         "skill_improvement",
         "memory_processing",
     })
 
-    # Skills that mark a task as a CraftBot internal workflow regardless
-    # of whether `workflow_id` was set. This is the union of every skill
-    # in the repo with `user-invocable: false`. A task whose
-    # `selected_skills` intersects this set is a system-spawned workflow
-    # (memory processing, soft onboarding, proactive heartbeats / planners,
-    # the skill creator/improver itself), and the "Create Skill" button
-    # must not appear on it.
-    #
-    # KEEP IN SYNC with INTERNAL_SKILL_NAMES in
-    # app/ui_layer/browser/frontend/src/pages/Tasks/TasksPage.tsx
+    # Detection of internal tasks via `selected_skills` — needed because
+    # most internal workflows (heartbeats, planners, soft onboarding) only
+    # set selected_skills, not workflow_id. This is the union of every
+    # skill in the repo with `user-invocable: false`. A task whose
+    # selected_skills intersects this set is system-spawned and the
+    # "Create Skill" button must not appear on it.
+    # Used together with _INTERNAL_WORKFLOW_IDS via OR — see the frontend
+    # `isInternalWorkflowTask` for the combined check.
     _INTERNAL_SKILL_NAMES = frozenset({
         "craftbot-skill-creator",
         "craftbot-skill-improve",
@@ -2998,10 +3009,17 @@ A quick Q&A will now begin to understand your objectives to serve you better:"""
         "month-planner",
     })
 
-    # Names that may not be created or overwritten by the user-facing flow.
-    # Subset of internal skill names — anything user-invocable:false is
-    # off-limits, plus we explicitly disallow re-creating the skill-creator
-    # / skill-improver workflow skills themselves.
+    # Names the user may not type into the SkillCreatorModal (validated in
+    # _handle_create_skill_from_task). Kept separate from
+    # _INTERNAL_SKILL_NAMES because the two answer different questions:
+    #   _INTERNAL_SKILL_NAMES → "is this *task* a system task?" (hides the
+    #     Create Skill button on its detail panel)
+    #   _RESERVED_SKILL_NAMES → "is this *name* one the user can claim?"
+    #     (modal input validation)
+    # The contents happen to coincide today, but a future user-invocable
+    # skill that we still don't want overwritten would belong only here,
+    # and an internal skill we'd let users replace would belong only in
+    # _INTERNAL_SKILL_NAMES — keeping them split avoids a re-split later.
     _RESERVED_SKILL_NAMES = frozenset({
         "craftbot-skill-creator",
         "craftbot-skill-improve",
@@ -3014,6 +3032,13 @@ A quick Q&A will now begin to understand your objectives to serve you better:"""
     })
 
     _SKILL_NAME_PATTERN = re.compile(r"^[a-z][a-z0-9-]{1,63}$")
+
+    def _get_skill_meta(self) -> Dict[str, Any]:
+        return {
+            "internalWorkflowIds": sorted(self._INTERNAL_WORKFLOW_IDS),
+            "internalSkillNames": sorted(self._INTERNAL_SKILL_NAMES),
+            "reservedSkillNames": sorted(self._RESERVED_SKILL_NAMES),
+        }
 
     async def _handle_create_skill_from_task(self, data: Dict[str, Any]) -> None:
         """

--- a/app/ui_layer/adapters/browser_adapter.py
+++ b/app/ui_layer/adapters/browser_adapter.py
@@ -6,8 +6,11 @@ import asyncio
 import base64
 import json
 import os
+import re
 import shutil
 import time
+import uuid
+from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set
 
@@ -430,6 +433,8 @@ class BrowserActionPanelComponent(ActionPanelProtocol):
                     input_data=stored.input_data,
                     output_data=stored.output_data,
                     error_message=stored.error_message,
+                    selected_skills=list(stored.selected_skills or []),
+                    workflow_id=stored.workflow_id,
                 ))
         except Exception:
             # Storage may not be available, continue without persistence
@@ -451,6 +456,8 @@ class BrowserActionPanelComponent(ActionPanelProtocol):
                     input_data=item.input_data,
                     output_data=item.output_data,
                     error_message=item.error_message,
+                    selected_skills=list(item.selected_skills or []),
+                    workflow_id=item.workflow_id,
                 )
                 self._storage.insert_item(stored)
             except Exception:
@@ -484,6 +491,8 @@ class BrowserActionPanelComponent(ActionPanelProtocol):
                 "input": item.input_data,
                 "output": item.output_data,
                 "error": item.error_message,
+                "selectedSkills": list(item.selected_skills or []),
+                "workflowId": item.workflow_id,
             },
         })
 
@@ -1370,6 +1379,9 @@ A quick Q&A will now begin to understand your objectives to serve you better:"""
 
         elif msg_type == "clear_tasks":
             await self._handle_clear_tasks()
+
+        elif msg_type == "create_skill_from_task":
+            await self._handle_create_skill_from_task(data)
 
         # Scheduler/Proactive operations
         elif msg_type == "scheduler_config_get":
@@ -2950,6 +2962,472 @@ A quick Q&A will now begin to understand your objectives to serve you better:"""
                 "type": "clear_tasks",
                 "data": {"success": False, "error": str(e)},
             })
+
+    # ─────────────────────────────────────────────────────────────────────
+    # Skill creation from a completed task
+    # ─────────────────────────────────────────────────────────────────────
+
+    # Tasks belonging to these workflow_ids must NEVER be eligible as
+    # source tasks — they ARE the skill / memory infrastructure.
+    # Some internal workflows set workflow_id, some don't (only set
+    # selected_skills) — see _INTERNAL_SKILL_NAMES below for the rest.
+    _INTERNAL_WORKFLOW_IDS = frozenset({
+        "skill_creation",
+        "skill_improvement",
+        "memory_processing",
+    })
+
+    # Skills that mark a task as a CraftBot internal workflow regardless
+    # of whether `workflow_id` was set. This is the union of every skill
+    # in the repo with `user-invocable: false`. A task whose
+    # `selected_skills` intersects this set is a system-spawned workflow
+    # (memory processing, soft onboarding, proactive heartbeats / planners,
+    # the skill creator/improver itself), and the "Create Skill" button
+    # must not appear on it.
+    #
+    # KEEP IN SYNC with INTERNAL_SKILL_NAMES in
+    # app/ui_layer/browser/frontend/src/pages/Tasks/TasksPage.tsx
+    _INTERNAL_SKILL_NAMES = frozenset({
+        "craftbot-skill-creator",
+        "craftbot-skill-improve",
+        "memory-processor",
+        "heartbeat-processor",
+        "user-profile-interview",
+        "day-planner",
+        "week-planner",
+        "month-planner",
+    })
+
+    # Names that may not be created or overwritten by the user-facing flow.
+    # Subset of internal skill names — anything user-invocable:false is
+    # off-limits, plus we explicitly disallow re-creating the skill-creator
+    # / skill-improver workflow skills themselves.
+    _RESERVED_SKILL_NAMES = frozenset({
+        "craftbot-skill-creator",
+        "craftbot-skill-improve",
+        "memory-processor",
+        "user-profile-interview",
+        "heartbeat-processor",
+        "day-planner",
+        "week-planner",
+        "month-planner",
+    })
+
+    _SKILL_NAME_PATTERN = re.compile(r"^[a-z][a-z0-9-]{1,63}$")
+
+    async def _handle_create_skill_from_task(self, data: Dict[str, Any]) -> None:
+        """
+        Spawn a workflow task that creates or improves a skill, using a
+        completed source task as evidence. Writes a per-task SKILL_SOURCE
+        markdown file before queueing the trigger.
+        """
+        response_type = "create_skill_from_task"
+
+        async def _err(msg: str) -> None:
+            await self._broadcast({
+                "type": response_type,
+                "data": {"success": False, "error": msg},
+            })
+
+        # ---- Validate request shape ----------------------------------
+        source_task_id = (data.get("taskId") or "").strip()
+        mode = data.get("mode")
+        skill_name_raw = (data.get("skillName") or "").strip()
+        target_skill_raw = (data.get("targetSkill") or "").strip()
+
+        # `verb` is the imperative form used inside the agent's instruction
+        # string ("Create skill 'x'."). `task_title_verb` is the progressive
+        # form used in the user-facing task title shown in the action panel
+        # ("Creating skill: x") so users see what the agent is *doing*, not
+        # a command at them.
+        if mode == "create":
+            workflow_id = "skill_creation"
+            workflow_skill = "craftbot-skill-creator"
+            target = skill_name_raw
+            verb = "Create"
+            task_title_verb = "Creating"
+        elif mode == "improve":
+            workflow_id = "skill_improvement"
+            workflow_skill = "craftbot-skill-improve"
+            target = target_skill_raw
+            verb = "Improve"
+            task_title_verb = "Improving"
+        else:
+            await _err("invalid_mode")
+            return
+
+        if not source_task_id:
+            await _err("missing_task_id")
+            return
+        if not target:
+            await _err("missing_skill_name")
+            return
+        if not self._SKILL_NAME_PATTERN.fullmatch(target):
+            await _err("invalid_skill_name")
+            return
+        if target in self._RESERVED_SKILL_NAMES:
+            await _err("reserved_skill_name")
+            return
+
+        # ---- Look up source task -------------------------------------
+        # The in-memory `task_manager.tasks` dict only holds RUNNING tasks —
+        # `_finalize_task` pops the entry when a task ends. So a completed
+        # source task is never resolvable via `get_task_by_id`. Source from
+        # the durable ActionItem record instead (in-memory panel first, then
+        # `actions.db` SQLite as fallback). Both paths carry `selected_skills`
+        # and `workflow_id` thanks to the earlier payload extension.
+        agent = self._controller.agent
+        task_manager = getattr(agent, "task_manager", None)
+        if task_manager is None:
+            await _err("task_manager_unavailable")
+            return
+
+        source_item = self._lookup_source_action_item(source_task_id)
+        if source_item is None:
+            await _err("source_task_not_found")
+            return
+        if source_item.item_type != "task":
+            await _err("source_task_not_found")
+            return
+        if source_item.status != "completed":
+            await _err("source_task_not_completed")
+            return
+        # Reject any task that is itself a CraftBot internal workflow.
+        # Two signals — either is sufficient:
+        #   1. `workflow_id` matches a known internal id (memory processing,
+        #      skill creation/improvement)
+        #   2. `selected_skills` intersects the user-invocable:false skill
+        #      set (soft onboarding, heartbeat, planners — these don't set
+        #      workflow_id, only selected_skills)
+        if (source_item.workflow_id or "") in self._INTERNAL_WORKFLOW_IDS:
+            await _err("source_task_is_internal_workflow")
+            return
+        if any(s in self._INTERNAL_SKILL_NAMES for s in (source_item.selected_skills or [])):
+            await _err("source_task_is_internal_workflow")
+            return
+
+        # ---- Skill existence checks ----------------------------------
+        skills_dir = Path(__file__).resolve().parents[3] / "skills"
+        target_dir = skills_dir / target
+        target_skill_md = target_dir / "SKILL.md"
+
+        if mode == "create":
+            if target_skill_md.exists():
+                await _err("skill_already_exists")
+                return
+            try:
+                from app.tui.skill_settings import get_skill_info
+                if get_skill_info(target):
+                    await _err("skill_already_exists")
+                    return
+            except Exception:
+                pass
+        else:  # improve
+            if not target_skill_md.exists():
+                await _err("skill_not_found")
+                return
+
+        # ---- Acquire workflow lock -----------------------------------
+        lock_manager = getattr(agent, "workflow_lock_manager", None)
+        if lock_manager is None:
+            await _err("workflow_lock_unavailable")
+            return
+        if not await lock_manager.try_acquire(workflow_id):
+            await _err("workflow_busy")
+            return
+
+        new_task_id = uuid.uuid4().hex
+        source_md_path: Optional[Path] = None
+        try:
+            # ---- Build SKILL_SOURCE_<id>.md --------------------------
+            from app.config import AGENT_FILE_SYSTEM_PATH
+            source_md_path = Path(AGENT_FILE_SYSTEM_PATH) / f"SKILL_SOURCE_{new_task_id}.md"
+            source_md_path.parent.mkdir(parents=True, exist_ok=True)
+            existing_skill_md = target_skill_md if mode == "improve" else None
+            source_md_path.write_text(
+                self._build_skill_source_md(
+                    mode=mode,
+                    target_skill=target,
+                    source_item=source_item,
+                    existing_skill_md=existing_skill_md,
+                ),
+                encoding="utf-8",
+            )
+
+            # ---- Ensure the workflow skill is enabled ----------------
+            try:
+                enable_skill(workflow_skill)
+            except Exception as e:
+                logger.debug(f"[SKILL_CREATOR] enable_skill({workflow_skill}) noop/failed: {e}")
+
+            # ---- Spawn the workflow task -----------------------------
+            # Use absolute paths in the instruction so the agent can pass
+            # them verbatim to read_file / write_file / stream_edit. With
+            # relative paths (e.g. "skills/<name>/SKILL.md") the agent has
+            # been observed mistakenly prepending the source-file's prefix
+            # (`agent_file_system/`), landing the new SKILL.md inside the
+            # agent file system instead of the project's `skills/` dir.
+            absolute_source_path = source_md_path.resolve()
+            absolute_target_path = target_skill_md.resolve()
+            instruction = (
+                f"SILENT BACKGROUND TASK — do not message the user.\n"
+                f"{verb} skill '{target}'.\n"
+                f"Source file (read this — absolute path, use verbatim): {absolute_source_path}\n"
+                f"Target file (write the new SKILL.md here — absolute path, use verbatim): {absolute_target_path}\n"
+                f"Mode: {mode}\n"
+                f"Skill name: {target}\n"
+                f"Read the source file, follow the {workflow_skill} skill instructions, "
+                f"write the new skill to the target file (use the absolute target path verbatim), "
+                f"and end the task with task_end."
+            )
+            # No colon in the title — EventTransformer._create_task_start_event
+            # splits on the first ":" and keeps only the suffix, which would
+            # otherwise leave the panel showing just the bare skill name.
+            task_name = f'{task_title_verb} skill "{target}"'
+            task_manager.create_task(
+                task_name=task_name,
+                task_instruction=instruction,
+                mode="complex",
+                action_sets=["file_operations"],
+                selected_skills=[workflow_skill],
+                session_id=new_task_id,
+                workflow_id=workflow_id,
+            )
+
+            # ---- Queue trigger so execution actually starts ---------
+            from app.trigger import Trigger
+            trigger = Trigger(
+                fire_at=time.time(),
+                priority=60,
+                next_action_description=f"{verb} skill '{target}' from completed task",
+                session_id=new_task_id,
+                payload={},
+            )
+            await agent.triggers.put(trigger)
+
+            # Acknowledge in the chat immediately so the user sees the work
+            # being picked up. The agent will follow up with a presentation
+            # message when the workflow completes (see craftbot-skill-* SKILL.md).
+            ack_text = (
+                f"Creating skill `{target}` from the completed task."
+                if mode == "create"
+                else f"Improving skill `{target}` based on the recent task."
+            )
+            try:
+                await self._display_chat_message("System", ack_text, "system")
+            except Exception as e:
+                logger.debug(f"[SKILL_CREATOR] ack chat message failed: {e}")
+
+            await self._broadcast({
+                "type": response_type,
+                "data": {
+                    "success": True,
+                    "taskId": new_task_id,
+                    "skillName": target,
+                    "mode": mode,
+                },
+            })
+            return
+
+        except Exception as e:
+            logger.warning(f"[SKILL_CREATOR] handler failed: {e}", exc_info=True)
+            # Release the lock since the task never took ownership.
+            try:
+                await lock_manager.release(workflow_id)
+            except Exception:
+                pass
+            # Best-effort cleanup of the source file we wrote.
+            if source_md_path is not None:
+                try:
+                    source_md_path.unlink()
+                except Exception:
+                    pass
+            await _err(str(e) or "internal_error")
+            return
+
+    def _lookup_source_action_item(self, item_id: str) -> Optional[ActionItem]:
+        """Find a task-level ActionItem by id.
+
+        Tries the in-memory action panel first (fastest, current session),
+        then falls back to ActionStorage (`actions.db`) so completed tasks
+        from previous sessions still resolve. Both sources carry
+        `selected_skills` and `workflow_id` after the payload extension.
+        """
+        # In-memory first
+        try:
+            for item in (self._action_panel._items if self._action_panel else []):
+                if item.id == item_id:
+                    return item
+        except Exception:
+            pass
+
+        # SQLite fallback
+        try:
+            storage = getattr(self._action_panel, "_storage", None) if self._action_panel else None
+            if storage is not None:
+                stored = storage.get_item(item_id)
+                if stored is not None:
+                    return ActionItem(
+                        id=stored.id,
+                        name=stored.name,
+                        status=stored.status,
+                        item_type=stored.item_type,
+                        parent_id=stored.parent_id,
+                        created_at=stored.created_at,
+                        completed_at=stored.completed_at,
+                        input_data=stored.input_data,
+                        output_data=stored.output_data,
+                        error_message=stored.error_message,
+                        selected_skills=list(stored.selected_skills or []),
+                        workflow_id=stored.workflow_id,
+                    )
+        except Exception:
+            pass
+
+        return None
+
+    def _gather_child_action_items(self, parent_id: str) -> List[ActionItem]:
+        """Collect every child ActionItem under `parent_id`, deduped by id.
+
+        Pulls from in-memory first, then ActionStorage. Result is sorted by
+        creation time. The two sources usually overlap completely; the union
+        is the safe choice for a task that just completed (in-memory has the
+        absolute-latest state) or one that was loaded from disk after a
+        restart (storage is the only source).
+        """
+        seen_ids: Set[str] = set()
+        children: List[ActionItem] = []
+
+        try:
+            for item in (self._action_panel._items if self._action_panel else []):
+                if item.parent_id == parent_id and item.id not in seen_ids:
+                    children.append(item)
+                    seen_ids.add(item.id)
+        except Exception:
+            pass
+
+        try:
+            storage = getattr(self._action_panel, "_storage", None) if self._action_panel else None
+            if storage is not None:
+                for sit in storage.get_items(limit=2000, include_running=True):
+                    if sit.parent_id == parent_id and sit.id not in seen_ids:
+                        children.append(ActionItem(
+                            id=sit.id,
+                            name=sit.name,
+                            status=sit.status,
+                            item_type=sit.item_type,
+                            parent_id=sit.parent_id,
+                            created_at=sit.created_at,
+                            completed_at=sit.completed_at,
+                            input_data=sit.input_data,
+                            output_data=sit.output_data,
+                            error_message=sit.error_message,
+                            selected_skills=list(sit.selected_skills or []),
+                            workflow_id=sit.workflow_id,
+                        ))
+                        seen_ids.add(sit.id)
+        except Exception:
+            pass
+
+        children.sort(key=lambda it: it.created_at or 0.0)
+        return children
+
+    def _build_skill_source_md(
+        self,
+        *,
+        mode: str,
+        target_skill: str,
+        source_item: ActionItem,
+        existing_skill_md: Optional[Path],
+    ) -> str:
+        """Compose the per-task SKILL_SOURCE markdown file from durable
+        ActionItem records (the live `Task` object is gone by the time the
+        user clicks Create Skill — see _lookup_source_action_item).
+
+        Sections:
+          frontmatter (mode, target_skill, source_task_id, generated_at)
+          ## Task name           — from ActionItem.name
+          ## Outcome             — status, created, ended, selected_skills, workflow_id
+          ## Action trace        — every child action+reasoning row from the DB
+          ## Existing SKILL.md   — verbatim, improve mode only
+        """
+        FIELD_CAP = 2048
+        ERROR_CAP = 300
+
+        def truncate(value: Optional[str], cap: int = FIELD_CAP) -> str:
+            if value is None:
+                return "(none)"
+            text = str(value)
+            if len(text) <= cap:
+                return text
+            return text[:cap] + f"\n…[truncated {len(text) - cap} chars]"
+
+        def fmt_ts(ts: Optional[float]) -> str:
+            if not ts:
+                return "(unknown)"
+            try:
+                return datetime.fromtimestamp(ts).isoformat()
+            except Exception:
+                return str(ts)
+
+        child_items = self._gather_child_action_items(source_item.id)
+
+        selected_skills_str = ", ".join(source_item.selected_skills or []) or "(none)"
+        workflow_id_str = source_item.workflow_id or "(none)"
+
+        lines: List[str] = [
+            "---",
+            f"mode: {mode}",
+            f"target_skill: {target_skill}",
+            f"source_task_id: {source_item.id}",
+            f"generated_at: {datetime.utcnow().isoformat()}Z",
+            "---",
+            "",
+            "# Source Task Context",
+            "",
+            "## Task name",
+            truncate(source_item.name),
+            "",
+            "## Outcome",
+            f"- Status: {source_item.status}",
+            f"- Created: {fmt_ts(source_item.created_at)}",
+            f"- Ended: {fmt_ts(source_item.completed_at)}",
+            f"- Selected skills: {selected_skills_str}",
+            f"- Workflow id: {workflow_id_str}",
+            "",
+            "## Action trace",
+            "",
+        ]
+
+        if not child_items:
+            lines.append("(no recorded actions)")
+        else:
+            for idx, item in enumerate(child_items, 1):
+                duration_ms = item.duration
+                duration_str = f"{duration_ms}ms" if duration_ms is not None else "—"
+                lines.append(
+                    f"### [{idx}] {item.name} — {item.status} ({duration_str}) [{item.item_type}]"
+                )
+                lines.append(f"- input: {truncate(item.input_data)}")
+                lines.append(f"- output: {truncate(item.output_data)}")
+                err_text = item.error_message
+                lines.append(
+                    f"- error: {truncate(err_text, ERROR_CAP) if err_text else '(none)'}"
+                )
+                lines.append("")
+
+        if existing_skill_md is not None:
+            lines.append("## Existing SKILL.md")
+            lines.append("")
+            try:
+                existing = existing_skill_md.read_text(encoding="utf-8")
+            except Exception as e:
+                existing = f"(failed to read: {e})"
+            lines.append("```")
+            lines.append(existing)
+            lines.append("```")
+
+        return "\n".join(lines)
 
     # ─────────────────────────────────────────────────────────────────────
     # Scheduler/Proactive Operation Handlers
@@ -5332,6 +5810,8 @@ A quick Q&A will now begin to understand your objectives to serve you better:"""
                     "input": a.input_data,
                     "output": a.output_data,
                     "error": a.error_message,
+                    "selectedSkills": list(a.selected_skills or []),
+                    "workflowId": a.workflow_id,
                 }
                 for a in older_items
             ]
@@ -5917,6 +6397,8 @@ A quick Q&A will now begin to understand your objectives to serve you better:"""
                     "input": a.input_data,
                     "output": a.output_data,
                     "error": a.error_message,
+                    "selectedSkills": list(a.selected_skills or []),
+                    "workflowId": a.workflow_id,
                 }
                 for a in self._action_panel.get_items()
             ],

--- a/app/ui_layer/browser/frontend/src/components/Chat/Chat.tsx
+++ b/app/ui_layer/browser/frontend/src/components/Chat/Chat.tsx
@@ -60,6 +60,7 @@ export function Chat({ livingUIId, placeholder, emptyMessage }: ChatProps) {
     actions,
     connected,
     sendMessage,
+    sendCommand,
     sendOptionClick,
     openFile,
     openFolder,
@@ -313,12 +314,24 @@ export function Chat({ livingUIId, placeholder, emptyMessage }: ChatProps) {
         setIsListening(false)
       }
 
-      sendMessage(
-        input.trim(),
-        pendingAttachments.length > 0 ? pendingAttachments : undefined,
-        replyContext,
-        livingUIId
-      )
+      const trimmed = input.trim()
+      // Slash commands route through the dedicated command channel so no
+      // optimistic user bubble is inserted — the backend's CommandExecutor
+      // responds with system/error messages rather than echoing user input.
+      // Attachments + slash command falls through to chat (commands don't
+      // accept attachments), which preserves the existing behavior for that
+      // edge case.
+      const isSlashCommand = trimmed.startsWith('/') && pendingAttachments.length === 0
+      if (isSlashCommand) {
+        sendCommand(trimmed)
+      } else {
+        sendMessage(
+          trimmed,
+          pendingAttachments.length > 0 ? pendingAttachments : undefined,
+          replyContext,
+          livingUIId
+        )
+      }
       if (!connected) {
         showToast('info', 'Reconnecting — your message will send when the connection is restored.')
       }

--- a/app/ui_layer/browser/frontend/src/components/ui/SkillCreatorModal.module.css
+++ b/app/ui_layer/browser/frontend/src/components/ui/SkillCreatorModal.module.css
@@ -1,0 +1,230 @@
+/* SkillCreatorModal — input/choice modal for creating/improving a skill from a task */
+.modalOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: var(--z-modal);
+  padding: var(--space-4);
+  animation: fadeIn 0.15s ease-out;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.modalContent {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-lg);
+  width: 100%;
+  max-width: 460px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  animation: slideUp 0.15s ease-out;
+}
+
+@keyframes slideUp {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.modalHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-4);
+  border-bottom: 1px solid var(--border-primary);
+}
+
+.modalHeader h3 {
+  font-size: var(--text-lg);
+  font-weight: var(--font-semibold);
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.modalClose {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-md);
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.modalClose:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.modalBody {
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.intro {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  margin: 0;
+  line-height: 1.5;
+}
+
+.choiceGroup {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.choiceItem {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.choiceItem:hover {
+  background: var(--bg-hover);
+}
+
+.choiceItem.choiceItemSelected {
+  border-color: var(--color-primary);
+  background: var(--color-primary-subtle);
+}
+
+.choiceRadio {
+  margin-top: 2px;
+}
+
+.choiceLabel {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+}
+
+.choiceHint {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+}
+
+.fieldLabel {
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.fieldInput {
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  background: var(--bg-primary);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  font-family: var(--font-mono, monospace);
+  transition: border-color var(--transition-fast);
+}
+
+.fieldInput:focus {
+  outline: none;
+  border-color: var(--color-primary);
+}
+
+.fieldInput.fieldInputError {
+  border-color: var(--color-error);
+}
+
+.fieldHint {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.fieldError {
+  font-size: var(--text-xs);
+  color: var(--color-error);
+  margin: 0;
+}
+
+.modalFooter {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-2);
+  padding: var(--space-4);
+  border-top: 1px solid var(--border-primary);
+}
+
+/* ─── Success view ─────────────────────────────────────────────── */
+.successIcon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  margin: 0 auto;
+  border-radius: 50%;
+  background: rgba(16, 185, 129, 0.15);
+  color: var(--color-success, #10b981);
+}
+
+.successHeadline {
+  font-size: var(--text-base);
+  font-weight: var(--font-semibold);
+  color: var(--text-primary);
+  text-align: center;
+  margin: 0;
+}
+
+.successHeadline code {
+  font-family: var(--font-mono, monospace);
+  background: var(--bg-primary);
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  font-size: 0.95em;
+}
+
+/* ─── Submitting indicator ─────────────────────────────────────── */
+.submittingText {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  margin: 0;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}
+
+.spinning {
+  animation: spin 1s linear infinite;
+}

--- a/app/ui_layer/browser/frontend/src/components/ui/SkillCreatorModal.tsx
+++ b/app/ui_layer/browser/frontend/src/components/ui/SkillCreatorModal.tsx
@@ -19,6 +19,7 @@ export interface SkillCreatorSuccessInfo {
 export interface SkillCreatorModalProps {
   isOpen: boolean
   sourceSkills: string[]
+  reservedNames: Set<string>
   status: 'idle' | 'submitting' | 'success' | 'error'
   serverError: string | null
   successInfo: SkillCreatorSuccessInfo | null
@@ -27,13 +28,6 @@ export interface SkillCreatorModalProps {
 }
 
 const NAME_PATTERN = /^[a-z][a-z0-9-]{1,63}$/
-const RESERVED_NAMES = new Set<string>([
-  'craftbot-skill-creator',
-  'craftbot-skill-improve',
-  'memory-processor',
-  'user-profile-interview',
-  'heartbeat-processor',
-])
 
 type Choice = { kind: 'create' } | { kind: 'improve'; skill: string }
 
@@ -44,6 +38,7 @@ function choiceKey(c: Choice): string {
 export function SkillCreatorModal({
   isOpen,
   sourceSkills,
+  reservedNames,
   status,
   serverError,
   successInfo,
@@ -86,11 +81,11 @@ export function SkillCreatorModal({
     if (!NAME_PATTERN.test(trimmed)) {
       return 'Use lowercase letters, digits, and hyphens. Must start with a letter, 2–64 chars.'
     }
-    if (RESERVED_NAMES.has(trimmed)) {
+    if (reservedNames.has(trimmed)) {
       return 'This name is reserved. Pick another.'
     }
     return null
-  }, [isCreateMode, skillName])
+  }, [isCreateMode, skillName, reservedNames])
 
   const canSubmit = !submitting && !isSuccess && (
     isCreateMode

--- a/app/ui_layer/browser/frontend/src/components/ui/SkillCreatorModal.tsx
+++ b/app/ui_layer/browser/frontend/src/components/ui/SkillCreatorModal.tsx
@@ -1,0 +1,274 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+import { X, Check, Loader2 } from 'lucide-react'
+import { Button } from './Button'
+import styles from './SkillCreatorModal.module.css'
+
+export type SkillCreatorMode = 'create' | 'improve'
+
+export interface SkillCreatorSubmit {
+  mode: SkillCreatorMode
+  skillName?: string
+  targetSkill?: string
+}
+
+export interface SkillCreatorSuccessInfo {
+  skillName: string
+  mode: SkillCreatorMode
+}
+
+export interface SkillCreatorModalProps {
+  isOpen: boolean
+  sourceSkills: string[]
+  status: 'idle' | 'submitting' | 'success' | 'error'
+  serverError: string | null
+  successInfo: SkillCreatorSuccessInfo | null
+  onClose: () => void
+  onSubmit: (payload: SkillCreatorSubmit) => void
+}
+
+const NAME_PATTERN = /^[a-z][a-z0-9-]{1,63}$/
+const RESERVED_NAMES = new Set<string>([
+  'craftbot-skill-creator',
+  'craftbot-skill-improve',
+  'memory-processor',
+  'user-profile-interview',
+  'heartbeat-processor',
+])
+
+type Choice = { kind: 'create' } | { kind: 'improve'; skill: string }
+
+function choiceKey(c: Choice): string {
+  return c.kind === 'create' ? 'create' : `improve:${c.skill}`
+}
+
+export function SkillCreatorModal({
+  isOpen,
+  sourceSkills,
+  status,
+  serverError,
+  successInfo,
+  onClose,
+  onSubmit,
+}: SkillCreatorModalProps) {
+  const submitting = status === 'submitting'
+  const isSuccess = status === 'success'
+
+  const choices = useMemo<Choice[]>(() => {
+    const list: Choice[] = [{ kind: 'create' }]
+    for (const s of sourceSkills) {
+      list.push({ kind: 'improve', skill: s })
+    }
+    return list
+  }, [sourceSkills])
+
+  const [selectedKey, setSelectedKey] = useState<string>(choiceKey(choices[0]))
+  const [skillName, setSkillName] = useState<string>('')
+
+  // Reset the form ONLY on the closed→open transition, not on every
+  // `choices` change. This keeps the form intact while submitting (when
+  // the parent may re-render and pass a new `choices` reference).
+  const wasOpenRef = useRef(false)
+  useEffect(() => {
+    if (isOpen && !wasOpenRef.current) {
+      setSelectedKey(choiceKey(choices[0]))
+      setSkillName('')
+    }
+    wasOpenRef.current = isOpen
+  }, [isOpen, choices])
+
+  const selected = choices.find(c => choiceKey(c) === selectedKey) ?? choices[0]
+  const isCreateMode = selected.kind === 'create'
+
+  const validationError = useMemo<string | null>(() => {
+    if (!isCreateMode) return null
+    const trimmed = skillName.trim()
+    if (!trimmed) return null
+    if (!NAME_PATTERN.test(trimmed)) {
+      return 'Use lowercase letters, digits, and hyphens. Must start with a letter, 2–64 chars.'
+    }
+    if (RESERVED_NAMES.has(trimmed)) {
+      return 'This name is reserved. Pick another.'
+    }
+    return null
+  }, [isCreateMode, skillName])
+
+  const canSubmit = !submitting && !isSuccess && (
+    isCreateMode
+      ? skillName.trim().length > 0 && !validationError
+      : true
+  )
+
+  if (!isOpen) return null
+
+  const handleSubmit = () => {
+    if (!canSubmit) return
+    if (selected.kind === 'create') {
+      onSubmit({ mode: 'create', skillName: skillName.trim() })
+    } else {
+      onSubmit({ mode: 'improve', targetSkill: selected.skill })
+    }
+  }
+
+  const handleOverlayClick = () => {
+    // While submitting, clicking the overlay does nothing — the request is
+    // in flight and we don't want to lose track of it.
+    if (submitting) return
+    onClose()
+  }
+
+  // ─────────────────────────── SUCCESS VIEW ───────────────────────────
+  // After the backend acknowledges, the modal stays open showing a
+  // confirmation. The actual workflow runs in the background; the user
+  // dismisses the modal manually.
+  if (isSuccess && successInfo) {
+    const isCreate = successInfo.mode === 'create'
+    const verbing = isCreate ? 'Creating' : 'Improving'
+    return (
+      <div className={styles.modalOverlay} onClick={handleOverlayClick}>
+        <div className={styles.modalContent} onClick={e => e.stopPropagation()}>
+          <div className={styles.modalHeader}>
+            <h3>Skill workflow started</h3>
+            <button
+              className={styles.modalClose}
+              onClick={onClose}
+              aria-label="Close"
+            >
+              <X size={16} />
+            </button>
+          </div>
+          <div className={styles.modalBody}>
+            <div className={styles.successIcon}>
+              <Check size={28} />
+            </div>
+            <p className={styles.successHeadline}>
+              {verbing} <code>{successInfo.skillName}</code>…
+            </p>
+            <p className={styles.intro}>
+              The agent is working on it now. You'll see progress in chat
+              and the new task will appear in the task panel. Feel free to
+              close this dialog.
+            </p>
+          </div>
+          <div className={styles.modalFooter}>
+            <Button variant="primary" onClick={onClose}>
+              Close
+            </Button>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  // ──────────────────────────── FORM VIEW ────────────────────────────
+  const showRadio = sourceSkills.length > 0
+
+  return (
+    <div className={styles.modalOverlay} onClick={handleOverlayClick}>
+      <div className={styles.modalContent} onClick={e => e.stopPropagation()}>
+        <div className={styles.modalHeader}>
+          <h3>Create skill from task</h3>
+          <button
+            className={styles.modalClose}
+            onClick={onClose}
+            aria-label="Close"
+            disabled={submitting}
+          >
+            <X size={16} />
+          </button>
+        </div>
+        <div className={styles.modalBody}>
+          <p className={styles.intro}>
+            CraftBot will read this task's record and turn it into a reusable skill.
+            The new (or edited) skill will be invocable on future tasks.
+          </p>
+
+          {showRadio && (
+            <div className={styles.choiceGroup} role="radiogroup">
+              {choices.map(c => {
+                const key = choiceKey(c)
+                const isSel = key === selectedKey
+                const label = c.kind === 'create'
+                  ? 'Create a new skill'
+                  : `Improve "${c.skill}"`
+                const hint = c.kind === 'create'
+                  ? 'Distil this task into a brand-new skill.'
+                  : 'Refine the existing skill using this task as evidence.'
+                return (
+                  <label
+                    key={key}
+                    className={`${styles.choiceItem} ${isSel ? styles.choiceItemSelected : ''}`}
+                  >
+                    <input
+                      type="radio"
+                      className={styles.choiceRadio}
+                      name="skill-creator-choice"
+                      checked={isSel}
+                      onChange={() => setSelectedKey(key)}
+                      disabled={submitting}
+                    />
+                    <span className={styles.choiceLabel}>
+                      <strong>{label}</strong>
+                      <span className={styles.choiceHint}>{hint}</span>
+                    </span>
+                  </label>
+                )
+              })}
+            </div>
+          )}
+
+          {isCreateMode && (
+            <>
+              <label className={styles.fieldLabel} htmlFor="skill-creator-name">
+                New skill name
+              </label>
+              <input
+                id="skill-creator-name"
+                type="text"
+                className={`${styles.fieldInput} ${validationError ? styles.fieldInputError : ''}`}
+                placeholder="my-new-skill"
+                value={skillName}
+                onChange={e => setSkillName(e.target.value)}
+                disabled={submitting}
+                autoFocus
+                onKeyDown={e => {
+                  if (e.key === 'Enter') handleSubmit()
+                }}
+              />
+              {validationError ? (
+                <p className={styles.fieldError}>{validationError}</p>
+              ) : (
+                <p className={styles.fieldHint}>
+                  Lowercase letters, digits, and hyphens. Example: <code>weekly-pr-summary</code>.
+                </p>
+              )}
+            </>
+          )}
+
+          {submitting && (
+            <p className={styles.submittingText}>
+              <Loader2 size={14} className={styles.spinning} />
+              {' '}Submitting — waiting for the agent to acknowledge…
+            </p>
+          )}
+
+          {serverError && (
+            <p className={styles.fieldError}>{serverError}</p>
+          )}
+        </div>
+        <div className={styles.modalFooter}>
+          <Button variant="secondary" onClick={onClose} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            loading={submitting}
+          >
+            {isCreateMode ? 'Create' : 'Improve'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/ui_layer/browser/frontend/src/components/ui/index.ts
+++ b/app/ui_layer/browser/frontend/src/components/ui/index.ts
@@ -16,3 +16,6 @@ export { AttachmentDisplay } from './AttachmentDisplay'
 
 export { ConfirmModal } from './ConfirmModal'
 export type { ConfirmModalProps } from './ConfirmModal'
+
+export { SkillCreatorModal } from './SkillCreatorModal'
+export type { SkillCreatorModalProps, SkillCreatorMode, SkillCreatorSubmit } from './SkillCreatorModal'

--- a/app/ui_layer/browser/frontend/src/contexts/WebSocketContext.tsx
+++ b/app/ui_layer/browser/frontend/src/contexts/WebSocketContext.tsx
@@ -1043,10 +1043,8 @@ export function WebSocketProvider({ children }: { children: ReactNode }) {
   }, [sendOrQueue])
 
   const sendCommand = useCallback((command: string) => {
-    if (wsRef.current?.readyState === WebSocket.OPEN) {
-      wsRef.current.send(JSON.stringify({ type: 'command', command }))
-    }
-  }, [])
+    sendOrQueue(JSON.stringify({ type: 'command', command }))
+  }, [sendOrQueue])
 
   const clearMessages = useCallback(() => {
     setState(prev => ({ ...prev, messages: [] }))

--- a/app/ui_layer/browser/frontend/src/contexts/WebSocketContext.tsx
+++ b/app/ui_layer/browser/frontend/src/contexts/WebSocketContext.tsx
@@ -2,9 +2,10 @@ import React, { createContext, useContext, useEffect, useRef, useState, useCallb
 import type {
   ChatMessage, ActionItem, AgentStatus, InitialState, WSMessage, DashboardMetrics,
   TaskCancelResponse, FilteredDashboardMetrics, MetricsTimePeriod, OnboardingStep,
-  OnboardingStepResponse, OnboardingSubmitResponse, OnboardingCompleteResponse, 
-  LocalLLMState, LocalLLMCheckResponse, LocalLLMTestResponse, LocalLLMInstallResponse, 
+  OnboardingStepResponse, OnboardingSubmitResponse, OnboardingCompleteResponse,
+  LocalLLMState, LocalLLMCheckResponse, LocalLLMTestResponse, LocalLLMInstallResponse,
   LocalLLMProgressResponse, LocalLLMPullProgressResponse, SuggestedModel,
+  SkillMeta,
   // Living UI types
   LivingUIProject, LivingUICreateRequest, LivingUIStatusUpdate, LivingUIStateUpdate,
   LivingUITodo, LivingUITodosUpdate,
@@ -83,6 +84,7 @@ interface WebSocketState {
   livingUITodos: Record<string, LivingUITodo[]>
   activeLivingUIId: string | null
   livingUIStates: Record<string, LivingUIStateUpdate['state']>
+  skillMeta: SkillMeta
 }
 
 interface WebSocketContextType extends WebSocketState {
@@ -195,6 +197,11 @@ const defaultState: WebSocketState = {
   livingUITodos: {},
   activeLivingUIId: null,
   livingUIStates: {},
+  skillMeta: {
+    internalWorkflowIds: [],
+    internalSkillNames: [],
+    reservedSkillNames: [],
+  },
 }
 
 const WebSocketContext = createContext<WebSocketContextType | undefined>(undefined)
@@ -351,6 +358,19 @@ export function WebSocketProvider({ children }: { children: ReactNode }) {
             || false,
           hasMoreMessages: initMessages.length >= 50,
           hasMoreActions: initActions.filter((a: ActionItem) => a.itemType === 'task').length >= 15,
+        }))
+        break
+      }
+
+      case 'skill_meta': {
+        const data = msg.data as unknown as SkillMeta
+        setState(prev => ({
+          ...prev,
+          skillMeta: {
+            internalWorkflowIds: data.internalWorkflowIds || [],
+            internalSkillNames: data.internalSkillNames || [],
+            reservedSkillNames: data.reservedSkillNames || [],
+          },
         }))
         break
       }

--- a/app/ui_layer/browser/frontend/src/pages/Tasks/TasksPage.module.css
+++ b/app/ui_layer/browser/frontend/src/pages/Tasks/TasksPage.module.css
@@ -202,6 +202,7 @@
   gap: var(--space-2);
 }
 
+
 .cancelButton {
   display: flex;
   align-items: center;

--- a/app/ui_layer/browser/frontend/src/pages/Tasks/TasksPage.tsx
+++ b/app/ui_layer/browser/frontend/src/pages/Tasks/TasksPage.tsx
@@ -7,35 +7,14 @@ import type { ActionItem } from '../../types'
 import { useSkillCreator } from './useSkillCreator'
 import styles from './TasksPage.module.css'
 
-// Tasks belonging to these internal workflows must NOT show the
-// "Create Skill" button — they are themselves part of the skill /
-// memory / proactive infrastructure. The signal arrives via either
-// `workflowId` (memory_processing, skill_creation, skill_improvement)
-// or `selectedSkills` (soft onboarding, heartbeats, planners — these
-// don't set workflowId, only selectedSkills).
-//
-// KEEP IN SYNC with _INTERNAL_WORKFLOW_IDS / _INTERNAL_SKILL_NAMES in
-// app/ui_layer/adapters/browser_adapter.py
-const INTERNAL_WORKFLOW_IDS = new Set<string>([
-  'skill_creation',
-  'skill_improvement',
-  'memory_processing',
-])
-const INTERNAL_SKILL_NAMES = new Set<string>([
-  'craftbot-skill-creator',
-  'craftbot-skill-improve',
-  'memory-processor',
-  'heartbeat-processor',
-  'user-profile-interview',
-  'day-planner',
-  'week-planner',
-  'month-planner',
-])
-
-function isInternalWorkflowTask(item: ActionItem): boolean {
-  if (item.workflowId && INTERNAL_WORKFLOW_IDS.has(item.workflowId)) return true
+function isInternalWorkflowTask(
+  item: ActionItem,
+  internalWorkflowIds: Set<string>,
+  internalSkillNames: Set<string>,
+): boolean {
+  if (item.workflowId && internalWorkflowIds.has(item.workflowId)) return true
   for (const s of item.selectedSkills ?? []) {
-    if (INTERNAL_SKILL_NAMES.has(s)) return true
+    if (internalSkillNames.has(s)) return true
   }
   return false
 }
@@ -306,7 +285,10 @@ const MIN_PANEL_WIDTH = 200
 const MAX_PANEL_WIDTH = 600
 
 export function TasksPage() {
-  const { actions, messages, cancelTask, cancellingTaskId, setReplyTarget, loadOlderActions, hasMoreActions, loadingOlderActions } = useWebSocket()
+  const { actions, messages, cancelTask, cancellingTaskId, setReplyTarget, loadOlderActions, hasMoreActions, loadingOlderActions, skillMeta } = useWebSocket()
+  const internalWorkflowIds = useMemo(() => new Set(skillMeta.internalWorkflowIds), [skillMeta.internalWorkflowIds])
+  const internalSkillNames = useMemo(() => new Set(skillMeta.internalSkillNames), [skillMeta.internalSkillNames])
+  const reservedSkillNames = useMemo(() => new Set(skillMeta.reservedSkillNames), [skillMeta.reservedSkillNames])
   const navigate = useNavigate()
   const [selectedItem, setSelectedItem] = useState<ActionItem | null>(null)
   const [mobileShowDetail, setMobileShowDetail] = useState(false)
@@ -545,7 +527,7 @@ export function TasksPage() {
                     >
                       {cancellingTaskId === selectedItem.id ? 'Cancelling...' : 'Cancel Task'}
                     </Button>
-                  ) : selectedItem.status === 'completed' && !isInternalWorkflowTask(selectedItem) ? (
+                  ) : selectedItem.status === 'completed' && !isInternalWorkflowTask(selectedItem, internalWorkflowIds, internalSkillNames) ? (
                     <Button
                       variant="ghost"
                       size="sm"
@@ -629,6 +611,7 @@ export function TasksPage() {
       <SkillCreatorModal
         isOpen={skillCreator.isOpen}
         sourceSkills={skillCreator.sourceSkills}
+        reservedNames={reservedSkillNames}
         status={skillCreator.status}
         serverError={skillCreator.serverError}
         successInfo={skillCreator.successInfo}

--- a/app/ui_layer/browser/frontend/src/pages/Tasks/TasksPage.tsx
+++ b/app/ui_layer/browser/frontend/src/pages/Tasks/TasksPage.tsx
@@ -1,10 +1,44 @@
 import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react'
-import { ChevronRight, XCircle, ArrowLeft, Reply } from 'lucide-react'
+import { ChevronRight, XCircle, ArrowLeft, Reply, Plus } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { useWebSocket } from '../../contexts/WebSocketContext'
-import { StatusIndicator, Badge, Button, IconButton } from '../../components/ui'
+import { StatusIndicator, Badge, Button, IconButton, SkillCreatorModal } from '../../components/ui'
 import type { ActionItem } from '../../types'
+import { useSkillCreator } from './useSkillCreator'
 import styles from './TasksPage.module.css'
+
+// Tasks belonging to these internal workflows must NOT show the
+// "Create Skill" button — they are themselves part of the skill /
+// memory / proactive infrastructure. The signal arrives via either
+// `workflowId` (memory_processing, skill_creation, skill_improvement)
+// or `selectedSkills` (soft onboarding, heartbeats, planners — these
+// don't set workflowId, only selectedSkills).
+//
+// KEEP IN SYNC with _INTERNAL_WORKFLOW_IDS / _INTERNAL_SKILL_NAMES in
+// app/ui_layer/adapters/browser_adapter.py
+const INTERNAL_WORKFLOW_IDS = new Set<string>([
+  'skill_creation',
+  'skill_improvement',
+  'memory_processing',
+])
+const INTERNAL_SKILL_NAMES = new Set<string>([
+  'craftbot-skill-creator',
+  'craftbot-skill-improve',
+  'memory-processor',
+  'heartbeat-processor',
+  'user-profile-interview',
+  'day-planner',
+  'week-planner',
+  'month-planner',
+])
+
+function isInternalWorkflowTask(item: ActionItem): boolean {
+  if (item.workflowId && INTERNAL_WORKFLOW_IDS.has(item.workflowId)) return true
+  for (const s of item.selectedSkills ?? []) {
+    if (INTERNAL_SKILL_NAMES.has(s)) return true
+  }
+  return false
+}
 
 // Expandable value component for long text
 const MAX_VALUE_LENGTH = 80
@@ -276,6 +310,7 @@ export function TasksPage() {
   const navigate = useNavigate()
   const [selectedItem, setSelectedItem] = useState<ActionItem | null>(null)
   const [mobileShowDetail, setMobileShowDetail] = useState(false)
+  const skillCreator = useSkillCreator()
 
   // Resizable panel state
   const [panelWidth, setPanelWidth] = useState(DEFAULT_PANEL_WIDTH)
@@ -510,6 +545,15 @@ export function TasksPage() {
                     >
                       {cancellingTaskId === selectedItem.id ? 'Cancelling...' : 'Cancel Task'}
                     </Button>
+                  ) : selectedItem.status === 'completed' && !isInternalWorkflowTask(selectedItem) ? (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      icon={<Plus size={14} />}
+                      onClick={() => skillCreator.open(selectedItem)}
+                    >
+                      Create Skill
+                    </Button>
                   ) : (selectedItem.status === 'error' || selectedItem.status === 'cancelled') && (
                     <Badge variant="error">Aborted</Badge>
                   )}
@@ -581,6 +625,16 @@ export function TasksPage() {
           </div>
         )}
       </div>
+
+      <SkillCreatorModal
+        isOpen={skillCreator.isOpen}
+        sourceSkills={skillCreator.sourceSkills}
+        status={skillCreator.status}
+        serverError={skillCreator.serverError}
+        successInfo={skillCreator.successInfo}
+        onClose={skillCreator.close}
+        onSubmit={skillCreator.submit}
+      />
     </div>
   )
 }

--- a/app/ui_layer/browser/frontend/src/pages/Tasks/useSkillCreator.ts
+++ b/app/ui_layer/browser/frontend/src/pages/Tasks/useSkillCreator.ts
@@ -1,0 +1,124 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useSettingsWebSocket } from '../Settings/useSettingsWebSocket'
+import type { ActionItem } from '../../types'
+import type { SkillCreatorSubmit, SkillCreatorSuccessInfo } from '../../components/ui/SkillCreatorModal'
+
+export type SkillCreatorStatus = 'idle' | 'submitting' | 'success' | 'error'
+
+interface SkillCreatorResponse {
+  success: boolean
+  taskId?: string
+  skillName?: string
+  mode?: 'create' | 'improve'
+  error?: string
+}
+
+const ERROR_MESSAGES: Record<string, string> = {
+  invalid_mode: 'Invalid request mode.',
+  missing_task_id: 'No source task selected.',
+  missing_skill_name: 'Enter a skill name.',
+  invalid_skill_name: 'Skill name format is invalid.',
+  reserved_skill_name: 'That name is reserved.',
+  source_task_not_found: 'Source task no longer exists.',
+  source_task_not_completed: 'Source task is not completed.',
+  source_task_is_internal_workflow: 'This task cannot be turned into a skill.',
+  skill_already_exists: 'A skill with this name already exists.',
+  skill_not_found: 'The target skill no longer exists.',
+  workflow_busy: 'Another skill workflow is in progress. Try again in a moment.',
+  task_manager_unavailable: 'Agent is not ready.',
+  workflow_lock_unavailable: 'Agent is not ready.',
+}
+
+function humanize(error: string | undefined): string {
+  if (!error) return 'Unknown error.'
+  return ERROR_MESSAGES[error] ?? error
+}
+
+export function useSkillCreator() {
+  const { send, onMessage } = useSettingsWebSocket()
+  const [isOpen, setIsOpen] = useState(false)
+  const [sourceTask, setSourceTask] = useState<ActionItem | null>(null)
+  const [status, setStatus] = useState<SkillCreatorStatus>('idle')
+  const [serverError, setServerError] = useState<string | null>(null)
+  const [lastResult, setLastResult] = useState<SkillCreatorResponse | null>(null)
+
+  // Subscribe to backend responses. The modal stays OPEN on success so the
+  // user sees the "submitted, agent is working" confirmation inside the
+  // dialog they were just interacting with — they dismiss it manually with
+  // the Close button. (Previously the modal auto-closed and a tiny chip in
+  // the top bar showed status, which was confusing.)
+  useEffect(() => {
+    const unsubscribe = onMessage('create_skill_from_task', (data: unknown) => {
+      const resp = data as SkillCreatorResponse
+      setLastResult(resp)
+      if (resp.success) {
+        setStatus('success')
+        setServerError(null)
+      } else {
+        setStatus('error')
+        setServerError(humanize(resp.error))
+      }
+    })
+    return unsubscribe
+  }, [onMessage])
+
+  const open = useCallback((task: ActionItem) => {
+    setSourceTask(task)
+    setIsOpen(true)
+    setServerError(null)
+    setStatus('idle')
+  }, [])
+
+  const close = useCallback(() => {
+    if (status === 'submitting') return // don't allow closing mid-flight
+    setIsOpen(false)
+    setSourceTask(null)
+    setServerError(null)
+    // Reset status so the next open shows a fresh form (otherwise a prior
+    // success/error would persist and the modal would skip the form view).
+    setStatus('idle')
+    setLastResult(null)
+  }, [status])
+
+  const submit = useCallback((payload: SkillCreatorSubmit) => {
+    if (!sourceTask) return
+    setStatus('submitting')
+    setServerError(null)
+    send('create_skill_from_task', {
+      taskId: sourceTask.id,
+      mode: payload.mode,
+      skillName: payload.skillName,
+      targetSkill: payload.targetSkill,
+    })
+  }, [send, sourceTask])
+
+  // Stabilize the array reference — `?? []` would yield a new array each
+  // render, which invalidates downstream useMemo/useEffect deps in the modal
+  // and causes the form to reset on every parent re-render (e.g. while
+  // submitting).
+  const sourceSkills = useMemo(
+    () => sourceTask?.selectedSkills ?? [],
+    [sourceTask],
+  )
+
+  // Compact view of the last successful submit, for the modal's success
+  // state. Returns null unless we have a valid skill name + mode pair.
+  const successInfo = useMemo<SkillCreatorSuccessInfo | null>(() => {
+    if (status !== 'success') return null
+    if (!lastResult?.skillName || !lastResult?.mode) return null
+    return { skillName: lastResult.skillName, mode: lastResult.mode }
+  }, [status, lastResult])
+
+  return {
+    isOpen,
+    sourceTask,
+    sourceSkills,
+    status,
+    serverError,
+    lastResult,
+    successInfo,
+    open,
+    close,
+    submit,
+  }
+}

--- a/app/ui_layer/browser/frontend/src/types/index.ts
+++ b/app/ui_layer/browser/frontend/src/types/index.ts
@@ -50,6 +50,8 @@ export interface ActionItem {
   output?: string
   error?: string
   duration?: number
+  selectedSkills?: string[]
+  workflowId?: string
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -105,6 +107,8 @@ export type WSMessageType =
   // Task control
   | 'task_cancel'
   | 'task_cancel_response'
+  // Skill creation from completed task
+  | 'create_skill_from_task'
   // Option click (interactive buttons in chat)
   | 'option_click'
   // Onboarding

--- a/app/ui_layer/browser/frontend/src/types/index.ts
+++ b/app/ui_layer/browser/frontend/src/types/index.ts
@@ -109,6 +109,7 @@ export type WSMessageType =
   | 'task_cancel_response'
   // Skill creation from completed task
   | 'create_skill_from_task'
+  | 'skill_meta'
   // Option click (interactive buttons in chat)
   | 'option_click'
   // Onboarding
@@ -163,6 +164,12 @@ export interface InitialState {
   dashboardMetrics?: DashboardMetrics
   needsHardOnboarding?: boolean
   agentName?: string
+}
+
+export interface SkillMeta {
+  internalWorkflowIds: string[]
+  internalSkillNames: string[]
+  reservedSkillNames: string[]
 }
 
 // ─────────────────────────────────────────────────────────────────────

--- a/app/ui_layer/components/types.py
+++ b/app/ui_layer/components/types.py
@@ -101,6 +101,8 @@ class ActionItem:
         input_data: Input parameters/schema for the action
         output_data: Output/result of the action
         error_message: Error message if action failed
+        selected_skills: Skills attached to the task (task-level only)
+        workflow_id: Internal workflow this task belongs to (task-level only)
     """
 
     id: str
@@ -113,6 +115,8 @@ class ActionItem:
     input_data: Optional[str] = None
     output_data: Optional[str] = None
     error_message: Optional[str] = None
+    selected_skills: List[str] = field(default_factory=list)
+    workflow_id: Optional[str] = None
 
     @property
     def is_task(self) -> bool:

--- a/app/usage/action_storage.py
+++ b/app/usage/action_storage.py
@@ -8,9 +8,10 @@ Provides local persistence for action history across agent restarts.
 
 from __future__ import annotations
 
+import json
 import logging
 import sqlite3
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -19,6 +20,17 @@ try:
 except Exception:
     logger = logging.getLogger(__name__)
     logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+
+def _decode_skills(value: Optional[str]) -> List[str]:
+    """Decode the JSON-encoded selected_skills column. Tolerates legacy NULL/garbage."""
+    if not value:
+        return []
+    try:
+        decoded = json.loads(value)
+        return decoded if isinstance(decoded, list) else []
+    except (ValueError, TypeError):
+        return []
 
 
 @dataclass
@@ -35,6 +47,9 @@ class StoredActionItem:
     input_data: Optional[str] = None
     output_data: Optional[str] = None
     error_message: Optional[str] = None
+    # Task-level metadata (populated only when item_type == "task")
+    selected_skills: List[str] = field(default_factory=list)
+    workflow_id: Optional[str] = None
 
     @property
     def duration(self) -> Optional[int]:
@@ -56,6 +71,8 @@ class StoredActionItem:
             "input": self.input_data,
             "output": self.output_data,
             "error": self.error_message,
+            "selectedSkills": self.selected_skills,
+            "workflowId": self.workflow_id,
         }
 
 
@@ -101,9 +118,19 @@ class ActionStorage:
                     input_data TEXT,
                     output_data TEXT,
                     error_message TEXT,
+                    selected_skills TEXT,
+                    workflow_id TEXT,
                     db_created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
                 )
             """)
+
+            # Idempotent column add for pre-existing DBs
+            cursor.execute("PRAGMA table_info(action_items)")
+            existing_columns = {row[1] for row in cursor.fetchall()}
+            if "selected_skills" not in existing_columns:
+                cursor.execute("ALTER TABLE action_items ADD COLUMN selected_skills TEXT")
+            if "workflow_id" not in existing_columns:
+                cursor.execute("ALTER TABLE action_items ADD COLUMN workflow_id TEXT")
 
             # Create indexes for common queries
             cursor.execute("""
@@ -132,13 +159,15 @@ class ActionStorage:
         Args:
             item: The StoredActionItem to insert or update.
         """
+        skills_json = json.dumps(item.selected_skills) if item.selected_skills else None
         with sqlite3.connect(self._db_path) as conn:
             cursor = conn.cursor()
             cursor.execute("""
                 INSERT OR REPLACE INTO action_items
                 (id, name, status, item_type, parent_id, created_at,
-                 completed_at, input_data, output_data, error_message)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 completed_at, input_data, output_data, error_message,
+                 selected_skills, workflow_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """, (
                 item.id,
                 item.name,
@@ -150,6 +179,8 @@ class ActionStorage:
                 item.input_data,
                 item.output_data,
                 item.error_message,
+                skills_json,
+                item.workflow_id,
             ))
             conn.commit()
 
@@ -218,7 +249,8 @@ class ActionStorage:
 
             query = """
                 SELECT id, name, status, item_type, parent_id, created_at,
-                       completed_at, input_data, output_data, error_message
+                       completed_at, input_data, output_data, error_message,
+                       selected_skills, workflow_id
                 FROM action_items
             """
             if not include_running:
@@ -240,6 +272,8 @@ class ActionStorage:
                     input_data=row[7],
                     output_data=row[8],
                     error_message=row[9],
+                    selected_skills=_decode_skills(row[10]),
+                    workflow_id=row[11],
                 )
                 for row in rows
             ]
@@ -259,7 +293,8 @@ class ActionStorage:
             # Get last N items ordered by created_at DESC, then reverse
             cursor.execute("""
                 SELECT id, name, status, item_type, parent_id, created_at,
-                       completed_at, input_data, output_data, error_message
+                       completed_at, input_data, output_data, error_message,
+                       selected_skills, workflow_id
                 FROM action_items
                 ORDER BY created_at DESC
                 LIMIT ?
@@ -278,6 +313,8 @@ class ActionStorage:
                     input_data=row[7],
                     output_data=row[8],
                     error_message=row[9],
+                    selected_skills=_decode_skills(row[10]),
+                    workflow_id=row[11],
                 )
                 for row in rows
             ]
@@ -299,7 +336,8 @@ class ActionStorage:
             cursor = conn.cursor()
             cursor.execute("""
                 SELECT id, name, status, item_type, parent_id, created_at,
-                       completed_at, input_data, output_data, error_message
+                       completed_at, input_data, output_data, error_message,
+                       selected_skills, workflow_id
                 FROM action_items
                 WHERE id = ?
             """, (item_id,))
@@ -317,6 +355,8 @@ class ActionStorage:
                     input_data=row[7],
                     output_data=row[8],
                     error_message=row[9],
+                    selected_skills=_decode_skills(row[10]),
+                    workflow_id=row[11],
                 )
             return None
 
@@ -464,7 +504,8 @@ class ActionStorage:
             placeholders = ','.join('?' * len(task_ids))
             cursor.execute(f"""
                 SELECT id, name, status, item_type, parent_id, created_at,
-                       completed_at, input_data, output_data, error_message
+                       completed_at, input_data, output_data, error_message,
+                       selected_skills, workflow_id
                 FROM action_items
                 WHERE id IN ({placeholders}) OR parent_id IN ({placeholders})
                 ORDER BY created_at ASC
@@ -483,6 +524,8 @@ class ActionStorage:
                     input_data=row[7],
                     output_data=row[8],
                     error_message=row[9],
+                    selected_skills=_decode_skills(row[10]),
+                    workflow_id=row[11],
                 )
                 for row in rows
             ]
@@ -519,7 +562,8 @@ class ActionStorage:
             placeholders = ','.join('?' * len(task_ids))
             cursor.execute(f"""
                 SELECT id, name, status, item_type, parent_id, created_at,
-                       completed_at, input_data, output_data, error_message
+                       completed_at, input_data, output_data, error_message,
+                       selected_skills, workflow_id
                 FROM action_items
                 WHERE id IN ({placeholders}) OR parent_id IN ({placeholders})
                 ORDER BY created_at ASC
@@ -538,6 +582,8 @@ class ActionStorage:
                     input_data=row[7],
                     output_data=row[8],
                     error_message=row[9],
+                    selected_skills=_decode_skills(row[10]),
+                    workflow_id=row[11],
                 )
                 for row in rows
             ]

--- a/skills/craftbot-skill-creator/SKILL.md
+++ b/skills/craftbot-skill-creator/SKILL.md
@@ -1,0 +1,266 @@
+---
+name: craftbot-skill-creator
+description: "Create a brand-new reusable skill from a single completed task. Read the per-task SKILL_SOURCE markdown the handler wrote, distil the workflow into a generalised SKILL.md, save it at skills/<name>/SKILL.md. Use this when CraftBot has spawned a 'Create Skill' workflow task and you need to author the new skill end-to-end without user interaction."
+user-invocable: false
+action-sets:
+  - file_operations
+  - core
+---
+
+# CraftBot Skill Creator
+
+Author a reusable skill from one completed task. The handler that spawned this task already gathered everything you need into a single markdown file — read it, generalise it, write the new skill, send the user a one-message summary, end the task. The handler has already posted "Creating skill `<name>`…" in chat for you, so do not duplicate that message. Your only chat message is the final presentation right before `task_end`. Do not iterate with test cases. Do not run subagents.
+
+## What you receive
+
+Your task instruction contains five lines (the two paths are **absolute** — pass them verbatim to `read_file` / `write_file`, do NOT prepend or modify any prefix):
+
+```
+Source file (read this — absolute path, use verbatim): <absolute path to SKILL_SOURCE_<id>.md>
+Target file (write the new SKILL.md here — absolute path, use verbatim): <absolute path to skills/<name>/SKILL.md>
+Mode: create
+Skill name: <kebab-case-name>
+```
+
+> ⚠️ Do not invent your own path for the target file. The handler has already placed it at the correct location under the project's `skills/` directory; using the literal value of `Target file:` puts the SKILL.md where the framework will discover it. A common mistake is generalising the source's `agent_file_system/` prefix onto the target — that lands the new skill in the wrong directory and CraftBot will never see it.
+
+`SKILL_SOURCE_<task_id>.md` has YAML frontmatter (`mode`, `target_skill`, `source_task_id`, `generated_at`) and these body sections, in order:
+
+- `## Task name` — the short task title shown in the action panel. Treat this as a one-line summary of what the user wanted, not a verbatim instruction (the original instruction is not retained on disk after the source task ends).
+- `## Outcome` — status, created/ended timestamps, the skills the source task had attached, and any internal `workflow_id`.
+- `## Action trace` — every action and reasoning item the source agent emitted, in order, with `input`, `output`, `error`, and duration. **This is your primary evidence** — it is the durable record of what actually happened, kept in `actions.db`.
+
+`create` mode means there is no existing SKILL.md for the target name; you write a fresh one.
+
+The Task name and the action trace together are enough to reconstruct the workflow. Treat the trace as the ground truth — the name is just a hint about user intent.
+
+## What you produce
+
+Two artefacts, in order:
+
+1. **One file** at the path given by `Target file:` in your task instruction (an absolute path under the project's `skills/` directory). Pass that path verbatim to `write_file` (or `create_file`). The directory does not exist yet; `write_file` creates the parent directory in the same call.
+2. **One presentation message** to the user via `send_message`, immediately after the file is written and immediately before `task_end`. See *Presentation message* below for the format.
+
+Do not write any other files. Do not send any chat message other than the single presentation one — the handler has already posted the "Creating skill …" acknowledgement.
+
+## Capture intent — from the source task
+
+You will not interview the user. The source task IS the workflow you are codifying. Read `SKILL_SOURCE_<task_id>.md` once with `read_file`, then answer these four questions for yourself before drafting:
+
+1. **What should this skill enable Claude to do?** Use the `## Task name` as a hint, then walk the `## Action trace` to see what the agent actually accomplished. Generalise: strip the specific subject ("PRs in repo X" → "summarise PRs in a repository"). The skill must be reusable across many invocations.
+2. **When should this skill trigger?** What user phrases or contexts would lead someone to want this workflow next time? Be concrete in the description (see *Description* below).
+3. **What is the output format?** Look at the final write/output actions in the trace. The skill should specify the same shape so future invocations produce comparable results.
+4. **What is the shortest happy path?** The source agent may have re-queried, backtracked, or self-corrected. Walk the trace and identify the *one* sequence that gets to the outcome. Earlier dead-ends do not belong in the skill body — but a `## Common pitfalls` section can mention them so future runs avoid them too.
+
+If the source task has very thin evidence (one or two actions, no real workflow), still write a useful skill — but keep the body short and honest. Don't pad.
+
+## Anatomy of a CraftBot skill
+
+```
+skills/<skill-name>/
+├── SKILL.md           (required)
+│   ├── YAML frontmatter
+│   └── Markdown body
+├── scripts/           (optional — executable helpers)
+├── references/        (optional — long docs the agent can read on demand)
+└── assets/            (optional — templates, fixtures)
+```
+
+You will only write `SKILL.md` in this workflow. The optional directories exist for skills authored by hand; do not create them here even if the source task touched many helper scripts. (If you notice strong repeated work in the trace, mention it in `## Common pitfalls` so a human author can come back and bundle it later.)
+
+## Frontmatter — the four fields
+
+CraftBot extends Anthropic's standard frontmatter (`name`, `description`) with two local fields (`user-invocable`, `action-sets`) — both required.
+
+```yaml
+---
+name: <kebab-case-skill-name>
+description: <one paragraph — see Description below>
+user-invocable: true
+action-sets:
+  - <action-set-1>
+  - <action-set-2>
+---
+```
+
+| Field | What it means | How to fill it |
+|---|---|---|
+| `name` | Stable kebab-case identifier. Must match the directory name. | Use the value from your task instruction verbatim. |
+| `description` | The primary triggering signal — what the skill does AND when to use it. | See *Description* below. |
+| `user-invocable` | Whether a user can pick this skill from the skill picker. | `true` for almost every new skill. Set `false` only if the skill is a silent backend workflow (memory processing, etc.) — that is not the case here. |
+| `action-sets` | Action-set names the skill actually uses. | Match the source task's `Action sets` line in SKILL_SOURCE. Drop any that the action trace shows were never actually called. The `core` set is auto-included by the framework — do not list it. |
+
+### Description — make it pushy
+
+Claude tends to *under-trigger* skills it isn't sure about. A bare functional description like "Summarise GitHub PRs" loses to a skill with the same purpose but a more directive description. Aim for two parts: what + when. Use ~50–120 words.
+
+Bad (too thin, won't trigger):
+
+```
+description: Summarise GitHub PRs.
+```
+
+Good (does the job):
+
+```
+description: Summarise the recent GitHub pull requests in a repository, grouped by author. Use this whenever the user asks for a PR digest, weekly engineering summary, "what shipped this week", or a code-review activity report — even if they don't say "PR" explicitly. Produces a markdown summary with one section per author and a one-line entry per PR.
+```
+
+The "Use this whenever…" clause is what fixes under-triggering. Include 2–4 phrasings the user might actually type, plus the output shape.
+
+## Body — sections to include
+
+The body is markdown loaded into context whenever the skill triggers. Keep it **under ~300 lines** for a one-task-derived skill (Anthropic's general ceiling is 500). If the workflow seems to need more, that is a sign you are over-fitting to the source task.
+
+Include these sections, in this order. Skip optional ones if they have nothing useful to say.
+
+1. **`# <Title-Case Name>` + one-paragraph overview.** What the skill enables. What kind of input it expects. What it produces.
+2. **`## When to use`** *(optional but recommended)*. Bullet list of trigger scenarios. The description already covers this; this section is for nuance — domains, adjacent cases, "use this instead of X when…".
+3. **`## Definition of Done`**. Numbered list of observable conditions that mark the task complete. Future agents will use this to decide whether to call `task_end`.
+4. **`## General Steps`**. Numbered list. The shortest happy path, derived from the source action trace. One imperative sentence per step. No specific values. No code.
+5. **`## Output Format`** *(if the skill produces structured output)*. The exact template the agent should write. Use a fenced code block.
+6. **`## Examples`** *(0–2 examples)*. Realistic input → output pairs. Strip identifying details. Each example should be ~5–15 lines, not pages.
+7. **`## Common pitfalls`** *(only if the source trace contained real evidence)*. Bullet list. Each bullet: the symptom you saw, then the avoidance. See *Mistake-scanning* below.
+8. **`## Allowed Actions`**. Comma-separated list of action names the skill expects to use, drawn from the source action trace.
+
+Do **not** include sections for: testing, evaluation, packaging, description optimization. Those are the human author's job. The single SKILL.md is your only deliverable.
+
+## Writing style
+
+Apply these from Anthropic's skill-creator guidance. They matter more than any individual section.
+
+- **Imperative form.** "Read the file" — not "you should read the file" or "the file must be read".
+- **Explain the why** for non-obvious rules. A short `*Why:* …` line after a rule lets future agents handle edge cases the rule didn't anticipate. Rules without rationale rot.
+- **Avoid heavy-handed MUSTs.** ALL-CAPS imperatives are a yellow flag. If you wrote `MUST` or `NEVER`, ask whether explaining the underlying reasoning would do the job better.
+- **Theory of mind.** The agent reading this skill is competent. Tell it the goal and the constraints; trust it to fill in the gaps. Don't enumerate every micro-step.
+- **Generalise.** No specific dates, names, IDs, URLs, paths copied from the source task. Concrete numbers from the source become "the relevant <thing>" or are dropped entirely. *Why:* concrete values rot the moment the skill runs against new data.
+- **Lean.** Each sentence should pull weight. After your first draft, re-read it and delete anything you wouldn't miss.
+- **No placeholder data.** If the source task used a specific spreadsheet, describe the *role* the spreadsheet played, not its column names — those will differ next time.
+
+## Mistake-scanning — the `## Common pitfalls` section
+
+Walk the action trace once with this question: *did the source agent waste time or take a wrong direction that future agents could be warned away from?*
+
+**Surface (task-specific) signals:**
+
+- Two consecutive calls to the same action with different parameters → the agent had the wrong mental model first time. Tell the new skill what the right first parameters look like.
+- An output row whose content shows the agent went the wrong direction (e.g., wrong domain, wrong filter), prompting a corrective re-action.
+- Mid-workflow context-file reads (USER.md, MEMORY.md) → front-load these in the skill so future runs don't pause to look things up.
+- Search/query that came back with too many or wrong results, prompting a more specific re-query → tell the new skill what makes the query specific enough.
+
+**Ignore (generic) signals:**
+
+- File-not-found, path-not-resolved, permission-denied — infrastructure, not workflow knowledge.
+- OS-specific errors (path separators, line endings, encoding).
+- Network timeouts, rate limits, transient HTTP errors.
+- JSON/parse errors any task could hit.
+
+**If the trace is clean** (no errors, no re-actions, perfectly linear) → omit the `## Common pitfalls` section. Don't invent pitfalls. Speculative warnings dilute real ones.
+
+## Definition of Done (for this workflow itself)
+
+You are done when all of these are true:
+
+1. `skills/<skill-name>/SKILL.md` exists at the path your task instruction specified.
+2. The frontmatter has all four fields and parses as YAML.
+3. `name` matches `<skill-name>`. `description` follows the *pushy* pattern above. `action-sets` lists only sets the source task actually used.
+4. The body has at minimum a one-paragraph overview, `## Definition of Done`, `## General Steps`, and `## Allowed Actions`.
+5. No specific values from the source task leak into the skill (no concrete dates, names, IDs, URLs, paths, file contents).
+6. Total body length is reasonable for the workflow's complexity (~80–300 lines is the right ballpark).
+7. You have sent the presentation message via `send_message` (see below).
+8. You have called `task_end` with a one-line summary.
+
+## Presentation message — required, exactly once
+
+After writing the SKILL.md and immediately before `task_end`, call `send_message` once with a short summary the user can read at a glance. Aim for 3–6 short lines. Adapt this template — do not copy verbatim:
+
+```
+✨ Created the **<skill-name>** skill.
+What it does: <one-sentence summary of the workflow it captures>.
+When it'll trigger: <one short example phrase from the description>.
+You can invoke it on future tasks via the skill picker.
+```
+
+Rules:
+- Reference the skill by name in backticks or bold so it stands out.
+- Do NOT paste the SKILL.md body. The user can open the file.
+- Do NOT mention the source task by name or include any specific values from it (consistent with the no-leak rule).
+- Keep it brief and confirmatory — this is an "it's done" message, not a tutorial.
+- The handler has already posted "Creating skill `<name>`…" in chat, so do not duplicate that or send any other chat message during the workflow.
+
+## Allowed Actions
+
+`read_file`, `create_file` (or `write_file`), `stream_edit`, `send_message`, `task_update_todos`, `task_end`.
+
+`stream_edit` is only needed if you want to refine the file you just created — write it correctly the first time and you won't need it.
+
+## Forbidden
+
+- More than one `send_message` call. The presentation message above is the only one — anything else is noise.
+- `web_search`, `run_shell`, `run_python` — outside `file_operations` + `core`.
+- Writing or modifying any file outside `skills/<skill-name>/`.
+- Overwriting an existing skill. (The handler refuses to spawn this workflow if the directory already exists; if you somehow find one there, end the task immediately rather than overwriting.)
+
+## Example: a complete worked output
+
+Source task (paraphrased): the user asked the agent to summarise the recent GitHub PRs in some repository. The action trace shows two `web_search` calls (the first too broad), one `read_file` of a USER.md to fetch the user's preferred summary length, and one `create_file` writing the final markdown digest.
+
+A reasonable `skills/pr-weekly-summary/SKILL.md`:
+
+```markdown
+---
+name: pr-weekly-summary
+description: Summarise the recent pull requests in a GitHub repository, grouped by author. Use this whenever the user asks for a PR digest, "what shipped this week", a code-review activity report, or a weekly engineering summary — even if they don't say "PR" explicitly. Produces a markdown summary with one section per author.
+user-invocable: true
+action-sets:
+  - file_operations
+  - web_research
+---
+
+# PR Weekly Summary
+
+Produce a markdown digest of recent pull requests in a GitHub repository, grouped by author. Use the user's preferred summary length from USER.md if present.
+
+## When to use
+
+- The user asks "what shipped this week?", "PR digest", "code review summary".
+- The user names a repository and a time window and asks for a status overview.
+
+## Definition of Done
+
+1. A markdown file exists at the requested output path (or, if none requested, in the workspace root).
+2. PRs are grouped by author and ordered by merge date within each author.
+3. Each PR has a one-line entry: title, number, link.
+4. Empty author groups are omitted.
+
+## General Steps
+
+1. Read USER.md to pick up the user's preferred summary verbosity if present.
+2. Confirm the repository and date window from the user's request. Default window is the last 7 days if unspecified.
+3. Fetch merged PRs in the window with `web_search`. Always include the date filter in the first query — broad queries return too many results.
+4. Group PRs by author; within each group, order by merge date descending.
+5. Write the markdown digest with `create_file`.
+6. `task_end` with a one-line summary.
+
+## Output Format
+
+```
+# PR digest for <repository> (<window>)
+
+## <Author>
+- #<number> <title> — <merge-date> — <link>
+
+## <Author>
+- ...
+```
+
+## Common pitfalls
+
+- Searches without an explicit date window return too many results. Pin the window in the first query.
+
+## Allowed Actions
+
+`web_search`, `read_file`, `create_file`, `task_update_todos`, `task_end`.
+```
+
+Notice what is *not* in this output: the specific repository name, the specific week, the count of PRs found, the actual author names, the path of the python script the source agent wrote. All of those would have rotted by the next invocation.

--- a/skills/craftbot-skill-improve/SKILL.md
+++ b/skills/craftbot-skill-improve/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: craftbot-skill-improve
+description: "Refine an existing CraftBot skill using evidence from one completed task that used it. Read the per-task SKILL_SOURCE markdown the handler wrote, diff it against the existing SKILL.md, apply surgical edits to skills/<target>/SKILL.md. Use this when CraftBot has spawned an 'Improve Skill' workflow task and you need to refine the skill's accuracy or token efficiency without redesigning it."
+user-invocable: false
+action-sets:
+  - file_operations
+  - core
+---
+
+# CraftBot Skill Improver
+
+Refine one existing skill using evidence from one task that used it. The handler that spawned this task already gathered everything you need into a single markdown file — read it, diff it against the live skill, apply small surgical edits, send the user a one-message summary of the changes, end the task. The handler has already posted "Improving skill `<name>`…" in chat for you, so do not duplicate that message. Your only chat message is the final presentation right before `task_end`. Do not iterate with test cases. Do not run subagents.
+
+## What you receive
+
+Your task instruction contains five lines (the two paths are **absolute** — pass them verbatim to `read_file` / `stream_edit`, do NOT prepend or modify any prefix):
+
+```
+Source file (read this — absolute path, use verbatim): <absolute path to SKILL_SOURCE_<id>.md>
+Target file (edit this — absolute path, use verbatim): <absolute path to skills/<existing-name>/SKILL.md>
+Mode: improve
+Skill name: <existing-skill-name>
+```
+
+> ⚠️ Do not invent your own path for the target file. Using the literal value of `Target file:` ensures `stream_edit` modifies the actual installed SKILL.md.
+
+`SKILL_SOURCE_<task_id>.md` has YAML frontmatter (`mode: improve`, `target_skill`, `source_task_id`, `generated_at`) and these body sections:
+
+- `## Task name` — the short task title shown in the action panel. A one-line summary of intent, not a verbatim instruction.
+- `## Outcome` — status, created/ended timestamps, the skills the source task had attached, and any internal `workflow_id`.
+- `## Action trace` — every action and reasoning item, in order, with `input`, `output`, `error`, and duration. **This is your primary evidence** — it is the durable record of what actually happened.
+- `## Existing SKILL.md` — the verbatim contents of `skills/<target>/SKILL.md` *as captured at the moment the workflow started*.
+
+The target skill exists. Your job is to edit it in place. The action trace is the evidence; the existing SKILL.md is what you are diffing against.
+
+## What you produce
+
+Two artefacts, in order:
+
+1. **Targeted edits** to exactly one file: the path given by `Target file:` in your task instruction (an absolute path under the project's `skills/` directory). Pass that path verbatim to `stream_edit`. Do not use `create_file` / `write_file` — those overwrite. Do not write any other files. Do not change the directory layout. Do not delete bundled resources in `scripts/`, `references/`, or `assets/`.
+2. **One presentation message** to the user via `send_message`, immediately after the edits and immediately before `task_end`. See *Presentation message* below for the format.
+
+Do not send any chat message other than the single presentation one — the handler has already posted the "Improving skill …" acknowledgement.
+
+## Improvement constraints — what makes this different from creation
+
+These four rules are the heart of *improve* mode. Read them before drafting.
+
+1. **Do not redesign the skill.** The existing skill encodes a tested workflow. Your job is *refinement*, not rewriting. Drastic restructuring regresses use cases that this single source task never exercised.
+   *Why:* one task is a sample size of one. The skill has likely been used many times before; you are seeing one slice.
+
+2. **Optimise for accuracy AND token efficiency.** A change is justified if and only if it does one of:
+   - **Prevents a class of mistake** the source task hit (and that the existing skill did not warn about), OR
+   - **Shortens** the skill without removing meaning (kill filler, redundant restatements, dead bullets).
+   *Why:* both quality and prompt-cost matter. Skills are loaded into context every time they trigger.
+
+3. **Prefer surgical edits over wholesale rewrites.** One `stream_edit` per change. Each edit replaces or inserts a small contiguous range. If you are about to replace half the file, stop — that is redesign, not refinement.
+   *Why:* small diffs are reviewable and reversible by humans afterwards.
+
+4. **Do not invent pitfalls.** If the source task ran cleanly, do not add speculative warnings. If the trace shows the existing pitfall warnings are wrong, fix or remove them.
+   *Why:* unfounded warnings dilute real ones; agents start ignoring the section.
+
+## How to think about improvements
+
+These come straight from Anthropic's skill-improver guidance and apply here verbatim.
+
+- **Generalise from the feedback.** The skill will be invoked many more times than just this one task. If a fix only works for the source task's specific scenario, it's overfitting. Prefer changes that handle a *class* of cases, not the literal symptoms you saw.
+- **Keep the prompt lean.** Read the action trace, not just the final outputs. If the existing skill told the agent to do something that the trace shows was wasted effort, removing that instruction is a valid improvement.
+- **Explain the why.** When you add a rule, add a `*Why:* …` line right after it. When you sharpen an existing rule, preserve any existing `*Why:*` line — those are gold.
+- **Look for repeated work.** If the action trace shows the agent independently wrote the same helper logic the existing skill could have bundled, mention it in the skill body so a human author knows to bundle it later. Do *not* attempt to create `scripts/` files yourself — that's outside this workflow's scope.
+
+## CraftBot frontmatter — what you can and cannot change
+
+CraftBot skills have four frontmatter fields:
+
+| Field | Allowed change in *improve* mode |
+|---|---|
+| `name` | **Never change.** The directory name and the agent's task instruction depend on it. |
+| `description` | Edit only if the source task evidence proves the current description is wrong (e.g., the agent triggered the skill for a use case the description should explicitly cover). Apply the *pushy* pattern: what + when, with example user phrasings. |
+| `user-invocable` | Almost never change. Flip only if you have hard evidence the current value is wrong. |
+| `action-sets` | Add a set only if the trace shows the agent actually called actions from it that the skill expects. Remove a set only if the existing skill never references its actions and the trace confirms it goes unused. |
+
+## Anatomy reminder
+
+```
+skills/<skill-name>/
+├── SKILL.md           ← edit this only
+├── scripts/           ← do not modify in this workflow
+├── references/        ← do not modify in this workflow
+└── assets/            ← do not modify in this workflow
+```
+
+Bundled resources may exist for the target skill. Leave them alone. If the source trace suggests one of them is outdated, mention it in `## Common pitfalls` so a human can revisit.
+
+## Workflow
+
+Use `task_update_todos` at the start to track these. Mark each completed before moving on.
+
+1. **Read the SOURCE.** `read_file` on the path from your task instruction. Note the action trace, errors, summary, and the verbatim existing SKILL.md.
+2. **Re-read the live target.** `read_file` on `skills/<target-skill>/SKILL.md`. The SOURCE may be milliseconds stale; the live file is authoritative for line offsets when you `stream_edit`.
+3. **Diff in your head.** Two questions:
+   - What did the source task do that the existing skill *does not document* (and should)?
+   - What did the source task do that the existing skill *says to do but evidence shows is wrong / extra*?
+4. **Plan a small edit list.** Each entry is one of: *add a pitfall*, *trim a redundant step*, *sharpen wording for accuracy*, *shrink wording for tokens*. Aim for 1–4 edits. If you find yourself listing 10, you are redesigning — pick the highest-leverage few and stop.
+5. **Apply edits.** One `stream_edit` per item in the list. Re-read the file between edits if line offsets have shifted significantly.
+6. **Send the presentation message** via `send_message`. See *Presentation message* below.
+7. **`task_end`** with a one-line summary of what changed.
+
+## Mistake-scanning — what to surface as new pitfalls
+
+Walk the action trace once. For each signal, decide whether the existing skill already warns about it. If yes, no edit needed. If no, consider adding to `## Common pitfalls`.
+
+**Surface (task-specific) signals not already covered:**
+
+- Two consecutive same-action calls with different parameters → wrong mental model first time. Add a pitfall describing the right first-pass parameters.
+- Output that shows the agent went the wrong direction → add a pitfall describing the direction to take.
+- Mid-workflow context-file reads → suggest front-loading via a step in `## General Steps` instead of a pitfall.
+- Search/query that returned too many or wrong results → add a pitfall about query specificity.
+
+**Ignore (generic) signals:**
+
+- File-not-found, path issues, permissions, OS quirks, network timeouts, rate limits, JSON parse errors. Same exclusions as in *create* mode.
+
+If `## Common pitfalls` does not exist in the target skill and you have at most one task-specific signal to add, prefer to fold it into `## General Steps` as a sharpening of an existing step rather than creating a whole new section.
+
+## Token-efficiency heuristics
+
+When trimming, prefer to delete:
+
+- Redundant restatement of the same rule in two sections.
+- Filler phrases ("It is important to note that…", "As mentioned above…", "Please ensure that you…").
+- Examples that demonstrate the same case as another example.
+- ALL-CAPS imperatives whose content is already covered by an imperative sentence elsewhere.
+
+When trimming, do **not** delete:
+
+- The frontmatter or any of its required fields.
+- The Definition of Done section (or whatever named section serves that role).
+- Real pitfalls that warn about a class of mistake.
+- `*Why:* …` reasoning lines — those are how future agents handle edge cases the rule didn't anticipate.
+
+## Definition of Done (for this workflow itself)
+
+You are done when all of these are true:
+
+1. `skills/<target-skill>/SKILL.md` has been modified, or you have decided no edit is justified and the presentation message says so.
+2. The frontmatter still parses as valid YAML and `name` is unchanged.
+3. The skill's body still covers what it did before — you didn't remove a load-bearing section.
+4. Net line-count change is within roughly ±25%. Net negative is fine and often better.
+5. No specific values from the source task have leaked into the skill (no concrete dates, names, IDs, URLs, paths, file contents).
+6. You have sent the presentation message via `send_message` (see below).
+7. You have called `task_end` with a one-line summary of what changed (e.g., "Added pitfall about over-broad search queries; trimmed redundant restatement of the date-filter rule").
+
+## Presentation message — required, exactly once
+
+After applying the edits and immediately before `task_end`, call `send_message` once with a short summary of what changed. Aim for 3–6 short lines. Adapt this template — do not copy verbatim:
+
+```
+✏️ Improved the **<skill-name>** skill.
+Changes:
+- <one-line description of edit 1>
+- <one-line description of edit 2>
+The skill is now more accurate / leaner / better at <specific behaviour>.
+```
+
+If you decided no edit was justified, send a brief "no changes — the existing skill already covers the workflow cleanly" message instead.
+
+Rules:
+- Reference the skill by name in backticks or bold.
+- Summarise edits at the *behaviour* level ("now warns about over-broad searches"), not the *line* level ("inserted line at offset 47").
+- Do NOT mention the source task by name or include any specific values from it.
+- Keep it brief and confirmatory.
+- The handler has already posted "Improving skill `<name>`…" in chat, so do not duplicate that or send any other chat message during the workflow.
+
+## Allowed Actions
+
+`read_file`, `stream_edit`, `send_message`, `task_update_todos`, `task_end`.
+
+`create_file` / `write_file` are forbidden in this workflow — see *Improvement constraints* above.
+
+## Forbidden
+
+- More than one `send_message` call. The presentation message above is the only one.
+- `create_file`, `write_file` — those overwrite. Use `stream_edit`.
+- `web_search`, `run_shell`, `run_python` — outside `file_operations` + `core`.
+- Writing or modifying any file outside `skills/<target-skill>/SKILL.md`.
+- Renaming the skill directory or the `name` frontmatter field.
+- Deleting bundled resources in `scripts/`, `references/`, or `assets/`.
+
+## Example: a worked diff
+
+Existing skill `pr-weekly-summary` (excerpt):
+
+```markdown
+## General Steps
+
+1. Confirm the repository and date window from the user's request.
+2. Fetch merged PRs.
+3. Group by author and write the digest.
+```
+
+Source task evidence: the action trace shows two `web_search` calls — the first without a date filter (returned hundreds of results), the second narrowed down. The existing skill never warned about query breadth.
+
+Reasonable edits (two `stream_edit` calls):
+
+1. Sharpen step 2 of `## General Steps` to:
+   ```
+   2. Fetch merged PRs filtered by the requested date window — broad queries return too many results.
+   ```
+2. Append to (or create) `## Common pitfalls`:
+   ```
+   - Searches without an explicit date window return too many results. Pin the window in the first query.
+   ```
+
+Edits *not* to apply:
+
+- Inserting the specific repository name from the source task.
+- Inserting the specific date range used in the source task.
+- Inserting an "expected results count" hint based on the source task's count.
+- Restructuring `## General Steps` from numbered list into prose because the source agent worked through it differently.
+- Deleting the `## Output Format` section because the source task happened not to need it.
+
+## When to make no edits at all
+
+It is fine — and sometimes correct — to apply zero edits. If the action trace is perfectly linear, has no errors or re-actions, and the existing skill already covers everything the trace exhibits, the right answer is to call `task_end` with a summary like "Reviewed evidence; no improvement justified — existing skill already covers the workflow cleanly." Adding speculative content would harm the skill.


### PR DESCRIPTION
What and why?
CraftBot now create and improve skill from completed tasks. CraftBot distils the action trace into a reusable skills/<name>/SKILL.md for agent to read. The new skill auto-enables and can be called immediately.

Features/items added

- "Create Skill" button on completed tasks (hidden for internal workflow tasks like planner, heartbeat, memory processing).
- Added two skills, craftbot-skill-creator and craftbot-skill-improve
- Auto-enable + auto-sync so the new skill is enabled and slash commands / settings page refresh 
- ActionItem persistence extended with selected_skills + workflow_id (SQLite migration + frontend payloads).
- MAX_SKILL_INSTRUCTIONS_TOKENS raised 2000 to 16000 to stop truncating skills.
- TASK_HISTORY.md auto-creates on first append (matches EVENT.md pattern).
- Fix command shows user chat bubble issue. Command will not create user chat bubble.

Potential issue

- Skills might be written in the wrong directory, for example agent_file_system/skills.