### PR TITLE
fix: remove requirements.txt comments for proper install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,15 +41,14 @@ python-dotenv
 scikit-learn
 watchdog
 telethon
-lark-oapi              # Lark Long-Connection / WebSocket listener
-croniter>=2.0.0        # Cron expression parsing for scheduler
-playwright             # WhatsApp Web browser automation
-opencv-python-headless # Video analysis keyframe extraction
-babel>=2.14.0          # Language list for onboarding
-boto3>=1.34.0          # AWS Bedrock provider (LLM/VLM/embedding via Converse + Titan)
-pdfplumber             # PDF text, table, and bbox extraction (read_pdf primary engine)
-pypdfium2              # PDF page dimensions for scanned document fallback (read_pdf)
-pdfminer.six           # PDF text extraction fallback (read_pdf)
-pymupdf                # PDF editing engine — redaction, annotations, replace (edit_pdf)
-pypdf                  # AcroForm field filling and PDF merging (edit_pdf)
-
+lark-oapi
+croniter>=2.0.0
+playwright
+opencv-python-headless
+babel>=2.14.0
+boto3>=1.34.0
+pdfplumber
+pypdfium2
+pdfminer.six
+pymupdf
+pypdf


### PR DESCRIPTION
## What
- Removed comments in `requirements.txt` file preventing CraftBot install

## Why
Closes #297 

## How to test
Clone CraftBot
Run `python craftbot.py install`