### PR TITLE
improvement: new image interface modeled after VLM interface

### DIFF
--- a/agent_core/__init__.py
+++ b/agent_core/__init__.py
@@ -31,6 +31,7 @@ from agent_core.core.models import (
 )
 from agent_core.core.embedding_interface import EmbeddingInterface
 from agent_core.core.vlm_interface import VLMInterface
+from agent_core.core.image_gen_interface import ImageGenInterface
 from agent_core.core.database_interface import DatabaseInterface
 from agent_core.core.trigger import Trigger
 from agent_core.core.task import Task, TodoItem, TodoStatus
@@ -272,6 +273,7 @@ __all__ = [
     # Interfaces
     "EmbeddingInterface",
     "VLMInterface",
+    "ImageGenInterface",
     "DatabaseInterface",
     "GeminiClient",
     "GeminiAPIError",

--- a/agent_core/core/image_gen_interface.py
+++ b/agent_core/core/image_gen_interface.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+"""
+Image generation interface.
+
+Re-exports ImageGenInterface from the impl module for backward compatibility.
+Use the runtime-specific wrapper (app/image_gen_interface.py) when running
+inside CraftBot — it injects the appropriate state and usage hooks.
+"""
+
+from agent_core.core.impl.image_gen import ImageGenInterface
+
+__all__ = ["ImageGenInterface"]

--- a/agent_core/core/impl/image_gen/__init__.py
+++ b/agent_core/core/impl/image_gen/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+"""Image generation interface package."""
+
+from agent_core.core.impl.image_gen.interface import ImageGenInterface
+
+__all__ = ["ImageGenInterface"]

--- a/agent_core/core/impl/image_gen/interface.py
+++ b/agent_core/core/impl/image_gen/interface.py
@@ -5,7 +5,10 @@ Image generation interface for agent_core.
 Supports OpenAI (gpt-image-2) and Gemini (gemini-*-image-preview) providers.
 Provider logic lives here; the action (generate_image.py) just delegates.
 
-Mirrors VLMInterface structure — constructor, reinitialize(), hooks, dispatch.
+Mirrors VLMInterface structure — constructor, hooks, dispatch. Unlike VLM there
+is intentionally no in-place reinitialize(): provider switches build a fresh
+instance via agent_base.reinitialize_image_gen() and swap it in only on success,
+so an in-flight generate_image() keeps using its old instance/client until done.
 """
 
 from __future__ import annotations
@@ -23,6 +26,7 @@ from agent_core.core.hooks import (
     GetTokenCountHook,
     ReportUsageHook,
     SetTokenCountHook,
+    UsageEventData,
 )
 from agent_core.utils.logger import logger
 
@@ -132,46 +136,6 @@ def _to_pil_image(img_data: Any) -> Any:
     return img_data
 
 
-# ── Gemini response helpers ───────────────────────────────────────────────────
-
-def _extract_gemini_images(response: Any) -> List[Any]:
-    images: List[Any] = []
-    if hasattr(response, "candidates") and response.candidates:
-        for candidate in response.candidates:
-            if not (
-                hasattr(candidate, "content")
-                and hasattr(candidate.content, "parts")
-            ):
-                continue
-            for part in candidate.content.parts:
-                if (
-                    hasattr(part, "inline_data")
-                    and part.inline_data
-                    and hasattr(part.inline_data, "mime_type")
-                    and part.inline_data.mime_type.startswith("image/")
-                ):
-                    images.append(part.inline_data.data)
-    if not images and hasattr(response, "images"):
-        for img in response.images:
-            if hasattr(img, "data"):
-                images.append(img.data)
-    return images
-
-
-def _gemini_block_reason(response: Any) -> Optional[str]:
-    if hasattr(response, "prompt_feedback"):
-        fb = response.prompt_feedback
-        if hasattr(fb, "block_reason") and fb.block_reason:
-            return str(fb.block_reason)
-    if hasattr(response, "candidates") and response.candidates:
-        for c in response.candidates:
-            if hasattr(c, "finish_reason") and c.finish_reason:
-                reason = str(c.finish_reason)
-                if "SAFETY" in reason.upper():
-                    return reason
-    return None
-
-
 # ── Main interface ────────────────────────────────────────────────────────────
 
 class ImageGenInterface:
@@ -225,7 +189,6 @@ class ImageGenInterface:
             base_url=base_url,
             deferred=deferred,
         )
-
         self.provider = ctx["provider"]
         self.model = ctx["model"]
         self.client = ctx["client"]            # OpenAI client or None
@@ -236,55 +199,37 @@ class ImageGenInterface:
     def is_initialized(self) -> bool:
         return self._initialized
 
-    def reinitialize(
+    def _report_usage_async(
         self,
-        provider: Optional[str] = None,
-        api_key: Optional[str] = None,
-        base_url: Optional[str] = None,
-    ) -> bool:
-        """Reinitialize with new provider/key settings (e.g. after config change)."""
-        from app.models.factory import ModelFactory
-        from app.models.types import InterfaceType
+        *,
+        provider: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cached_tokens: int = 0,
+    ) -> None:
+        """Report image-generation usage if the hook is set (mirrors VLM).
 
-        target_provider = provider or self.provider
-
-        if api_key is None or base_url is None:
-            from app.config import get_api_key, get_base_url
-
-            target_api_key = api_key if api_key is not None else get_api_key(target_provider)
-            target_base_url = base_url if base_url is not None else get_base_url(target_provider)
-        else:
-            target_api_key = api_key
-            target_base_url = base_url
-
+        Best-effort: scheduling onto the running loop can fail when invoked
+        from a worker thread without one, in which case the usage is dropped
+        with a warning rather than breaking generation.
+        """
+        if not self._report_usage:
+            return
         try:
-            from app.config import get_image_gen_model as _get_model  # type: ignore[import]
-
-            target_model = _get_model()
-        except Exception:
-            target_model = None
-
-        try:
-            ctx = ModelFactory.create(
-                provider=target_provider,
-                interface=InterfaceType.IMAGE_GEN,
-                model_override=target_model,
-                api_key=target_api_key,
-                base_url=target_base_url,
-                deferred=False,
+            event = UsageEventData(
+                service_type="image_gen",
+                provider=provider,
+                model=model,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cached_tokens=cached_tokens,
             )
-            self.provider = ctx["provider"]
-            self.model = ctx["model"]
-            self.client = ctx["client"]
-            self._gemini_client = ctx["gemini_client"]
-            self._initialized = ctx.get("initialized", False)
-            logger.info(
-                f"[IMAGE_GEN] Reinitialized: provider={self.provider}, model={self.model}"
+            asyncio.get_event_loop().call_soon(
+                lambda: asyncio.create_task(self._report_usage(event))
             )
-            return self._initialized
         except Exception as e:
-            logger.error(f"[IMAGE_GEN] Reinitialize failed: {e}", exc_info=True)
-            return False
+            logger.warning(f"[IMAGE_GEN] Failed to report usage: {e}")
 
     # ─────────────────────────── Public API ──────────────────────────────────
 
@@ -443,6 +388,15 @@ class ImageGenInterface:
         except Exception as exc:
             raise RuntimeError(_classify_error("openai", exc)) from exc
 
+        usage = getattr(response, "usage", None)
+        if usage is not None:
+            self._report_usage_async(
+                provider="openai",
+                model=self.model,
+                input_tokens=getattr(usage, "input_tokens", 0) or 0,
+                output_tokens=getattr(usage, "output_tokens", 0) or 0,
+            )
+
         images_bytes: List[bytes] = []
         for item in response.data:
             if item.b64_json:
@@ -480,23 +434,14 @@ class ImageGenInterface:
         safety_filter_level: str,
         timestamp: str,
     ) -> List[str]:
-        try:
-            from google import genai  # type: ignore[import]
-            from google.genai import types as gtypes  # type: ignore[import]
-        except ImportError as exc:
-            raise RuntimeError(
-                f"google-genai is required for Gemini image generation. "
-                f"Install with `pip install google-genai`: {exc}"
-            ) from exc
-
         if not self._gemini_client:
             raise RuntimeError(
                 "Gemini API key is not configured. "
                 "Set 'image_gen_provider' to 'openai' or add a Google API key in settings."
             )
 
-        # Reference images as Gemini content parts (style guidance)
-        image_parts: List[Any] = []
+        # Reference images as (bytes, mime) inline parts (style guidance)
+        ref_parts: List[Any] = []
         for ref_path in reference_images:
             if not os.path.isfile(ref_path):
                 continue
@@ -511,7 +456,7 @@ class ImageGenInterface:
                     ".gif": "image/gif",
                     ".webp": "image/webp",
                 }.get(ext, "image/png")
-                image_parts.append(gtypes.Part.from_bytes(data=data, mime_type=mime))
+                ref_parts.append((data, mime))
             except Exception:
                 pass
 
@@ -520,18 +465,16 @@ class ImageGenInterface:
         if negative_prompt:
             gen_prompt += f"\n- Avoid: {negative_prompt}"
 
-        content_parts = image_parts + [gen_prompt]
-
-        safety_settings = None
         _threshold_map = {
             "block_only_high": "BLOCK_ONLY_HIGH",
             "block_medium_and_above": "BLOCK_MEDIUM_AND_ABOVE",
             "block_low_and_above": "BLOCK_LOW_AND_ABOVE",
         }
+        safety_settings = None
         if safety_filter_level != "block_none":
             threshold = _threshold_map.get(safety_filter_level, "BLOCK_MEDIUM_AND_ABOVE")
             safety_settings = [
-                gtypes.SafetySetting(category=cat, threshold=threshold)
+                {"category": cat, "threshold": threshold}
                 for cat in (
                     "HARM_CATEGORY_HARASSMENT",
                     "HARM_CATEGORY_HATE_SPEECH",
@@ -540,28 +483,34 @@ class ImageGenInterface:
                 )
             ]
 
-        config = gtypes.GenerateContentConfig(
-            candidate_count=1,
-            response_modalities=["TEXT", "IMAGE"],
-            image_config=gtypes.ImageConfig(image_size=resolution),
-            safety_settings=safety_settings,
-        )
-
         try:
-            api_key = self._gemini_client._api_key
-            client = genai.Client(api_key=api_key)
-            response = client.models.generate_content(
-                model=self.model,
-                contents=content_parts,
-                config=config,
+            # One client for the whole Gemini surface: the shared REST
+            # GeminiClient handles image generation too (no google-genai SDK —
+            # see GeminiClient's module docstring for why it avoids the SDK).
+            result = self._gemini_client.generate_image(
+                self.model,
+                prompt=gen_prompt,
+                reference_images=ref_parts,
+                image_size=resolution,
+                safety_settings=safety_settings,
             )
         except Exception as exc:
             raise RuntimeError(_classify_error("gemini", exc)) from exc
 
-        images_data = _extract_gemini_images(response)
+        usage_md = result.get("usage_metadata") or {}
+        if usage_md:
+            self._report_usage_async(
+                provider="gemini",
+                model=self.model,
+                input_tokens=usage_md.get("promptTokenCount", 0) or 0,
+                output_tokens=usage_md.get("candidatesTokenCount", 0) or 0,
+                cached_tokens=usage_md.get("cachedContentTokenCount", 0) or 0,
+            )
+
+        images_data = result.get("images") or []
 
         if not images_data:
-            block_reason = _gemini_block_reason(response)
+            block_reason = result.get("block_reason")
             if block_reason:
                 raise RuntimeError(
                     f"Gemini blocked the request (safety filter: {block_reason}). "

--- a/agent_core/core/impl/image_gen/interface.py
+++ b/agent_core/core/impl/image_gen/interface.py
@@ -1,0 +1,582 @@
+# -*- coding: utf-8 -*-
+"""
+Image generation interface for agent_core.
+
+Supports OpenAI (gpt-image-2) and Gemini (gemini-*-image-preview) providers.
+Provider logic lives here; the action (generate_image.py) just delegates.
+
+Mirrors VLMInterface structure — constructor, reinitialize(), hooks, dispatch.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import io
+import os
+import tempfile
+import urllib.request as _urllib_request
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from agent_core.core.hooks import (
+    GetTokenCountHook,
+    ReportUsageHook,
+    SetTokenCountHook,
+)
+from agent_core.utils.logger import logger
+
+try:
+    from PIL import Image as _PilImage  # type: ignore[import]
+except ImportError:
+    _PilImage = None  # type: ignore[assignment]
+
+# OpenAI supports only three canvas sizes. Document the closest-fit mapping so
+# callers understand the constraint at a glance.
+#
+# True 16:9 (1920×1080) and 9:16 are not available. The values below use the
+# widest/tallest canvases OpenAI exposes; warn at runtime when the mismatch
+# matters (resolution ≥ 2K or aspect ratio 16:9/9:16).
+_OPENAI_ASPECT_MAP: Dict[str, str] = {
+    "1:1": "1024x1024",
+    "3:4": "1024x1536",
+    "4:3": "1536x1024",
+    "9:16": "1024x1536",   # nearest fit — true 9:16 not supported
+    "16:9": "1536x1024",   # nearest fit — true 16:9 not supported
+}
+_OPENAI_INEXACT_RATIOS = {"16:9", "9:16"}
+
+_OPENAI_QUALITY_MAP: Dict[str, str] = {
+    "1K": "medium",
+    "2K": "high",
+    "4K": "high",   # API tops out at 1536px; warn caller
+}
+
+# ── Error message catalog (provider-keyed, English) ──────────────────────────
+# Used to build human-readable RuntimeErrors that flow back through the
+# action-selection loop, matching VLMInterface's raise-don't-return pattern.
+_ERR: Dict[str, Dict[str, str]] = {
+    "openai": {
+        "quota": "OpenAI API rate limit or quota exceeded",
+        "invalid_key": "Invalid OpenAI API key — verify your key in settings.",
+        "content_policy": "Request blocked by OpenAI content policy — modify your prompt.",
+        "model_not_found": (
+            "OpenAI model not available — ensure your account has access to gpt-image-2."
+        ),
+        "generic": "OpenAI image generation failed",
+    },
+    "gemini": {
+        "quota": "Gemini API rate limit or quota exceeded",
+        "invalid_key": "Invalid Gemini API key — verify your Google API key in settings.",
+        "content_policy": "Request blocked by Gemini safety filters — modify your prompt.",
+        "model_not_found": (
+            "Gemini model not available — ensure your account has access to the "
+            "image generation preview model."
+        ),
+        "generic": "Gemini image generation failed",
+    },
+}
+
+
+def _classify_error(provider: str, exc: Exception) -> str:
+    """Map a raw exception message to a catalog entry for the given provider."""
+    msg = str(exc).lower()
+    catalog = _ERR.get(provider, _ERR["openai"])
+    if "quota" in msg or "rate" in msg or "billing" in msg or "insufficient_quota" in msg:
+        return catalog["quota"]
+    if "invalid" in msg and "key" in msg or "invalid_api_key" in msg:
+        return catalog["invalid_key"]
+    if "content_policy" in msg or "safety" in msg or "blocked" in msg:
+        return catalog["content_policy"]
+    if "not found" in msg or "404" in msg or "not available" in msg:
+        return catalog["model_not_found"]
+    # Do NOT include the raw exception — SDK error messages can contain API key fragments.
+    return catalog["generic"]
+
+
+# ── File-path helpers ─────────────────────────────────────────────────────────
+
+def _build_save_path(
+    output_path: str,
+    timestamp: str,
+    index: int,
+    total: int,
+) -> str:
+    if output_path:
+        if total > 1:
+            base, ext = os.path.splitext(output_path)
+            ext = ext or ".png"
+            return f"{base}_{index + 1}{ext}"
+        save_path = output_path
+        if not os.path.splitext(save_path)[1]:
+            save_path += ".png"
+        return save_path
+    return os.path.join(
+        tempfile.gettempdir(), f"generated_image_{timestamp}_{index + 1}.png"
+    )
+
+
+def _save_pil_image(pil_image: Any, save_path: str) -> None:
+    parent = os.path.dirname(os.path.abspath(save_path))
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    pil_image.save(save_path, "PNG")
+
+
+def _to_pil_image(img_data: Any) -> Any:
+    """Convert raw image data (bytes or base64 str) to a PIL Image."""
+    if isinstance(img_data, str):
+        return _PilImage.open(io.BytesIO(base64.b64decode(img_data)))
+    if isinstance(img_data, bytes):
+        return _PilImage.open(io.BytesIO(img_data))
+    return img_data
+
+
+# ── Gemini response helpers ───────────────────────────────────────────────────
+
+def _extract_gemini_images(response: Any) -> List[Any]:
+    images: List[Any] = []
+    if hasattr(response, "candidates") and response.candidates:
+        for candidate in response.candidates:
+            if not (
+                hasattr(candidate, "content")
+                and hasattr(candidate.content, "parts")
+            ):
+                continue
+            for part in candidate.content.parts:
+                if (
+                    hasattr(part, "inline_data")
+                    and part.inline_data
+                    and hasattr(part.inline_data, "mime_type")
+                    and part.inline_data.mime_type.startswith("image/")
+                ):
+                    images.append(part.inline_data.data)
+    if not images and hasattr(response, "images"):
+        for img in response.images:
+            if hasattr(img, "data"):
+                images.append(img.data)
+    return images
+
+
+def _gemini_block_reason(response: Any) -> Optional[str]:
+    if hasattr(response, "prompt_feedback"):
+        fb = response.prompt_feedback
+        if hasattr(fb, "block_reason") and fb.block_reason:
+            return str(fb.block_reason)
+    if hasattr(response, "candidates") and response.candidates:
+        for c in response.candidates:
+            if hasattr(c, "finish_reason") and c.finish_reason:
+                reason = str(c.finish_reason)
+                if "SAFETY" in reason.upper():
+                    return reason
+    return None
+
+
+# ── Main interface ────────────────────────────────────────────────────────────
+
+class ImageGenInterface:
+    """Image generation interface with multi-provider support.
+
+    Supports OpenAI (gpt-image-2) and Gemini image generation models.
+    Uses hooks for state access and usage reporting, mirroring VLMInterface.
+
+    Args:
+        provider: Provider name ("openai", "gemini").
+        model: Model name override (None = use registry default).
+        api_key: API key (required for openai/gemini).
+        base_url: Base URL override (unused by image providers currently).
+        deferred: If True, allow deferred initialization without raising.
+        get_token_count: Hook to read current token count from state.
+        set_token_count: Hook to write token count to state.
+        report_usage: Optional hook to report usage for cost tracking.
+    """
+
+    def __init__(
+        self,
+        *,
+        provider: Optional[str] = None,
+        model: Optional[str] = None,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        deferred: bool = False,
+        get_token_count: Optional[GetTokenCountHook] = None,
+        set_token_count: Optional[SetTokenCountHook] = None,
+        report_usage: Optional[ReportUsageHook] = None,
+    ) -> None:
+        self.provider = provider
+        self._initialized = False
+        self._deferred = deferred
+        self._init_api_key = api_key
+        self._init_base_url = base_url
+
+        self._get_token_count = get_token_count or (lambda: 0)
+        self._set_token_count = set_token_count or (lambda x: None)
+        self._report_usage = report_usage
+
+        # Defer import to avoid circular dependency (same pattern as VLMInterface)
+        from app.models.factory import ModelFactory
+        from app.models.types import InterfaceType
+
+        ctx = ModelFactory.create(
+            provider=provider,
+            interface=InterfaceType.IMAGE_GEN,
+            model_override=model,
+            api_key=api_key,
+            base_url=base_url,
+            deferred=deferred,
+        )
+
+        self.provider = ctx["provider"]
+        self.model = ctx["model"]
+        self.client = ctx["client"]            # OpenAI client or None
+        self._gemini_client = ctx["gemini_client"]
+        self._initialized = ctx.get("initialized", False)
+
+    @property
+    def is_initialized(self) -> bool:
+        return self._initialized
+
+    def reinitialize(
+        self,
+        provider: Optional[str] = None,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+    ) -> bool:
+        """Reinitialize with new provider/key settings (e.g. after config change)."""
+        from app.models.factory import ModelFactory
+        from app.models.types import InterfaceType
+
+        target_provider = provider or self.provider
+
+        if api_key is None or base_url is None:
+            from app.config import get_api_key, get_base_url
+
+            target_api_key = api_key if api_key is not None else get_api_key(target_provider)
+            target_base_url = base_url if base_url is not None else get_base_url(target_provider)
+        else:
+            target_api_key = api_key
+            target_base_url = base_url
+
+        try:
+            from app.config import get_image_gen_model as _get_model  # type: ignore[import]
+
+            target_model = _get_model()
+        except Exception:
+            target_model = None
+
+        try:
+            ctx = ModelFactory.create(
+                provider=target_provider,
+                interface=InterfaceType.IMAGE_GEN,
+                model_override=target_model,
+                api_key=target_api_key,
+                base_url=target_base_url,
+                deferred=False,
+            )
+            self.provider = ctx["provider"]
+            self.model = ctx["model"]
+            self.client = ctx["client"]
+            self._gemini_client = ctx["gemini_client"]
+            self._initialized = ctx.get("initialized", False)
+            logger.info(
+                f"[IMAGE_GEN] Reinitialized: provider={self.provider}, model={self.model}"
+            )
+            return self._initialized
+        except Exception as e:
+            logger.error(f"[IMAGE_GEN] Reinitialize failed: {e}", exc_info=True)
+            return False
+
+    # ─────────────────────────── Public API ──────────────────────────────────
+
+    def generate_image(
+        self,
+        prompt: str,
+        resolution: str = "1K",
+        aspect_ratio: str = "1:1",
+        number_of_images: int = 1,
+        output_path: str = "",
+        negative_prompt: str = "",
+        reference_images: Optional[List[str]] = None,
+        safety_filter_level: str = "block_medium_and_above",
+    ) -> List[str]:
+        """Generate image(s) from a text prompt.
+
+        Args:
+            prompt: Text description of the image to generate.
+            resolution: "1K", "2K", or "4K".
+            aspect_ratio: "1:1", "3:4", "4:3", "9:16", or "16:9".
+            number_of_images: Number of images to generate (1–4).
+            output_path: Absolute path for the output file. Timestamped temp
+                path used when empty. For multiple images the index is appended
+                before the extension.
+            negative_prompt: Elements to avoid (Gemini native; appended to
+                prompt for OpenAI which has no dedicated parameter).
+            reference_images: List of absolute paths to reference images.
+                **Provider semantics differ**: Gemini treats these as style
+                guidance; OpenAI's images.edit treats them as compositional /
+                mask inputs. Warn users accordingly.
+            safety_filter_level: Gemini safety threshold
+                ("block_none", "block_only_high", "block_medium_and_above",
+                "block_low_and_above"). Ignored by OpenAI.
+
+        Returns:
+            List of absolute file paths to the generated PNG files.
+
+        Raises:
+            RuntimeError: If the provider is unsupported or generation fails.
+        """
+        if _PilImage is None:
+            raise RuntimeError(
+                "Pillow is required for image generation. "
+                "Install with: pip install Pillow"
+            )
+
+        if not prompt:
+            raise ValueError("prompt is required")
+
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        ref = reference_images or []
+
+        if self.provider == "openai":
+            paths = self._openai_generate(
+                prompt=prompt,
+                resolution=resolution,
+                aspect_ratio=aspect_ratio,
+                number_of_images=number_of_images,
+                output_path=output_path,
+                negative_prompt=negative_prompt,
+                reference_images=ref,
+                timestamp=timestamp,
+            )
+        elif self.provider == "gemini":
+            paths = self._gemini_generate(
+                prompt=prompt,
+                resolution=resolution,
+                aspect_ratio=aspect_ratio,
+                number_of_images=number_of_images,
+                output_path=output_path,
+                negative_prompt=negative_prompt,
+                reference_images=ref,
+                safety_filter_level=safety_filter_level,
+                timestamp=timestamp,
+            )
+        else:
+            raise RuntimeError(
+                f"Provider '{self.provider}' does not support image generation. "
+                "Set image_gen_provider to 'openai' or 'gemini' in settings.json."
+            )
+
+        logger.info(
+            f"[IMAGE_GEN] Generated {len(paths)} image(s) via {self.provider} "
+            f"(model={self.model})"
+        )
+        return paths
+
+    async def generate_image_async(self, **kwargs) -> List[str]:
+        """Async wrapper — runs generate_image in a thread pool."""
+        loop = asyncio.get_event_loop()
+        return await loop.run_in_executor(None, lambda: self.generate_image(**kwargs))
+
+    # ──────────────────────── OpenAI provider ────────────────────────────────
+
+    def _openai_generate(
+        self,
+        *,
+        prompt: str,
+        resolution: str,
+        aspect_ratio: str,
+        number_of_images: int,
+        output_path: str,
+        negative_prompt: str,
+        reference_images: List[str],
+        timestamp: str,
+    ) -> List[str]:
+        size = _OPENAI_ASPECT_MAP.get(aspect_ratio, "1024x1024")
+        if aspect_ratio in _OPENAI_INEXACT_RATIOS:
+            logger.warning(
+                f"[IMAGE_GEN] OpenAI does not support true {aspect_ratio}. "
+                f"Using closest available canvas {size} (~3:2 / ~2:3)."
+            )
+
+        quality = _OPENAI_QUALITY_MAP.get(resolution, "medium")
+        if resolution == "4K":
+            logger.warning(
+                "[IMAGE_GEN] OpenAI image generation tops out at 1536px; "
+                "'4K' is mapped to quality='high' (no true 4K output)."
+            )
+
+        full_prompt = prompt
+        if negative_prompt:
+            full_prompt += f"\n\nAvoid: {negative_prompt}"
+
+        if reference_images:
+            logger.warning(
+                "[IMAGE_GEN] OpenAI reference_images uses images.edit(), which treats "
+                "inputs as compositional/mask data — not style guidance as in Gemini. "
+                "Output may differ significantly from the Gemini provider."
+            )
+
+        try:
+            valid_refs = [p for p in reference_images if os.path.isfile(p)]
+            if valid_refs:
+                image_files = [open(p, "rb") for p in valid_refs]
+                try:
+                    response = self.client.images.edit(
+                        model=self.model,
+                        image=image_files,
+                        prompt=full_prompt,
+                        n=number_of_images,
+                        size=size,
+                        quality=quality,
+                    )
+                finally:
+                    for f in image_files:
+                        f.close()
+            else:
+                response = self.client.images.generate(
+                    model=self.model,
+                    prompt=full_prompt,
+                    n=number_of_images,
+                    size=size,
+                    quality=quality,
+                )
+        except Exception as exc:
+            raise RuntimeError(_classify_error("openai", exc)) from exc
+
+        images_bytes: List[bytes] = []
+        for item in response.data:
+            if item.b64_json:
+                images_bytes.append(base64.b64decode(item.b64_json))
+            elif item.url:
+                with _urllib_request.urlopen(item.url) as r:
+                    images_bytes.append(r.read())
+
+        if not images_bytes:
+            raise RuntimeError(
+                "OpenAI returned no image data — try rephrasing your prompt."
+            )
+
+        paths: List[str] = []
+        for i, raw in enumerate(images_bytes[:number_of_images]):
+            save_path = _build_save_path(output_path, timestamp, i, len(images_bytes))
+            pil_image = _PilImage.open(io.BytesIO(raw))
+            _save_pil_image(pil_image, save_path)
+            paths.append(save_path)
+
+        return paths
+
+    # ──────────────────────── Gemini provider ────────────────────────────────
+
+    def _gemini_generate(
+        self,
+        *,
+        prompt: str,
+        resolution: str,
+        aspect_ratio: str,
+        number_of_images: int,
+        output_path: str,
+        negative_prompt: str,
+        reference_images: List[str],
+        safety_filter_level: str,
+        timestamp: str,
+    ) -> List[str]:
+        try:
+            from google import genai  # type: ignore[import]
+            from google.genai import types as gtypes  # type: ignore[import]
+        except ImportError as exc:
+            raise RuntimeError(
+                f"google-genai is required for Gemini image generation. "
+                f"Install with `pip install google-genai`: {exc}"
+            ) from exc
+
+        if not self._gemini_client:
+            raise RuntimeError(
+                "Gemini API key is not configured. "
+                "Set 'image_gen_provider' to 'openai' or add a Google API key in settings."
+            )
+
+        # Reference images as Gemini content parts (style guidance)
+        image_parts: List[Any] = []
+        for ref_path in reference_images:
+            if not os.path.isfile(ref_path):
+                continue
+            try:
+                with open(ref_path, "rb") as f:
+                    data = f.read()
+                ext = os.path.splitext(ref_path)[1].lower()
+                mime = {
+                    ".png": "image/png",
+                    ".jpg": "image/jpeg",
+                    ".jpeg": "image/jpeg",
+                    ".gif": "image/gif",
+                    ".webp": "image/webp",
+                }.get(ext, "image/png")
+                image_parts.append(gtypes.Part.from_bytes(data=data, mime_type=mime))
+            except Exception:
+                pass
+
+        gen_prompt = f"Generate an image based on the following description:\n\n{prompt}"
+        gen_prompt += f"\n\nImage specifications:\n- Resolution: {resolution}\n- Aspect ratio: {aspect_ratio}\n- Number of variations: {number_of_images}"
+        if negative_prompt:
+            gen_prompt += f"\n- Avoid: {negative_prompt}"
+
+        content_parts = image_parts + [gen_prompt]
+
+        safety_settings = None
+        _threshold_map = {
+            "block_only_high": "BLOCK_ONLY_HIGH",
+            "block_medium_and_above": "BLOCK_MEDIUM_AND_ABOVE",
+            "block_low_and_above": "BLOCK_LOW_AND_ABOVE",
+        }
+        if safety_filter_level != "block_none":
+            threshold = _threshold_map.get(safety_filter_level, "BLOCK_MEDIUM_AND_ABOVE")
+            safety_settings = [
+                gtypes.SafetySetting(category=cat, threshold=threshold)
+                for cat in (
+                    "HARM_CATEGORY_HARASSMENT",
+                    "HARM_CATEGORY_HATE_SPEECH",
+                    "HARM_CATEGORY_SEXUALLY_EXPLICIT",
+                    "HARM_CATEGORY_DANGEROUS_CONTENT",
+                )
+            ]
+
+        config = gtypes.GenerateContentConfig(
+            candidate_count=1,
+            response_modalities=["TEXT", "IMAGE"],
+            image_config=gtypes.ImageConfig(image_size=resolution),
+            safety_settings=safety_settings,
+        )
+
+        try:
+            api_key = self._gemini_client._api_key
+            client = genai.Client(api_key=api_key)
+            response = client.models.generate_content(
+                model=self.model,
+                contents=content_parts,
+                config=config,
+            )
+        except Exception as exc:
+            raise RuntimeError(_classify_error("gemini", exc)) from exc
+
+        images_data = _extract_gemini_images(response)
+
+        if not images_data:
+            block_reason = _gemini_block_reason(response)
+            if block_reason:
+                raise RuntimeError(
+                    f"Gemini blocked the request (safety filter: {block_reason}). "
+                    "Try modifying your prompt or adjusting safety_filter_level."
+                )
+            raise RuntimeError(
+                "Gemini returned no image data — try rephrasing your prompt or "
+                "check that your API key has access to image generation."
+            )
+
+        paths: List[str] = []
+        for i, img_data in enumerate(images_data[:number_of_images]):
+            save_path = _build_save_path(output_path, timestamp, i, len(images_data))
+            pil_image = _to_pil_image(img_data)
+            _save_pil_image(pil_image, save_path)
+            paths.append(save_path)
+
+        return paths

--- a/agent_core/core/llm/google_gemini_client.py
+++ b/agent_core/core/llm/google_gemini_client.py
@@ -542,6 +542,94 @@ class GeminiClient:
             "cached_tokens": cached_tokens,
         }
 
+    def generate_image(
+        self,
+        model: str,
+        *,
+        prompt: str,
+        reference_images: Optional[List[tuple]] = None,
+        image_size: Optional[str] = None,
+        safety_settings: Optional[List[Dict[str, str]]] = None,
+    ) -> Dict[str, Any]:
+        """Generate image(s) via generateContent with the IMAGE response modality.
+
+        Uses the same REST endpoint as the text/multimodal helpers (no
+        ``google-genai`` SDK), keeping the whole Gemini surface on one client.
+
+        Args:
+            model: Image-capable model identifier (e.g. ``gemini-3-pro-image``).
+            prompt: Text description of the image to generate.
+            reference_images: Optional list of ``(bytes, mime_type)`` tuples sent
+                as inline reference parts (style guidance).
+            image_size: Optional size hint (e.g. ``"1K"``/``"2K"``/``"4K"``) passed
+                through ``generationConfig.imageConfig.imageSize``.
+            safety_settings: Optional list of ``{"category", "threshold"}`` dicts.
+
+        Returns:
+            Dict with:
+                - images: List[bytes] of decoded image data (may be empty)
+                - usage_metadata: Dict from the response's ``usageMetadata``
+                - block_reason: Optional[str] when blocked by a safety/finish reason
+        """
+        parts: List[Dict[str, Any]] = []
+        for data, mime in reference_images or []:
+            parts.append(
+                {
+                    "inlineData": {
+                        "mimeType": mime or "image/png",
+                        "data": base64.b64encode(data).decode("utf-8"),
+                    }
+                }
+            )
+        parts.append({"text": prompt})
+
+        generation_config: Dict[str, Any] = {
+            "responseModalities": ["TEXT", "IMAGE"],
+            "candidateCount": 1,
+        }
+        if image_size:
+            generation_config["imageConfig"] = {"imageSize": image_size}
+
+        payload: Dict[str, Any] = {
+            "contents": [{"role": "user", "parts": parts}],
+            "generationConfig": generation_config,
+        }
+        if safety_settings:
+            payload["safetySettings"] = safety_settings
+
+        response = self._post_json(
+            f"{_normalise_model_name(model)}:generateContent", payload
+        )
+
+        images: List[bytes] = []
+        for candidate in response.get("candidates", []) or []:
+            content = candidate.get("content") or {}
+            for part in content.get("parts", []) or []:
+                inline = part.get("inlineData") if isinstance(part, dict) else None
+                if inline and str(inline.get("mimeType", "")).startswith("image/"):
+                    try:
+                        images.append(base64.b64decode(inline["data"]))
+                    except Exception:
+                        pass
+
+        block_reason: Optional[str] = None
+        if not images:
+            feedback = response.get("promptFeedback")
+            if isinstance(feedback, dict) and feedback.get("blockReason"):
+                block_reason = str(feedback["blockReason"])
+            else:
+                for candidate in response.get("candidates", []) or []:
+                    fr = candidate.get("finishReason")
+                    if fr and "SAFETY" in str(fr).upper():
+                        block_reason = str(fr)
+                        break
+
+        return {
+            "images": images,
+            "usage_metadata": response.get("usageMetadata", {}) or {},
+            "block_reason": block_reason,
+        }
+
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------

--- a/agent_core/core/models/factory.py
+++ b/agent_core/core/models/factory.py
@@ -127,7 +127,27 @@ class ModelFactory:
             raise ValueError(f"Unsupported provider: {provider}")
 
         cfg = PROVIDER_CONFIG[provider]
-        model = model_override or MODEL_REGISTRY[provider][interface]
+        model = model_override or MODEL_REGISTRY[provider].get(interface)
+        if model is None:
+            if deferred:
+                return {
+                    "provider": provider,
+                    "model": None,
+                    "client": None,
+                    "gemini_client": None,
+                    "remote_url": None,
+                    "byteplus": None,
+                    "anthropic_client": None,
+                    "bedrock_client": None,
+                    "initialized": False,
+                }
+            supported = ", ".join(
+                p for p, caps in MODEL_REGISTRY.items() if caps.get(interface)
+            )
+            raise ValueError(
+                f"Provider '{provider}' does not support {interface.value}. "
+                f"Supported providers: {supported}"
+            )
 
         # Use provided base_url or fall back to default
         resolved_base_url = base_url or cfg.default_base_url

--- a/agent_core/core/models/model_registry.py
+++ b/agent_core/core/models/model_registry.py
@@ -8,46 +8,55 @@ MODEL_REGISTRY = {
         InterfaceType.LLM: "gpt-5.2-2025-12-11",
         InterfaceType.VLM: "gpt-5.2-2025-12-11",
         InterfaceType.EMBEDDING: "text-embedding-3-small",
+        InterfaceType.IMAGE_GEN: "gpt-image-2",
     },
     "gemini": {
         InterfaceType.LLM: "gemini-2.5-pro",
         InterfaceType.VLM: "gemini-2.5-pro",
         InterfaceType.EMBEDDING: "text-embedding-004",
+        InterfaceType.IMAGE_GEN: "gemini-3-pro-image",
     },
     "anthropic": {
         InterfaceType.LLM: "claude-sonnet-4-5-20250929",
         InterfaceType.VLM: "claude-sonnet-4-5-20250929",
         InterfaceType.EMBEDDING: None,  # Anthropic does not provide native embedding models
+        InterfaceType.IMAGE_GEN: None,
     },
     "byteplus": {
         InterfaceType.LLM: "seed-2-0-pro-260328",
         InterfaceType.VLM: "seed-2-0-pro-260328",
         InterfaceType.EMBEDDING: "skylark-embedding-vision-250615",
+        InterfaceType.IMAGE_GEN: None,
     },
     "remote": {
         InterfaceType.LLM: "llama3.2:3b",
         InterfaceType.VLM: "llava:7b",
         InterfaceType.EMBEDDING: "nomic-embed-text",
+        InterfaceType.IMAGE_GEN: None,
     },
     "minimax": {
         InterfaceType.LLM: "MiniMax-Text-01",
         InterfaceType.VLM: "MiniMax-VL-01",
         InterfaceType.EMBEDDING: None,
+        InterfaceType.IMAGE_GEN: None,
     },
     "deepseek": {
         InterfaceType.LLM: "deepseek-chat",
         InterfaceType.VLM: None,
         InterfaceType.EMBEDDING: None,
+        InterfaceType.IMAGE_GEN: None,
     },
     "moonshot": {
         InterfaceType.LLM: "kimi-k2.5",
         InterfaceType.VLM: "moonshot-v1-8k-vision-preview",
         InterfaceType.EMBEDDING: None,
+        InterfaceType.IMAGE_GEN: None,
     },
     "grok": {
         InterfaceType.LLM: "grok-3",
         InterfaceType.VLM: "grok-4-0709",
         InterfaceType.EMBEDDING: None,
+        InterfaceType.IMAGE_GEN: None,
     },
     "openrouter": {
         # OpenRouter slugs follow `<provider>/<model>` format. Default to a Claude
@@ -55,6 +64,7 @@ MODEL_REGISTRY = {
         InterfaceType.LLM: "anthropic/claude-sonnet-4.5",
         InterfaceType.VLM: "anthropic/claude-sonnet-4.5",
         InterfaceType.EMBEDDING: None,
+        InterfaceType.IMAGE_GEN: None,
     },
     "bedrock": {
         # Default to Claude Haiku 4.5 — best price/performance on Bedrock with
@@ -71,5 +81,6 @@ MODEL_REGISTRY = {
         InterfaceType.LLM: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
         InterfaceType.VLM: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
         InterfaceType.EMBEDDING: "amazon.titan-embed-text-v2:0",
+        InterfaceType.IMAGE_GEN: None,
     },
 }

--- a/agent_core/core/models/types.py
+++ b/agent_core/core/models/types.py
@@ -21,3 +21,4 @@ class InterfaceType(str, Enum):
     LLM = "llm"
     VLM = "vlm"
     EMBEDDING = "embedding"
+    IMAGE_GEN = "image_gen"

--- a/app/agent_base.py
+++ b/app/agent_base.py
@@ -70,6 +70,7 @@ from agent_core.core.impl.llm.errors import (
     LLMConsecutiveFailureError,
 )
 from app.vlm_interface import VLMInterface
+from app.image_gen_interface import ImageGenInterface
 from app.database_interface import DatabaseInterface
 from app.logger import logger
 from agent_core import (
@@ -163,6 +164,8 @@ class AgentBase:
         llm_model: str | None = None,
         vlm_provider: str | None = None,
         vlm_model: str | None = None,
+        image_gen_provider: str | None = None,
+        image_gen_model: str | None = None,
         deferred_init: bool = False,
     ) -> None:
         """
@@ -179,6 +182,8 @@ class AgentBase:
             llm_model: Model name override (None = use registry default).
             vlm_provider: Provider name for VLM (defaults to llm_provider if None).
             vlm_model: VLM model name override (None = use registry default).
+            image_gen_provider: Provider name for image generation (openai or gemini).
+            image_gen_model: Image gen model override (None = use registry default).
             deferred_init: If True, allow LLM/VLM initialization to be deferred
                 until API key is configured (useful for first-time setup).
         """
@@ -210,6 +215,17 @@ class AgentBase:
             api_key=_vlm_api_key,
             base_url=_vlm_base_url,
             deferred=deferred_init,
+        )
+
+        # Image generation uses its own provider/model settings
+        from app.config import get_image_gen_provider as _get_img_prov
+        _img_provider = image_gen_provider or _get_img_prov()
+        _img_api_key = get_api_key(_img_provider)
+        self.image_gen = ImageGenInterface(
+            provider=_img_provider,
+            model=image_gen_model,
+            api_key=_img_api_key,
+            deferred=True,  # always deferred — many users won't have an image-gen key
         )
 
         self.event_stream_manager = EventStreamManager(
@@ -308,6 +324,7 @@ class AgentBase:
             self.task_manager,
             self.state_manager,
             vlm_interface=self.vlm,
+            image_gen_interface=self.image_gen,
             memory_manager=self.memory_manager,
             context_engine=self.context_engine,
         )
@@ -2997,6 +3014,42 @@ class AgentBase:
                     tui_footage_callback=self._tui_footage_callback,
                 )
         return llm_ok and vlm_ok
+
+    def reinitialize_image_gen(self, provider: str | None = None) -> bool:
+        """Reinitialize the image generation interface with updated configuration.
+
+        Creates a fresh ImageGenInterface instance rather than mutating the
+        existing one, so any in-flight action that holds a reference to the
+        old instance completes cleanly against the old provider/client.
+
+        Args:
+            provider: Optional provider to switch to. If None, reads from settings.
+
+        Returns:
+            True if reinitialization was successful.
+        """
+        from app.config import get_image_gen_provider, get_api_key, get_image_gen_model
+        from app.image_gen_interface import ImageGenInterface
+        from app.internal_action_interface import InternalActionInterface
+
+        target_provider = provider or get_image_gen_provider()
+        api_key = get_api_key(target_provider)
+        model = get_image_gen_model()
+
+        new_interface = ImageGenInterface(
+            provider=target_provider,
+            model=model,
+            api_key=api_key,
+            deferred=False,
+        )
+        ok = new_interface.is_initialized
+        if ok:
+            self.image_gen = new_interface
+            InternalActionInterface.image_gen_interface = new_interface
+        logger.info(
+            f"[AGENT] Image gen reinitialized: provider={target_provider}, success={ok}"
+        )
+        return ok
 
     @property
     def is_llm_initialized(self) -> bool:

--- a/app/config.py
+++ b/app/config.py
@@ -91,8 +91,10 @@ def _get_default_settings() -> Dict[str, Any]:
         "model": {
             "llm_provider": "anthropic",
             "vlm_provider": "anthropic",
+            "image_gen_provider": "openai",
             "llm_model": None,
             "vlm_model": None,
+            "image_gen_model": None,
             "slow_mode": False,
             "slow_mode_tpm_limit": 30000,
         },
@@ -213,6 +215,19 @@ def get_vlm_model() -> Optional[str]:
     """Get configured VLM model override (or None for default)."""
     settings = get_settings()
     return settings.get("model", {}).get("vlm_model")
+
+
+def get_image_gen_provider() -> str:
+    """Get configured image generation provider."""
+    settings = get_settings()
+    model = settings.get("model", {})
+    return model.get("image_gen_provider") or model.get("vlm_provider", "openai")
+
+
+def get_image_gen_model() -> Optional[str]:
+    """Get configured image generation model override (or None for default)."""
+    settings = get_settings()
+    return settings.get("model", {}).get("image_gen_model")
 
 
 def get_api_key(provider: str) -> str:

--- a/app/data/action/generate_image.py
+++ b/app/data/action/generate_image.py
@@ -1,4 +1,45 @@
 from agent_core import action
+from agent_core.utils.logger import logger
+
+# Fallback priority when the configured provider can't generate images: prefer
+# Google (Gemini), then OpenAI, then any other provider the registry marks as
+# image-gen-capable. (Today only gemini/openai qualify, but this stays generic.)
+_IMAGE_GEN_PRIORITY = ["gemini", "openai"]
+
+
+def _resolve_image_gen_provider(configured_provider: str):
+    """Pick the provider to use for image generation.
+
+    Uses the configured provider when it both supports image generation and has
+    a configured API key. Otherwise falls back to the highest-priority provider
+    (see _IMAGE_GEN_PRIORITY) that is image-gen-capable AND has a key — so a user
+    on, say, an LLM-only provider can still generate images if they have a
+    Google/OpenAI key. Returns None when no provider can serve image generation.
+    """
+    from agent_core.core.models.model_registry import MODEL_REGISTRY
+    from agent_core.core.models.types import InterfaceType
+    from app.config import get_api_key
+
+    def supports(p: str) -> bool:
+        return bool(MODEL_REGISTRY.get(p, {}).get(InterfaceType.IMAGE_GEN))
+
+    def has_key(p: str) -> bool:
+        try:
+            return bool(get_api_key(p))
+        except Exception:
+            return False
+
+    if configured_provider and supports(configured_provider) and has_key(configured_provider):
+        return configured_provider
+
+    candidates = list(_IMAGE_GEN_PRIORITY)
+    for p, caps in MODEL_REGISTRY.items():
+        if caps.get(InterfaceType.IMAGE_GEN) and p not in candidates:
+            candidates.append(p)
+    for p in candidates:
+        if supports(p) and has_key(p):
+            return p
+    return None
 
 
 @action(
@@ -69,7 +110,7 @@ from agent_core import action
             "description": "Status message or error details.",
         },
     },
-    requirement=["google-genai", "openai", "Pillow"],
+    requirement=["openai", "Pillow"],
     test_payload={
         "prompt": "A cute cartoon cat sitting on a rainbow",
         "resolution": "1K",
@@ -88,24 +129,7 @@ def generate_image(input_data: dict) -> dict:
         }
 
     import app.internal_action_interface as iai
-    from agent_core.core.models.model_registry import MODEL_REGISTRY
-    from agent_core.core.models.types import InterfaceType
     from app.config import get_image_gen_provider
-
-    image_gen = iai.InternalActionInterface.image_gen_interface
-    current_provider = get_image_gen_provider()
-    registry_entry = MODEL_REGISTRY.get(current_provider, {}).get(InterfaceType.IMAGE_GEN)
-
-    if image_gen is None or not registry_entry:
-        return {
-            "status": "error",
-            "image_paths": [],
-            "message": (
-                f"Provider '{current_provider}' does not support image generation. "
-                "Set 'image_gen_provider' to 'openai' or 'gemini' in settings.json "
-                "and ensure the corresponding API key is configured under 'api_keys'."
-            ),
-        }
 
     prompt = str(input_data.get("prompt", "")).strip()
     if not prompt:
@@ -115,8 +139,68 @@ def generate_image(input_data: dict) -> dict:
             "message": "prompt is required.",
         }
 
+    configured_provider = get_image_gen_provider()
+    effective_provider = _resolve_image_gen_provider(configured_provider)
+
+    if effective_provider is None:
+        return {
+            "status": "error",
+            "image_paths": [],
+            "message": (
+                "No image-generation provider is available. Image generation requires "
+                "OpenAI or Google (Gemini) with a configured API key. Set "
+                "'image_gen_provider' and add the matching key under 'api_keys' in settings.json."
+            ),
+        }
+
+    # Use the live interface when it already serves the effective provider;
+    # otherwise build a transient interface for the fallback provider (the
+    # configured provider can't generate images, but another configured key can).
+    image_gen = iai.InternalActionInterface.image_gen_interface
+    if (
+        image_gen is None
+        or not getattr(image_gen, "is_initialized", False)
+        or image_gen.provider != effective_provider
+    ):
+        from app.image_gen_interface import ImageGenInterface
+        from app.config import get_api_key, get_image_gen_model
+
+        if effective_provider != configured_provider:
+            logger.info(
+                f"[IMAGE_GEN] Configured provider '{configured_provider}' can't generate "
+                f"images; falling back to '{effective_provider}' (has a configured key)."
+            )
+        try:
+            image_gen = ImageGenInterface(
+                provider=effective_provider,
+                # Honor the configured model override only when it matches the
+                # configured provider; a fallback provider uses its own default.
+                model=(
+                    get_image_gen_model()
+                    if effective_provider == configured_provider
+                    else None
+                ),
+                api_key=get_api_key(effective_provider),
+                deferred=False,
+            )
+        except Exception as e:
+            return {
+                "status": "error",
+                "image_paths": [],
+                "message": f"Failed to initialize image generation ({effective_provider}): {e}",
+            }
+        if not image_gen.is_initialized:
+            return {
+                "status": "error",
+                "image_paths": [],
+                "message": (
+                    f"Image generation provider '{effective_provider}' could not be "
+                    "initialized — check its API key in settings.json."
+                ),
+            }
+
     try:
-        paths = iai.InternalActionInterface.generate_image(
+        paths = image_gen.generate_image(
             prompt=prompt,
             resolution=str(input_data.get("resolution", "1K")).upper(),
             aspect_ratio=str(input_data.get("aspect_ratio", "1:1")),
@@ -131,7 +215,7 @@ def generate_image(input_data: dict) -> dict:
         return {
             "status": "success",
             "image_paths": paths,
-            "message": f"Generated {len(paths)} image(s) via {current_provider}.",
+            "message": f"Generated {len(paths)} image(s) via {effective_provider}.",
         }
     except Exception as e:
         return {

--- a/app/data/action/generate_image.py
+++ b/app/data/action/generate_image.py
@@ -3,13 +3,11 @@ from agent_core import action
 
 @action(
     name="generate_image",
-    description="""Generates an image using either OpenAI's Images 2.0 (gpt-image-2) or Google's Nano Banana 2 (gemini-3.1-flash-image-preview) model.
-- Automatically selects the provider based on which API key(s) are configured
-- If only one API key is set, that provider is used automatically
-- If both keys are configured, asks the user which provider to use and remembers the choice
-- If no API keys are configured, returns an error with setup instructions
-- Supports 1K, 2K, or 4K resolution and multiple aspect ratios
-- TIP: When generating multiple images for the same project or related work, use 'reference_images' parameter with previously generated images to maintain consistent style across all outputs""",
+    description="""Generates an image from a text prompt using the configured image generation provider (OpenAI gpt-image-2 or Google Gemini).
+- The provider is determined by 'image_gen_provider' in settings.json (default: openai). Supported: openai, gemini.
+- Saves the result as a PNG file to output_path, or a timestamped temp file if omitted.
+- TIP: When generating multiple related images, pass previously generated paths via 'reference_images' to maintain style consistency.
+- NOTE: reference_images semantics differ by provider — Gemini uses them as style guidance; OpenAI's images.edit treats them as compositional/mask inputs.""",
     default=True,
     mode="CLI",
     action_sets=["content_creation", "image", "document_processing"],
@@ -17,51 +15,43 @@ from agent_core import action
         "prompt": {
             "type": "string",
             "example": "A serene mountain landscape at sunset with a lake reflection",
-            "description": "The text prompt describing the image to generate.",
+            "description": "Text description of the image to generate.",
             "required": True,
         },
         "output_path": {
             "type": "string",
             "example": "C:/Users/user/Pictures/generated_image.png",
-            "description": "Absolute path where the generated image will be saved (e.g., C:/Users/user/image.png or /home/user/image.png). If not provided, saves to temp directory.",
+            "description": "Absolute path where the generated image will be saved. If omitted, saved to temp directory with a timestamped name.",
         },
         "resolution": {
             "type": "string",
             "example": "2K",
-            "description": "Output resolution. Options: '1K' (1080p), '2K', '4K'. Default: '1K'. Higher resolution costs more.",
+            "description": "Output resolution: '1K' (default), '2K', or '4K'. Higher resolution costs more. OpenAI tops out at ~1536px regardless of this setting.",
         },
         "aspect_ratio": {
             "type": "string",
             "example": "16:9",
-            "description": "Aspect ratio of the generated image. Options: '1:1', '3:4', '4:3', '9:16', '16:9'. Default: '1:1'.",
+            "description": "Aspect ratio: '1:1' (default), '3:4', '4:3', '9:16', '16:9'. OpenAI maps to the nearest available canvas size — true 16:9 and 9:16 are not supported natively.",
         },
         "number_of_images": {
             "type": "integer",
             "example": 1,
-            "description": "Number of images to generate (1-4). Default: 1.",
+            "description": "Number of images to generate (1–4). Default: 1.",
         },
         "negative_prompt": {
             "type": "string",
             "example": "blurry, low quality, distorted",
-            "description": "Text describing what to avoid in the generated image.",
+            "description": "Elements to avoid. Native on Gemini; appended to prompt for OpenAI.",
         },
         "reference_images": {
             "type": "array",
-            "example": [
-                "C:/Users/user/Pictures/reference1.png",
-                "C:/Users/user/Pictures/reference2.png",
-            ],
-            "description": "Optional list of reference image absolute paths to guide generation (up to 14 images). Use full absolute paths.",
+            "example": ["C:/Users/user/Pictures/ref.png"],
+            "description": "Optional reference image paths (up to 14). Gemini: style guidance. OpenAI: compositional/mask inputs (different behaviour — results may vary).",
         },
         "safety_filter_level": {
             "type": "string",
             "example": "block_medium_and_above",
-            "description": "Safety filter level (Gemini only). Options: 'block_none', 'block_only_high', 'block_medium_and_above', 'block_low_and_above'. Default: 'block_medium_and_above'. Ignored when using OpenAI.",
-        },
-        "provider_preference": {
-            "type": "string",
-            "example": "openai",
-            "description": "Which provider to use: 'openai' (Images 2.0 / gpt-image-2) or 'gemini' (Nano Banana 2 / gemini-3.1-flash-image-preview). Only needed when both API keys are configured and no saved preference exists. Providing this saves it as the default for future calls.",
+            "description": "Gemini safety filter: 'block_none', 'block_only_high', 'block_medium_and_above' (default), 'block_low_and_above'. Ignored by OpenAI.",
         },
     },
     output_schema={
@@ -72,19 +62,11 @@ from agent_core import action
         },
         "image_paths": {
             "type": "array",
-            "description": "List of paths to the generated image files.",
-        },
-        "prompt_used": {
-            "type": "string",
-            "description": "The prompt that was used for generation.",
-        },
-        "resolution": {
-            "type": "string",
-            "description": "The resolution of the generated image.",
+            "description": "Absolute paths to the generated PNG files.",
         },
         "message": {
             "type": "string",
-            "description": "Status message or error message.",
+            "description": "Status message or error details.",
         },
     },
     requirement=["google-genai", "openai", "Pillow"],
@@ -97,491 +79,63 @@ from agent_core import action
     },
 )
 def generate_image(input_data: dict) -> dict:
-    """
-    Generates an image using OpenAI's Images 2.0 (gpt-image-2) or Google's Nano Banana 2 (gemini-3.1-flash-image-preview).
-    """
-    import os
-    import sys
-    import subprocess
-    import importlib
-    import tempfile
-    from datetime import datetime
-
     simulated_mode = input_data.get("simulated_mode", False)
-
     if simulated_mode:
         return {
             "status": "success",
             "image_paths": ["/tmp/simulated_image_001.png"],
-            "prompt_used": input_data.get("prompt", "Simulated prompt"),
-            "resolution": input_data.get("resolution", "1K"),
             "message": "Image generated successfully (simulated mode).",
         }
 
-    # Determine which provider to use based on available API keys and user preference
-    from app.config import get_api_key, get_settings, save_settings
+    import app.internal_action_interface as iai
+    from agent_core.core.models.model_registry import MODEL_REGISTRY
+    from agent_core.core.models.types import InterfaceType
+    from app.config import get_image_gen_provider
 
-    openai_key = get_api_key("openai")
-    gemini_key = get_api_key("gemini")
+    image_gen = iai.InternalActionInterface.image_gen_interface
+    current_provider = get_image_gen_provider()
+    registry_entry = MODEL_REGISTRY.get(current_provider, {}).get(InterfaceType.IMAGE_GEN)
 
-    if not openai_key and not gemini_key:
+    if image_gen is None or not registry_entry:
         return {
             "status": "error",
             "image_paths": [],
-            "prompt_used": "",
-            "resolution": "",
             "message": (
-                "No image generation API key is configured. "
-                "Tell the user they need either an OpenAI API key (for Images 2.0 / gpt-image-2) "
-                "or a Google Gemini API key (for Nano Banana 2 / gemini-3.1-flash-image-preview), "
-                "and ask if they need help setting one up."
+                f"Provider '{current_provider}' does not support image generation. "
+                "Set 'image_gen_provider' to 'openai' or 'gemini' in settings.json "
+                "and ensure the corresponding API key is configured under 'api_keys'."
             ),
         }
 
-    provider_preference = input_data.get("provider_preference", "").strip().lower()
-    _cfg = get_settings()
-    saved_provider = _cfg.get("image_generation", {}).get("preferred_provider", "")
-
-    if openai_key and not gemini_key:
-        provider = "openai"
-    elif gemini_key and not openai_key:
-        provider = "gemini"
-    else:
-        # Both keys present
-        if provider_preference in ("openai", "gemini"):
-            provider = provider_preference
-            _cfg.setdefault("image_generation", {})["preferred_provider"] = provider
-            save_settings(_cfg)
-        elif saved_provider in ("openai", "gemini"):
-            provider = saved_provider
-        else:
-            provider = "gemini"
-
-    api_key = openai_key if provider == "openai" else gemini_key
-
-    # Validate required input
-    prompt = input_data.get("prompt", "").strip()
+    prompt = str(input_data.get("prompt", "")).strip()
     if not prompt:
         return {
             "status": "error",
             "image_paths": [],
-            "prompt_used": "",
-            "resolution": "",
-            "message": "A prompt is required to generate an image.",
-        }
-
-    # Get optional parameters
-    output_path = input_data.get("output_path", "")
-    resolution = input_data.get("resolution", "1K").upper()
-    aspect_ratio = input_data.get("aspect_ratio", "1:1")
-    number_of_images = min(max(int(input_data.get("number_of_images", 1)), 1), 4)
-    negative_prompt = input_data.get("negative_prompt", "")
-    reference_images = input_data.get("reference_images", [])
-    safety_filter_level = input_data.get(
-        "safety_filter_level", "block_medium_and_above"
-    )
-
-    # Validate resolution with user feedback
-    valid_resolutions = ["1K", "2K", "4K"]
-    warnings = []
-    if resolution not in valid_resolutions:
-        warnings.append(
-            f"Invalid resolution '{resolution}'. Defaulting to '1K'. Valid options: {', '.join(valid_resolutions)}."
-        )
-        resolution = "1K"
-
-    # Validate aspect ratio with user feedback
-    valid_ratios = ["1:1", "3:4", "4:3", "9:16", "16:9"]
-    if aspect_ratio not in valid_ratios:
-        warnings.append(
-            f"Invalid aspect ratio '{aspect_ratio}'. Defaulting to '1:1'. Valid options: {', '.join(valid_ratios)}."
-        )
-        aspect_ratio = "1:1"
-
-    # Validate safety filter level with user feedback
-    valid_safety_levels = [
-        "block_none",
-        "block_only_high",
-        "block_medium_and_above",
-        "block_low_and_above",
-    ]
-    if safety_filter_level not in valid_safety_levels:
-        warnings.append(
-            f"Invalid safety filter level '{safety_filter_level}'. Defaulting to 'block_medium_and_above'. Valid options: {', '.join(valid_safety_levels)}."
-        )
-        safety_filter_level = "block_medium_and_above"
-
-    # Validate number_of_images with user feedback
-    raw_num = int(input_data.get("number_of_images", 1))
-    if raw_num < 1 or raw_num > 4:
-        warnings.append(
-            f"number_of_images '{raw_num}' out of range. Clamped to {number_of_images}. Valid range: 1-4."
-        )
-
-    # Limit reference images to 14
-    if len(reference_images) > 14:
-        warnings.append(
-            f"Too many reference images ({len(reference_images)}). Only the first 14 will be used."
-        )
-        reference_images = reference_images[:14]
-
-    # Helper: extract images from Gemini response
-    def _extract_images_from_response(response):
-        images = []
-        # Primary path: candidates[].content.parts[].inline_data
-        if hasattr(response, "candidates") and response.candidates:
-            for candidate in response.candidates:
-                if not (
-                    hasattr(candidate, "content")
-                    and hasattr(candidate.content, "parts")
-                ):
-                    continue
-                for part in candidate.content.parts:
-                    if hasattr(part, "inline_data") and part.inline_data:
-                        if hasattr(
-                            part.inline_data, "mime_type"
-                        ) and part.inline_data.mime_type.startswith("image/"):
-                            images.append(part.inline_data.data)
-        # Fallback: response.images (older SDK versions)
-        if not images and hasattr(response, "images"):
-            for img in response.images:
-                if hasattr(img, "data"):
-                    images.append(img.data)
-                elif hasattr(img, "_pil_image"):
-                    images.append(img)
-        return images
-
-    # Helper: check if response was blocked by safety filters
-    def _get_block_reason(response):
-        if hasattr(response, "prompt_feedback"):
-            feedback = response.prompt_feedback
-            if hasattr(feedback, "block_reason") and feedback.block_reason:
-                return str(feedback.block_reason)
-        if hasattr(response, "candidates") and response.candidates:
-            for candidate in response.candidates:
-                if hasattr(candidate, "finish_reason") and candidate.finish_reason:
-                    reason = str(candidate.finish_reason)
-                    if "SAFETY" in reason.upper():
-                        return reason
-        return None
-
-    # Helper: build the save path for a generated image
-    def _build_save_path(output_path, timestamp, index, number_of_images, total_found):
-        if output_path:
-            if number_of_images > 1 or total_found > 1:
-                base, ext = os.path.splitext(output_path)
-                if not ext:
-                    ext = ".png"
-                return f"{base}_{index + 1}{ext}"
-            else:
-                save_path = output_path
-                if not os.path.splitext(save_path)[1]:
-                    save_path += ".png"
-                return save_path
-        else:
-            temp_dir = tempfile.gettempdir()
-            return os.path.join(
-                temp_dir, f"generated_image_{timestamp}_{index + 1}.png"
-            )
-
-    # Helper: convert image data to PIL Image
-    def _to_pil_image(img_data, Image, io, base64):
-        if isinstance(img_data, str):
-            image_bytes = base64.b64decode(img_data)
-            return Image.open(io.BytesIO(image_bytes))
-        elif isinstance(img_data, bytes):
-            return Image.open(io.BytesIO(img_data))
-        elif hasattr(img_data, "_pil_image"):
-            return img_data._pil_image
-        else:
-            return img_data
-
-    # Ensure required packages are installed
-    def _ensure_package(pkg_name):
-        try:
-            importlib.import_module(pkg_name.replace("-", "_").split("[")[0])
-        except ImportError:
-            subprocess.check_call(
-                [sys.executable, "-m", "pip", "install", pkg_name, "--quiet"]
-            )
-
-    try:
-        _ensure_package("google-genai")
-        _ensure_package("openai")
-        _ensure_package("Pillow")
-    except Exception as e:
-        return {
-            "status": "error",
-            "image_paths": [],
-            "prompt_used": prompt,
-            "resolution": resolution,
-            "message": f"Failed to install required packages: {str(e)}",
+            "message": "prompt is required.",
         }
 
     try:
-        from PIL import Image
-        import io
-        import base64
-
-        image_paths = []
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-
-        if provider == "gemini":
-            from google import genai
-            from google.genai import types
-
-            client = genai.Client(api_key=api_key)
-
-            # Prepare reference images if provided
-            image_parts = []
-            for ref_path in reference_images:
-                if os.path.exists(ref_path):
-                    try:
-                        with open(ref_path, "rb") as f:
-                            image_data = f.read()
-                        ext = os.path.splitext(ref_path)[1].lower()
-                        mime_map = {
-                            ".png": "image/png",
-                            ".jpg": "image/jpeg",
-                            ".jpeg": "image/jpeg",
-                            ".gif": "image/gif",
-                            ".webp": "image/webp",
-                        }
-                        mime_type = mime_map.get(ext, "image/png")
-                        image_parts.append(
-                            types.Part.from_bytes(data=image_data, mime_type=mime_type)
-                        )
-                    except Exception:
-                        pass  # Skip invalid reference images
-
-            # Build the prompt with generation instructions
-            generation_prompt = f"""Generate an image based on the following description:
-
-{prompt}
-
-Image specifications:
-- Resolution: {resolution}
-- Aspect ratio: {aspect_ratio}
-- Number of variations: {number_of_images}"""
-
-            if negative_prompt:
-                generation_prompt += f"\n- Avoid: {negative_prompt}"
-
-            content_parts = list(image_parts)
-            content_parts.append(generation_prompt)
-
-            # Safety settings
-            safety_settings = None
-            if safety_filter_level != "block_none":
-                harm_block_threshold = {
-                    "block_only_high": "BLOCK_ONLY_HIGH",
-                    "block_medium_and_above": "BLOCK_MEDIUM_AND_ABOVE",
-                    "block_low_and_above": "BLOCK_LOW_AND_ABOVE",
-                }.get(safety_filter_level, "BLOCK_MEDIUM_AND_ABOVE")
-
-                safety_settings = [
-                    types.SafetySetting(
-                        category=category, threshold=harm_block_threshold
-                    )
-                    for category in (
-                        "HARM_CATEGORY_HARASSMENT",
-                        "HARM_CATEGORY_HATE_SPEECH",
-                        "HARM_CATEGORY_SEXUALLY_EXPLICIT",
-                        "HARM_CATEGORY_DANGEROUS_CONTENT",
-                    )
-                ]
-
-            generate_config = types.GenerateContentConfig(
-                candidate_count=1,
-                response_modalities=["TEXT", "IMAGE"],
-                image_config=types.ImageConfig(image_size=resolution),
-                safety_settings=safety_settings,
-            )
-
-            response = client.models.generate_content(
-                model="gemini-3.1-flash-image-preview",
-                contents=content_parts,
-                config=generate_config,
-            )
-
-            images_found = _extract_images_from_response(response)
-
-            if not images_found:
-                block_reason = _get_block_reason(response)
-                if block_reason:
-                    return {
-                        "status": "error",
-                        "image_paths": [],
-                        "prompt_used": prompt,
-                        "resolution": resolution,
-                        "message": f"Image generation was blocked by safety filters: {block_reason}. Try modifying your prompt or adjusting safety_filter_level.",
-                    }
-                return {
-                    "status": "error",
-                    "image_paths": [],
-                    "prompt_used": prompt,
-                    "resolution": resolution,
-                    "message": "No images were generated. The model did not produce image output for this prompt. Try rephrasing your prompt or check if your API key has access to image generation.",
-                }
-
-            for i, img_data in enumerate(images_found[:number_of_images]):
-                save_path = _build_save_path(
-                    output_path, timestamp, i, number_of_images, len(images_found)
-                )
-                parent_dir = os.path.dirname(os.path.abspath(save_path))
-                if parent_dir:
-                    os.makedirs(parent_dir, exist_ok=True)
-                pil_image = _to_pil_image(img_data, Image, io, base64)
-                pil_image.save(save_path, "PNG")
-                image_paths.append(save_path)
-
-            model_label = "Nano Banana 2"
-
-        elif provider == "openai":
-            from openai import OpenAI
-
-            if safety_filter_level != "block_medium_and_above":
-                warnings.append(
-                    "safety_filter_level is not supported by OpenAI and has been ignored."
-                )
-
-            # Map aspect_ratio to OpenAI size string
-            openai_size_map = {
-                "1:1": "1024x1024",
-                "16:9": "1536x1024",
-                "4:3": "1536x1024",
-                "9:16": "1024x1536",
-                "3:4": "1024x1536",
-            }
-            openai_size = openai_size_map.get(aspect_ratio, "1024x1024")
-
-            # Map resolution to OpenAI quality
-            openai_quality_map = {"1K": "medium", "2K": "high", "4K": "high"}
-            openai_quality = openai_quality_map.get(resolution, "medium")
-
-            # Build prompt (OpenAI has no negative_prompt param — append to prompt)
-            full_prompt = prompt
-            if negative_prompt:
-                full_prompt += f"\n\nAvoid: {negative_prompt}"
-
-            client = OpenAI(api_key=api_key)
-
-            valid_ref_paths = [p for p in reference_images if os.path.exists(p)]
-            if valid_ref_paths:
-                image_files = [open(p, "rb") for p in valid_ref_paths]
-                try:
-                    response = client.images.edit(
-                        model="gpt-image-2",
-                        image=image_files,
-                        prompt=full_prompt,
-                        n=number_of_images,
-                        size=openai_size,
-                    )
-                finally:
-                    for f in image_files:
-                        f.close()
-            else:
-                response = client.images.generate(
-                    model="gpt-image-2",
-                    prompt=full_prompt,
-                    n=number_of_images,
-                    size=openai_size,
-                    quality=openai_quality,
-                )
-
-            import urllib.request as _urllib_request
-
-            images_found = []
-            for item in response.data:
-                if item.b64_json:
-                    images_found.append(base64.b64decode(item.b64_json))
-                elif item.url:
-                    with _urllib_request.urlopen(item.url) as _r:
-                        images_found.append(_r.read())
-
-            if not images_found:
-                return {
-                    "status": "error",
-                    "image_paths": [],
-                    "prompt_used": prompt,
-                    "resolution": resolution,
-                    "message": "No images were generated. The model did not produce image output for this prompt. Try rephrasing your prompt.",
-                }
-
-            for i, img_bytes in enumerate(images_found[:number_of_images]):
-                save_path = _build_save_path(
-                    output_path, timestamp, i, number_of_images, len(images_found)
-                )
-                parent_dir = os.path.dirname(os.path.abspath(save_path))
-                if parent_dir:
-                    os.makedirs(parent_dir, exist_ok=True)
-                pil_image = Image.open(io.BytesIO(img_bytes))
-                pil_image.save(save_path, "PNG")
-                image_paths.append(save_path)
-
-            model_label = "Images 2.0"
-
-        message = (
-            f"Successfully generated {len(image_paths)} image(s) using {model_label}."
+        paths = iai.InternalActionInterface.generate_image(
+            prompt=prompt,
+            resolution=str(input_data.get("resolution", "1K")).upper(),
+            aspect_ratio=str(input_data.get("aspect_ratio", "1:1")),
+            number_of_images=min(max(int(input_data.get("number_of_images", 1)), 1), 4),
+            output_path=str(input_data.get("output_path") or ""),
+            negative_prompt=str(input_data.get("negative_prompt") or ""),
+            reference_images=list(input_data.get("reference_images") or []),
+            safety_filter_level=str(
+                input_data.get("safety_filter_level") or "block_medium_and_above"
+            ),
         )
-        if warnings:
-            message += " Warnings: " + " ".join(warnings)
-
         return {
             "status": "success",
-            "image_paths": image_paths,
-            "prompt_used": prompt,
-            "resolution": resolution,
-            "message": message,
+            "image_paths": paths,
+            "message": f"Generated {len(paths)} image(s) via {current_provider}.",
         }
-
     except Exception as e:
-        error_message = str(e)
-
-        if provider == "gemini":
-            if "quota" in error_message.lower() or "rate" in error_message.lower():
-                error_message = (
-                    f"Gemini API rate limit or quota exceeded: {error_message}"
-                )
-            elif "invalid" in error_message.lower() and "key" in error_message.lower():
-                error_message = f"Invalid Gemini API key: {error_message}. Please verify your Google API key is correct."
-            elif (
-                "permission" in error_message.lower()
-                or "access" in error_message.lower()
-            ):
-                error_message = f"Gemini API access denied: {error_message}. Ensure your API key has access to the Nano Banana 2 model."
-            elif (
-                "safety" in error_message.lower() or "blocked" in error_message.lower()
-            ):
-                error_message = f"Content blocked by Gemini safety filters: {error_message}. Try modifying your prompt."
-            elif "not found" in error_message.lower() or "404" in error_message:
-                error_message = f"Gemini model not available: {error_message}. The gemini-3.1-flash-image-preview model may not be accessible with your API key. Try using Google AI Studio to verify access."
-        else:
-            if (
-                "billing" in error_message.lower()
-                or "insufficient_quota" in error_message.lower()
-                or "rate" in error_message.lower()
-            ):
-                error_message = (
-                    f"OpenAI API rate limit or quota exceeded: {error_message}"
-                )
-            elif "invalid_api_key" in error_message.lower() or (
-                "invalid" in error_message.lower() and "key" in error_message.lower()
-            ):
-                error_message = f"Invalid OpenAI API key: {error_message}. Please verify your OpenAI API key is correct."
-            elif (
-                "content_policy" in error_message.lower()
-                or "safety" in error_message.lower()
-                or "blocked" in error_message.lower()
-            ):
-                error_message = f"Content blocked by OpenAI safety policy: {error_message}. Try modifying your prompt."
-            elif "not found" in error_message.lower() or "404" in error_message:
-                error_message = f"OpenAI model not available: {error_message}. The gpt-image-2 model may not be accessible with your API key."
-
         return {
             "status": "error",
             "image_paths": [],
-            "prompt_used": prompt,
-            "resolution": resolution,
-            "message": error_message,
+            "message": str(e),
         }

--- a/app/image_gen_interface.py
+++ b/app/image_gen_interface.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+"""
+Image generation interface for CraftBot.
+
+Re-exports ImageGenInterface from agent_core with CraftBot-specific hooks
+for state access (using STATE singleton) and usage reporting.
+"""
+
+from typing import Optional
+
+from agent_core.core.impl.image_gen import ImageGenInterface as _ImageGenInterface
+from agent_core.core.hooks.types import UsageEventData
+from app.state.agent_state import get_session_props
+
+
+def _get_token_count() -> int:
+    return get_session_props().get_property("token_count", 0)
+
+
+def _set_token_count(count: int) -> None:
+    get_session_props().set_property("token_count", count)
+
+
+async def _report_usage(event: UsageEventData) -> None:
+    from app.usage import get_usage_reporter
+
+    await get_usage_reporter().report(event)
+
+
+class ImageGenInterface(_ImageGenInterface):
+    """ImageGenInterface configured for CraftBot's STATE singleton.
+
+    Automatically injects the get_token_count and set_token_count hooks
+    that use CraftBot's global STATE object.
+    """
+
+    def __init__(
+        self,
+        *,
+        provider: Optional[str] = None,
+        model: Optional[str] = None,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        deferred: bool = False,
+    ) -> None:
+        super().__init__(
+            provider=provider,
+            model=model,
+            api_key=api_key,
+            base_url=base_url,
+            deferred=deferred,
+            get_token_count=_get_token_count,
+            set_token_count=_set_token_count,
+            report_usage=_report_usage,
+        )

--- a/app/internal_action_interface.py
+++ b/app/internal_action_interface.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import Dict, Any, Optional, List, TYPE_CHECKING
 from app.llm import LLMInterface, LLMCallType
 from app.vlm_interface import VLMInterface
+from app.image_gen_interface import ImageGenInterface
 from app.task.task_manager import TaskManager
 from app.task import Task
 from app.state.state_manager import StateManager
@@ -43,6 +44,7 @@ class InternalActionInterface:
     task_manager: Optional[TaskManager] = None
     state_manager: Optional[StateManager] = None
     vlm_interface: Optional[VLMInterface] = None
+    image_gen_interface: Optional[ImageGenInterface] = None
     context_engine: Optional["ContextEngine"] = None
     gui_module: Optional["GUIModule"] = None
     memory_manager: Optional[MemoryManager] = None
@@ -57,6 +59,7 @@ class InternalActionInterface:
         task_manager: TaskManager,
         state_manager: StateManager,
         vlm_interface: Optional[VLMInterface] = None,
+        image_gen_interface: Optional[ImageGenInterface] = None,
         context_engine: Optional["ContextEngine"] = None,
         gui_module: Optional["GUIModule"] = None,
         memory_manager: MemoryManager | None = None,
@@ -74,6 +77,7 @@ class InternalActionInterface:
         cls.task_manager = task_manager
         cls.state_manager = state_manager
         cls.vlm_interface = vlm_interface
+        cls.image_gen_interface = image_gen_interface
         cls.context_engine = context_engine
         cls.gui_module = gui_module
         cls.memory_manager = memory_manager
@@ -109,6 +113,24 @@ class InternalActionInterface:
                 "InternalActionInterface not initialized with VLMInterface."
             )
         return cls.vlm_interface.describe_image(image_path, user_prompt=prompt)
+
+    @classmethod
+    def generate_image(cls, **kwargs) -> List[str]:
+        """Generate image(s) from a prompt using the image generation interface.
+
+        Delegates all arguments to ImageGenInterface.generate_image().
+
+        Returns:
+            List of absolute file paths to the generated images.
+
+        Raises:
+            RuntimeError: If image_gen_interface is not initialized or generation fails.
+        """
+        if cls.image_gen_interface is None:
+            raise RuntimeError(
+                "InternalActionInterface not initialized with ImageGenInterface."
+            )
+        return cls.image_gen_interface.generate_image(**kwargs)
 
     @classmethod
     def perform_ocr(cls, image_path: str, user_prompt: Optional[str] = None) -> dict:

--- a/app/main.py
+++ b/app/main.py
@@ -65,10 +65,12 @@ ConfigRegistry.register_workspace_root(str(get_project_root()))
 from app.config import (
     get_llm_provider,
     get_vlm_provider,
+    get_image_gen_provider,
     get_api_key,
     get_base_url,
     get_llm_model,
     get_vlm_model,
+    get_image_gen_model,
 )
 from app.agent_base import AgentBase
 
@@ -116,7 +118,8 @@ def _initial_settings() -> tuple:
     """Determine initial provider, API key, and base URL from settings.json.
 
     Returns:
-        Tuple of (provider, api_key, base_url, model, vlm_provider, vlm_model, has_valid_key)
+        Tuple of (provider, api_key, base_url, model, vlm_provider, vlm_model,
+        image_gen_provider, image_gen_model, has_valid_key)
         where has_valid_key indicates if a working API key was found.
     """
     # Read directly from settings.json
@@ -126,11 +129,13 @@ def _initial_settings() -> tuple:
     model = get_llm_model()  # None → use registry default for the provider
     vlm_prov = get_vlm_provider()
     vlm_mod = get_vlm_model()
+    img_prov = get_image_gen_provider()
+    img_mod = get_image_gen_model()
 
     # Remote (Ollama) doesn't require API key
     has_key = bool(api_key) or provider == "remote"
 
-    return provider, api_key, base_url, model, vlm_prov, vlm_mod, has_key
+    return provider, api_key, base_url, model, vlm_prov, vlm_mod, img_prov, img_mod, has_key
 
 
 async def main_async() -> None:
@@ -139,7 +144,7 @@ async def main_async() -> None:
     browser_mode = cli_args.get("browser", False)
 
     # Get settings from settings.json
-    provider, api_key, base_url, model, vlm_prov, vlm_mod, has_valid_key = (
+    provider, api_key, base_url, model, vlm_prov, vlm_mod, img_prov, img_mod, has_valid_key = (
         _initial_settings()
     )
 
@@ -166,6 +171,8 @@ async def main_async() -> None:
         llm_model=model,
         vlm_provider=vlm_prov,
         vlm_model=vlm_mod,
+        image_gen_provider=img_prov,
+        image_gen_model=img_mod,
         deferred_init=not has_valid_key,
     )
 

--- a/app/ui_layer/adapters/browser_adapter.py
+++ b/app/ui_layer/adapters/browser_adapter.py
@@ -4659,6 +4659,7 @@ A quick Q&A will now begin to understand your objectives to serve you better:"""
         try:
             new_provider = data.get("llmProvider")
             vlm_provider = data.get("vlmProvider")
+            image_gen_provider = data.get("imageGenProvider")
             api_key = data.get("apiKey")
             provider_for_key = data.get("providerForKey")
             base_url = data.get("baseUrl")
@@ -4721,8 +4722,10 @@ A quick Q&A will now begin to understand your objectives to serve you better:"""
             result = update_model_settings(
                 llm_provider=new_provider,
                 vlm_provider=vlm_provider,
+                image_gen_provider=image_gen_provider,
                 llm_model=data.get("llmModel"),
                 vlm_model=data.get("vlmModel"),
+                image_gen_model=data.get("imageGenModel"),
                 api_key=api_key,
                 provider_for_key=provider_for_key,
                 base_url=base_url,
@@ -4742,6 +4745,20 @@ A quick Q&A will now begin to understand your objectives to serve you better:"""
                     logger.warning(f"[BROWSER] Failed to reinitialize LLM: {e}")
                     result["warning"] = (
                         f"Settings saved but LLM reinitialization failed: {e}"
+                    )
+
+            # Reinitialize image gen interface when its provider changes
+            if result.get("success") and image_gen_provider:
+                try:
+                    agent = self._controller.agent
+                    agent.reinitialize_image_gen(image_gen_provider)
+                    logger.info(
+                        f"[BROWSER] Image gen reinitialized with provider: {image_gen_provider}"
+                    )
+                except Exception as e:
+                    logger.warning(f"[BROWSER] Failed to reinitialize image gen: {e}")
+                    result["warning"] = result.get("warning") or (
+                        f"Settings saved but image gen reinitialization failed: {e}"
                     )
 
             await self._broadcast(

--- a/app/ui_layer/adapters/browser_adapter.py
+++ b/app/ui_layer/adapters/browser_adapter.py
@@ -4766,6 +4766,20 @@ A quick Q&A will now begin to understand your objectives to serve you better:"""
                     )
                     return
 
+            # Capture the current image-gen provider/model BEFORE saving, so a
+            # failed reinitialize below can roll the persisted values back and
+            # keep settings.json consistent with the still-live interface.
+            prev_image_gen_provider = None
+            prev_image_gen_model = None
+            if image_gen_provider:
+                from app.config import (
+                    get_image_gen_provider as _get_ig_provider,
+                    get_image_gen_model as _get_ig_model,
+                )
+
+                prev_image_gen_provider = _get_ig_provider()
+                prev_image_gen_model = _get_ig_model()
+
             # Step 3: Now save settings (validation and connection test passed)
             result = update_model_settings(
                 llm_provider=new_provider,
@@ -4795,19 +4809,38 @@ A quick Q&A will now begin to understand your objectives to serve you better:"""
                         f"Settings saved but LLM reinitialization failed: {e}"
                     )
 
-            # Reinitialize image gen interface when its provider changes
+            # Reinitialize image gen interface when its provider changes.
+            # Settings are already persisted above, and reinitialize_image_gen
+            # only swaps the live interface on success — so if it fails (e.g.
+            # the new provider has no API key) we must roll the saved image-gen
+            # provider/model back to match the still-live interface. Otherwise
+            # settings.json would advertise a provider the running interface
+            # can't serve.
             if result.get("success") and image_gen_provider:
+                reinit_ok = False
                 try:
                     agent = self._controller.agent
-                    agent.reinitialize_image_gen(image_gen_provider)
+                    reinit_ok = agent.reinitialize_image_gen(image_gen_provider)
+                except Exception as e:
+                    logger.warning(f"[BROWSER] Failed to reinitialize image gen: {e}")
+
+                if reinit_ok:
                     logger.info(
                         f"[BROWSER] Image gen reinitialized with provider: {image_gen_provider}"
                     )
-                except Exception as e:
-                    logger.warning(f"[BROWSER] Failed to reinitialize image gen: {e}")
-                    result["warning"] = result.get("warning") or (
-                        f"Settings saved but image gen reinitialization failed: {e}"
+                else:
+                    # Roll persisted image-gen settings back to the previous
+                    # (still-live) values to avoid a settings/interface mismatch.
+                    update_model_settings(
+                        image_gen_provider=prev_image_gen_provider,
+                        image_gen_model=prev_image_gen_model,
                     )
+                    msg = (
+                        f"Image generation provider '{image_gen_provider}' could not be "
+                        f"initialized — check its API key. Kept '{prev_image_gen_provider}'."
+                    )
+                    logger.warning(f"[BROWSER] {msg}")
+                    result["warning"] = result.get("warning") or msg
 
             await self._broadcast(
                 {

--- a/app/ui_layer/browser/frontend/src/pages/Settings/ModelSettings.tsx
+++ b/app/ui_layer/browser/frontend/src/pages/Settings/ModelSettings.tsx
@@ -30,6 +30,8 @@ import {
   selectModelHasLoadedProviders,
   selectModelHasLoadedSettings,
   selectModelHasLoadedSlowMode,
+  selectImageGenProvider,
+  selectCurrentImageGenModel,
 } from '../../store/selectors/modelSettings'
 import { getOllamaInstallPercent } from '../../utils/ollamaInstall'
 import {
@@ -47,7 +49,9 @@ interface ProviderInfo {
   base_url_env?: string
   llm_model: string | null
   vlm_model: string | null
+  image_gen_model: string | null
   has_vlm: boolean
+  has_image_gen: boolean
   supports_catalog?: boolean
   is_bedrock?: boolean
 }
@@ -88,6 +92,8 @@ export function ModelSettings() {
   const ollamaModels = useAppSelector(selectOllamaModels)
   const ollamaAvailable = useAppSelector(selectOllamaAvailable)
   const awsCredentialsStatus = useAppSelector(selectAwsCredentials)
+  const imageGenProvider = useAppSelector(selectImageGenProvider)
+  const currentImageGenModel = useAppSelector(selectCurrentImageGenModel)
   const hasLoadedProviders = useAppSelector(selectModelHasLoadedProviders)
   const hasLoadedSettings = useAppSelector(selectModelHasLoadedSettings)
   const hasLoadedSlowMode = useAppSelector(selectModelHasLoadedSlowMode)
@@ -110,6 +116,13 @@ export function ModelSettings() {
   const [newAwsSecretAccessKey, setNewAwsSecretAccessKey] = useState('')
   const [newAwsSessionToken, setNewAwsSessionToken] = useState('')
   const [newAwsRegion, setNewAwsRegion] = useState('')
+
+  // Image generation form state (transient — local).
+  const [newImageGenProvider, setNewImageGenProvider] = useState('')
+  const [newImageGenModel, setNewImageGenModel] = useState('')
+  const [newImageGenApiKey, setNewImageGenApiKey] = useState('')
+  const [imageGenHasChanges, setImageGenHasChanges] = useState(false)
+  const [isImageGenSaving, setIsImageGenSaving] = useState(false)
 
   // UI state (transient — local).
   const [isSaving, setIsSaving] = useState(false)
@@ -167,6 +180,7 @@ export function ModelSettings() {
       onMessage('model_settings_update', (data: unknown) => {
         const d = data as { success: boolean; error?: string }
         setIsSaving(false)
+        setIsImageGenSaving(false)
         if (d.success) {
           setNewApiKey('')
           setNewBaseUrl('')
@@ -177,6 +191,10 @@ export function ModelSettings() {
           setNewAwsSessionToken('')
           setNewAwsRegion('')
           setHasChanges(false)
+          setNewImageGenProvider('')
+          setNewImageGenModel('')
+          setNewImageGenApiKey('')
+          setImageGenHasChanges(false)
           showToast('success', 'Settings saved')
         } else {
           showToast('error', d.error || 'Failed to save')
@@ -417,6 +435,19 @@ export function ModelSettings() {
         vlmModel: newVlmModel || currentVlmModel || undefined,
       })
     }
+  }
+
+  const handleImageGenSave = () => {
+    setIsImageGenSaving(true)
+    const effectiveProvider = newImageGenProvider || imageGenProvider
+    send('model_settings_update', {
+      imageGenProvider: effectiveProvider,
+      imageGenModel: newImageGenModel || currentImageGenModel || undefined,
+      ...(newImageGenApiKey ? {
+        apiKey: newImageGenApiKey,
+        providerForKey: effectiveProvider,
+      } : {}),
+    })
   }
 
   const handleDownloadModelClick = () => {
@@ -889,6 +920,90 @@ export function ModelSettings() {
               )}
             </Button>
           </div>
+
+          {/* Image Generation */}
+          <hr style={{ border: 'none', borderTop: '1px solid var(--border-primary)', margin: 'var(--space-4) 0' }} />
+          <div className={styles.sectionHeader} style={{ marginBottom: 'var(--space-3)' }}>
+            <h3>Image Generation</h3>
+            <p>Configure the provider used for image generation</p>
+          </div>
+          {(() => {
+            const imageGenProviders = providers.filter(p => p.has_image_gen)
+            const effectiveImgProvider = newImageGenProvider || imageGenProvider
+            const imgProviderInfo = imageGenProviders.find(p => p.id === effectiveImgProvider)
+            return (
+              <div className={styles.settingsForm} style={{ paddingTop: 0 }}>
+                <div className={styles.formGroup}>
+                  <label>Provider</label>
+                  <select
+                    value={effectiveImgProvider}
+                    onChange={(e) => {
+                      const sel = imageGenProviders.find(p => p.id === e.target.value)
+                      setNewImageGenProvider(e.target.value)
+                      setNewImageGenModel(sel?.image_gen_model || '')
+                      setNewImageGenApiKey('')
+                      setImageGenHasChanges(true)
+                    }}
+                  >
+                    {imageGenProviders.map(p => (
+                      <option key={p.id} value={p.id}>{p.name}</option>
+                    ))}
+                  </select>
+                </div>
+
+                {/* API Key for image gen provider */}
+                {imgProviderInfo?.requires_api_key && (
+                  <div className={styles.formGroup}>
+                    <label>
+                      API Key
+                      {apiKeys[effectiveImgProvider]?.has_key ? (
+                        <Badge variant="success" style={{ marginLeft: 8 }}>Configured</Badge>
+                      ) : (
+                        <Badge variant="warning" style={{ marginLeft: 8 }}>Required</Badge>
+                      )}
+                    </label>
+                    {apiKeys[effectiveImgProvider]?.has_key && (
+                      <div className={styles.maskedKey}>{apiKeys[effectiveImgProvider].masked_key}</div>
+                    )}
+                    <input
+                      type="password"
+                      value={newImageGenApiKey}
+                      onChange={(e) => { setNewImageGenApiKey(e.target.value); setImageGenHasChanges(true) }}
+                      placeholder={apiKeys[effectiveImgProvider]?.has_key ? 'Enter new key to replace...' : 'Enter API key...'}
+                    />
+                  </div>
+                )}
+
+                {/* Model override */}
+                <div className={styles.formGroup}>
+                  <label>Model</label>
+                  <input
+                    type="text"
+                    value={newImageGenModel || currentImageGenModel || ''}
+                    onChange={(e) => { setNewImageGenModel(e.target.value); setImageGenHasChanges(true) }}
+                    placeholder={imgProviderInfo?.image_gen_model || 'Default model'}
+                  />
+                </div>
+
+                <div className={styles.sectionFooter} style={{ borderTop: 'none', paddingTop: 0 }}>
+                  <Button
+                    variant="primary"
+                    onClick={handleImageGenSave}
+                    disabled={isImageGenSaving || !imageGenHasChanges}
+                  >
+                    {isImageGenSaving ? (
+                      <>
+                        <Loader2 size={14} className={styles.spinning} />
+                        Saving...
+                      </>
+                    ) : (
+                      'Save'
+                    )}
+                  </Button>
+                </div>
+              </div>
+            )
+          })()}
 
           {/* Slow Mode */}
           <hr style={{ border: 'none', borderTop: '1px solid var(--border-primary)', margin: 'var(--space-4) 0' }} />

--- a/app/ui_layer/browser/frontend/src/store/selectors/modelSettings.ts
+++ b/app/ui_layer/browser/frontend/src/store/selectors/modelSettings.ts
@@ -6,6 +6,8 @@ export const selectApiKeys = (state: RootState) => state.modelSettings.apiKeys
 export const selectBaseUrls = (state: RootState) => state.modelSettings.baseUrls
 export const selectCurrentLlmModel = (state: RootState) => state.modelSettings.currentLlmModel
 export const selectCurrentVlmModel = (state: RootState) => state.modelSettings.currentVlmModel
+export const selectImageGenProvider = (state: RootState) => state.modelSettings.imageGenProvider
+export const selectCurrentImageGenModel = (state: RootState) => state.modelSettings.currentImageGenModel
 export const selectSlowModeEnabled = (state: RootState) => state.modelSettings.slowModeEnabled
 export const selectOllamaModels = (state: RootState) => state.modelSettings.ollamaModels
 export const selectOllamaAvailable = (state: RootState) => state.modelSettings.ollamaAvailable

--- a/app/ui_layer/browser/frontend/src/store/slices/modelSettingsSlice.ts
+++ b/app/ui_layer/browser/frontend/src/store/slices/modelSettingsSlice.ts
@@ -9,7 +9,9 @@ export interface ProviderInfo {
   base_url_env?: string
   llm_model: string | null
   vlm_model: string | null
+  image_gen_model: string | null
   has_vlm: boolean
+  has_image_gen: boolean
   supports_catalog?: boolean
   is_bedrock?: boolean
 }
@@ -30,10 +32,12 @@ export interface AwsCredentialsStatus {
 interface ModelSettingsState {
   providers: ProviderInfo[]
   provider: string
+  imageGenProvider: string
   apiKeys: Record<string, ApiKeyStatus>
   baseUrls: Record<string, string>
   currentLlmModel: string
   currentVlmModel: string
+  currentImageGenModel: string
   slowModeEnabled: boolean
   ollamaModels: string[]
   ollamaAvailable: boolean | null
@@ -46,10 +50,12 @@ interface ModelSettingsState {
 const initialState: ModelSettingsState = {
   providers: [],
   provider: 'anthropic',
+  imageGenProvider: 'openai',
   apiKeys: {},
   baseUrls: {},
   currentLlmModel: '',
   currentVlmModel: '',
+  currentImageGenModel: '',
   slowModeEnabled: false,
   ollamaModels: [],
   ollamaAvailable: null,
@@ -69,15 +75,19 @@ const modelSettingsSlice = createSlice({
     },
     setSettings(state, action: PayloadAction<{
       provider: string
+      imageGenProvider: string
       llmModel: string
       vlmModel: string
+      imageGenModel: string
       apiKeys: Record<string, ApiKeyStatus>
       baseUrls: Record<string, string>
       awsCredentials?: AwsCredentialsStatus | null
     }>) {
       state.provider = action.payload.provider
+      state.imageGenProvider = action.payload.imageGenProvider
       state.currentLlmModel = action.payload.llmModel
       state.currentVlmModel = action.payload.vlmModel
+      state.currentImageGenModel = action.payload.imageGenModel
       state.apiKeys = action.payload.apiKeys
       state.baseUrls = action.payload.baseUrls
       if (action.payload.awsCredentials !== undefined) {
@@ -91,11 +101,17 @@ const modelSettingsSlice = createSlice({
     setProvider(state, action: PayloadAction<string>) {
       state.provider = action.payload
     },
+    setImageGenProvider(state, action: PayloadAction<string>) {
+      state.imageGenProvider = action.payload
+    },
     setCurrentLlmModel(state, action: PayloadAction<string>) {
       state.currentLlmModel = action.payload
     },
     setCurrentVlmModel(state, action: PayloadAction<string>) {
       state.currentVlmModel = action.payload
+    },
+    setCurrentImageGenModel(state, action: PayloadAction<string>) {
+      state.currentImageGenModel = action.payload
     },
     setApiKeys(state, action: PayloadAction<Record<string, ApiKeyStatus>>) {
       state.apiKeys = action.payload
@@ -118,8 +134,10 @@ export const {
   setProviders,
   setSettings,
   setProvider,
+  setImageGenProvider,
   setCurrentLlmModel,
   setCurrentVlmModel,
+  setCurrentImageGenModel,
   setApiKeys,
   setBaseUrls,
   setSlowModeEnabled,
@@ -138,8 +156,10 @@ register('model_settings_get', (data, dispatch) => {
   const d = data as {
     success: boolean
     llm_provider: string
+    image_gen_provider: string
     llm_model: string | null
     vlm_model: string | null
+    image_gen_model: string | null
     api_keys: Record<string, ApiKeyStatus>
     base_urls: Record<string, string>
     aws_credentials?: AwsCredentialsStatus | null
@@ -147,8 +167,10 @@ register('model_settings_get', (data, dispatch) => {
   if (d.success) {
     dispatch(setSettings({
       provider: d.llm_provider || 'anthropic',
+      imageGenProvider: d.image_gen_provider || 'openai',
       llmModel: d.llm_model || '',
       vlmModel: d.vlm_model || '',
+      imageGenModel: d.image_gen_model || '',
       apiKeys: d.api_keys || {},
       baseUrls: d.base_urls || {},
       awsCredentials: d.aws_credentials ?? null,
@@ -160,18 +182,25 @@ register('model_settings_update', (data, dispatch) => {
   const d = data as {
     success: boolean
     llm_provider?: string
+    image_gen_provider?: string
     llm_model?: string | null
     vlm_model?: string | null
+    image_gen_model?: string | null
     api_keys?: Record<string, ApiKeyStatus>
     base_urls?: Record<string, string>
     aws_credentials?: AwsCredentialsStatus | null
   }
   if (!d.success) return
   if (d.llm_provider) dispatch(setProvider(d.llm_provider))
+  // Always update imageGenProvider when the field is present (even on partial saves);
+  // using `!== undefined` mirrors model_settings_get so version-mismatched backends
+  // that omit the field don't silently leave the UI showing a stale provider.
+  if (d.image_gen_provider !== undefined) dispatch(setImageGenProvider(d.image_gen_provider || 'openai'))
   if (d.api_keys) dispatch(setApiKeys(d.api_keys))
   if (d.base_urls) dispatch(setBaseUrls(d.base_urls))
   if (d.llm_model !== undefined) dispatch(setCurrentLlmModel(d.llm_model || ''))
   if (d.vlm_model !== undefined) dispatch(setCurrentVlmModel(d.vlm_model || ''))
+  if (d.image_gen_model !== undefined) dispatch(setCurrentImageGenModel(d.image_gen_model || ''))
   if (d.aws_credentials !== undefined) dispatch(setAwsCredentials(d.aws_credentials))
 })
 

--- a/app/ui_layer/onboarding/controller.py
+++ b/app/ui_layer/onboarding/controller.py
@@ -17,6 +17,7 @@ from app.onboarding.interfaces.steps import (
 )
 from app.onboarding import onboarding_manager
 from app.ui_layer.settings.provider_settings import save_settings_to_json
+from agent_core.utils.logger import logger
 
 if TYPE_CHECKING:
     from app.ui_layer.controller.ui_controller import UIController
@@ -243,88 +244,21 @@ class OnboardingFlowController:
         self._state.completed = True
 
         # Extract collected data
-        provider = self._state.collected_data.get("provider", "openai")
-        raw_api_key_value = self._state.collected_data.get("api_key", "")
-        # Proxied providers (moonshot/minimax) submit {api_key, via, or_model?}
-        if isinstance(raw_api_key_value, dict):
-            api_key = raw_api_key_value.get("api_key", "")
-            submitted_or_model = raw_api_key_value.get("or_model", "")
-            proxied_via = raw_api_key_value.get("via", "openrouter")
-        else:
-            api_key = raw_api_key_value
-            submitted_or_model = ""
-            proxied_via = "direct"
-        agent_name_data = self._state.collected_data.get("agent_name", "Agent")
-        # Agent name step is a form step, so the collected value is a dict.
-        # Accept plain strings too for backward compatibility.
-        if isinstance(agent_name_data, dict):
-            agent_name = agent_name_data.get("agent_name") or "Agent"
-        else:
-            agent_name = agent_name_data or "Agent"
-        # The integrations step is informational — selected integrations are
-        # surfaced for awareness, but OAuth/token connection happens in
-        # Settings → Integrations after onboarding.
-        selected_skills = self._state.collected_data.get("skills", [])
+        data = self._state.collected_data
+        provider = data.get("provider", "openai")
+        api_key, proxied_via, submitted_or_model = self._parse_api_key(
+            data.get("api_key", "")
+        )
+        agent_name = self._parse_agent_name(data.get("agent_name", "Agent"))
+        selected_skills = data.get("skills", [])
 
-        # Save provider configuration to settings.json
-        from app.onboarding.interfaces.steps import ApiKeyStep
-
-        if provider == "remote":
-            # api_key holds the Ollama base URL for the remote provider
-            remote_url = api_key or "http://localhost:11434"
-            from app.ui_layer.settings.provider_settings import save_remote_endpoint
-
-            save_remote_endpoint(remote_url)
-        elif provider in ApiKeyStep.OPENROUTER_PROXIED and api_key:
-            if proxied_via == "openrouter":
-                # User chose to go via OpenRouter — save key as openrouter and set model slug.
-                if submitted_or_model:
-                    or_model = submitted_or_model
-                else:
-                    from agent_core.core.models.factory import (
-                        _to_openrouter_slug,
-                        _OR_MODEL_MAP,
-                    )
-                    from app.models import MODEL_REGISTRY, InterfaceType
-
-                    native_model = MODEL_REGISTRY.get(provider, {}).get(
-                        InterfaceType.LLM, ""
-                    )
-                    or_model = _OR_MODEL_MAP.get(provider, {}).get(
-                        native_model
-                    ) or _to_openrouter_slug(provider, native_model)
-                save_settings_to_json("openrouter", api_key)
-                from app.ui_layer.settings.model_settings import update_model_settings
-
-                update_model_settings(llm_model=or_model, vlm_model=or_model)
-                provider = "openrouter"
-            else:
-                # User has direct access — save key under the native provider.
-                save_settings_to_json(provider, api_key)
-        elif provider and api_key:
-            save_settings_to_json(provider, api_key)
-
-        if provider:
-            # Reinitialize the LLM with the new provider settings
-            if self._controller and self._controller.agent:
-                try:
-                    success = self._controller.agent.reinitialize_llm(provider)
-                    if success:
-                        from agent_core.utils.logger import logger
-
-                        logger.info(
-                            f"[ONBOARDING] Reinitialized LLM with provider: {provider}"
-                        )
-                    else:
-                        from agent_core.utils.logger import logger
-
-                        logger.warning(
-                            f"[ONBOARDING] Failed to reinitialize LLM with provider: {provider}"
-                        )
-                except Exception as e:
-                    from agent_core.utils.logger import logger
-
-                    logger.warning(f"[ONBOARDING] Error reinitializing LLM: {e}")
+        # Persist the provider + key (may reassign provider, e.g. a
+        # geo-restricted provider routed via OpenRouter), then activate it on
+        # the live LLM/VLM and image-gen interfaces.
+        provider = self._save_provider(
+            provider, api_key, proxied_via, submitted_or_model
+        )
+        self._activate_provider(provider)
 
         # Update controller state if available
         if self._controller:
@@ -357,8 +291,6 @@ class OnboardingFlowController:
             agent_profile_picture=onboarding_manager.state.agent_profile_picture,
         )
         if not success:
-            from agent_core.utils.logger import logger
-
             logger.error(
                 "[ONBOARDING] Failed to persist hard onboarding state — "
                 "onboarding will re-trigger on next launch. "
@@ -372,6 +304,117 @@ class OnboardingFlowController:
             import asyncio
 
             asyncio.create_task(self._trigger_soft_onboarding_async())
+
+    @staticmethod
+    def _parse_api_key(raw: Any) -> tuple[str, str, str]:
+        """Normalize the api_key step value.
+
+        Proxied providers (moonshot/minimax) submit a dict
+        ``{api_key, via, or_model?}``; everyone else submits a plain string.
+        Returns ``(api_key, proxied_via, submitted_or_model)``.
+        """
+        if isinstance(raw, dict):
+            return (
+                raw.get("api_key", ""),
+                raw.get("via", "openrouter"),
+                raw.get("or_model", ""),
+            )
+        return raw, "direct", ""
+
+    @staticmethod
+    def _parse_agent_name(raw: Any) -> str:
+        """The agent-name step is a form (dict); accept plain strings too."""
+        if isinstance(raw, dict):
+            return raw.get("agent_name") or "Agent"
+        return raw or "Agent"
+
+    def _save_provider(
+        self, provider: str, api_key: str, proxied_via: str, submitted_or_model: str
+    ) -> str:
+        """Persist the chosen provider + key to settings.json.
+
+        Returns the effective provider, which differs from the input only when
+        a geo-restricted provider (moonshot/minimax) is routed via OpenRouter.
+        """
+        if provider == "remote":
+            # api_key holds the Ollama base URL for the remote provider.
+            from app.ui_layer.settings.provider_settings import save_remote_endpoint
+
+            save_remote_endpoint(api_key or "http://localhost:11434")
+            return provider
+
+        if provider in ApiKeyStep.OPENROUTER_PROXIED and api_key:
+            if proxied_via != "openrouter":
+                # Direct access — save the key under the native provider.
+                save_settings_to_json(provider, api_key)
+                return provider
+            # Routed via OpenRouter — save the key as openrouter + set the slug.
+            or_model = submitted_or_model or self._default_openrouter_model(provider)
+            save_settings_to_json("openrouter", api_key)
+            from app.ui_layer.settings.model_settings import update_model_settings
+
+            update_model_settings(llm_model=or_model, vlm_model=or_model)
+            return "openrouter"
+
+        if provider and api_key:
+            save_settings_to_json(provider, api_key)
+        return provider
+
+    @staticmethod
+    def _default_openrouter_model(provider: str) -> str:
+        """Map a native provider's default LLM to its OpenRouter slug."""
+        from agent_core.core.models.factory import _to_openrouter_slug, _OR_MODEL_MAP
+        from app.models import MODEL_REGISTRY, InterfaceType
+
+        native_model = MODEL_REGISTRY.get(provider, {}).get(InterfaceType.LLM, "")
+        return _OR_MODEL_MAP.get(provider, {}).get(native_model) or _to_openrouter_slug(
+            provider, native_model
+        )
+
+    def _activate_provider(self, provider: str) -> None:
+        """Activate the provider on the live interfaces: reinitialize LLM/VLM,
+        and point image generation at it when the provider can generate images.
+
+        Settings persistence happens here too (image_gen_provider) so it applies
+        even when no agent is attached (e.g. headless); the reinitialize calls
+        are skipped without an agent.
+        """
+        if not provider:
+            return
+        agent = self._controller.agent if self._controller else None
+
+        if agent:
+            try:
+                if agent.reinitialize_llm(provider):
+                    logger.info(
+                        f"[ONBOARDING] Reinitialized LLM with provider: {provider}"
+                    )
+                else:
+                    logger.warning(
+                        f"[ONBOARDING] Failed to reinitialize LLM with provider: {provider}"
+                    )
+            except Exception as e:
+                logger.warning(f"[ONBOARDING] Error reinitializing LLM: {e}")
+
+        # Point image generation at the chosen provider when it can generate
+        # images (OpenAI/Gemini), reusing the key just entered — so image gen
+        # works out of the box instead of being stranded on the default with no
+        # key. Image-incapable providers (Anthropic, DeepSeek, Ollama, …) are
+        # left on the existing image-gen default.
+        try:
+            from app.models import MODEL_REGISTRY, InterfaceType
+
+            if MODEL_REGISTRY.get(provider, {}).get(InterfaceType.IMAGE_GEN):
+                from app.ui_layer.settings.model_settings import update_model_settings
+
+                update_model_settings(image_gen_provider=provider)
+                if agent:
+                    agent.reinitialize_image_gen(provider)
+                logger.info(
+                    f"[ONBOARDING] Image generation set to provider: {provider}"
+                )
+        except Exception as e:
+            logger.warning(f"[ONBOARDING] Error configuring image gen: {e}")
 
     async def _trigger_soft_onboarding_async(self) -> None:
         """

--- a/app/ui_layer/settings/model_settings.py
+++ b/app/ui_layer/settings/model_settings.py
@@ -175,6 +175,7 @@ def get_available_providers() -> Dict[str, Any]:
 
             llm_model = provider_models.get(InterfaceType.LLM)
             vlm_model = provider_models.get(InterfaceType.VLM)
+            image_gen_model = provider_models.get(InterfaceType.IMAGE_GEN)
 
             providers.append(
                 {
@@ -186,6 +187,8 @@ def get_available_providers() -> Dict[str, Any]:
                     "llm_model": llm_model,
                     "vlm_model": vlm_model,
                     "has_vlm": vlm_model is not None,
+                    "image_gen_model": image_gen_model,
+                    "has_image_gen": image_gen_model is not None,
                     "supports_catalog": info.get("supports_catalog", False),
                     "is_bedrock": info.get("is_bedrock", False),
                 }
@@ -222,10 +225,12 @@ def get_model_settings() -> Dict[str, Any]:
         # Get configured providers (settings.json is the single source of truth)
         llm_provider = model_settings.get("llm_provider", "anthropic")
         vlm_provider = model_settings.get("vlm_provider", llm_provider)
+        image_gen_provider = model_settings.get("image_gen_provider", "openai")
 
         # Get custom models if set
         llm_model = model_settings.get("llm_model")
         vlm_model = model_settings.get("vlm_model")
+        image_gen_model = model_settings.get("image_gen_model")
 
         # Check API key status for each provider (settings.json only)
         api_keys = {}
@@ -292,8 +297,10 @@ def get_model_settings() -> Dict[str, Any]:
             "success": True,
             "llm_provider": llm_provider,
             "vlm_provider": vlm_provider,
+            "image_gen_provider": image_gen_provider,
             "llm_model": llm_model,
             "vlm_model": vlm_model,
+            "image_gen_model": image_gen_model,
             "api_keys": api_keys,
             "base_urls": base_urls,
             "aws_credentials": aws_creds_status,
@@ -308,8 +315,10 @@ def get_model_settings() -> Dict[str, Any]:
 def update_model_settings(
     llm_provider: Optional[str] = None,
     vlm_provider: Optional[str] = None,
+    image_gen_provider: Optional[str] = None,
     llm_model: Optional[str] = None,
     vlm_model: Optional[str] = None,
+    image_gen_model: Optional[str] = None,
     api_key: Optional[str] = None,
     provider_for_key: Optional[str] = None,
     base_url: Optional[str] = None,
@@ -367,11 +376,31 @@ def update_model_settings(
             if vlm_model is None:
                 settings["model"]["vlm_model"] = None
 
+        # Update image generation provider (validate before saving)
+        if image_gen_provider:
+            supported_img_providers = {
+                p for p, caps in MODEL_REGISTRY.items() if caps.get(InterfaceType.IMAGE_GEN)
+            }
+            if image_gen_provider not in supported_img_providers:
+                return {
+                    "success": False,
+                    "error": (
+                        f"'{image_gen_provider}' does not support image generation. "
+                        f"Supported providers: {', '.join(sorted(supported_img_providers))}"
+                    ),
+                }
+            old_img_provider = settings["model"].get("image_gen_provider")
+            settings["model"]["image_gen_provider"] = image_gen_provider
+            if image_gen_provider != old_img_provider and image_gen_model is None:
+                settings["model"]["image_gen_model"] = None
+
         # Update custom models (explicit values override the auto-clear above)
         if llm_model is not None:
             settings["model"]["llm_model"] = llm_model if llm_model else None
         if vlm_model is not None:
             settings["model"]["vlm_model"] = vlm_model if vlm_model else None
+        if image_gen_model is not None:
+            settings["model"]["image_gen_model"] = image_gen_model if image_gen_model else None
 
         # Update API key in settings.json
         if provider_for_key and api_key is not None:

--- a/app/ui_layer/settings/model_settings.py
+++ b/app/ui_layer/settings/model_settings.py
@@ -225,12 +225,30 @@ def get_model_settings() -> Dict[str, Any]:
         # Get configured providers (settings.json is the single source of truth)
         llm_provider = model_settings.get("llm_provider", "anthropic")
         vlm_provider = model_settings.get("vlm_provider", llm_provider)
-        image_gen_provider = model_settings.get("image_gen_provider", "openai")
+        # When no explicit image-gen provider is set, follow the VLM provider if
+        # it can generate images (so installs onboarded before image gen was
+        # wired to the chosen provider show the right value), else the default.
+        image_gen_provider = model_settings.get("image_gen_provider")
+        if not image_gen_provider:
+            if MODEL_REGISTRY.get(vlm_provider, {}).get(InterfaceType.IMAGE_GEN):
+                image_gen_provider = vlm_provider
+            else:
+                image_gen_provider = "openai"
 
-        # Get custom models if set
-        llm_model = model_settings.get("llm_model")
-        vlm_model = model_settings.get("vlm_model")
-        image_gen_model = model_settings.get("image_gen_model")
+        # Model overrides, falling back to the provider's registry default so
+        # the UI shows the concrete model actually in use rather than a blank
+        # field. Hard onboarding only persists the provider (model overrides
+        # stay unset = "use the provider default"), which otherwise rendered as
+        # an empty Model box in settings.
+        llm_model = model_settings.get("llm_model") or MODEL_REGISTRY.get(
+            llm_provider, {}
+        ).get(InterfaceType.LLM)
+        vlm_model = model_settings.get("vlm_model") or MODEL_REGISTRY.get(
+            vlm_provider, {}
+        ).get(InterfaceType.VLM)
+        image_gen_model = model_settings.get("image_gen_model") or MODEL_REGISTRY.get(
+            image_gen_provider, {}
+        ).get(InterfaceType.IMAGE_GEN)
 
         # Check API key status for each provider (settings.json only)
         api_keys = {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,9 +12,9 @@ beautifulsoup4
 chardet
 lxml
 lxml_html_clean
-openai>=1.0.0
+openai>=2.0.0
 google-genai>=1.0.0
-anthropic>=0.25.0
+anthropic>=0.97.0
 chromadb
 onnxruntime
 tiktoken


### PR DESCRIPTION
# Image Generation Feature — Code Overview

This document explains the primary function of each changed file in the `improvement/generate-image` branch. The feature adds image generation as a first-class capability alongside CraftBot's existing LLM and VLM support, following the same layered architecture.

---

## Architecture at a Glance

The feature is structured in three layers:

```
agent_core (provider-agnostic library)
  └── InterfaceType.IMAGE_GEN
  └── MODEL_REGISTRY entries
  └── ModelFactory support
  └── ImageGenInterface (core engine)

app (CraftBot application wrappers)
  └── app/image_gen_interface.py  — hooks into CraftBot state
  └── app/config.py               — reads settings.json
  └── app/agent_base.py           — lifecycle management
  └── app/internal_action_interface.py — action entry point
  └── app/data/action/generate_image.py — the callable action

UI (frontend settings)
  └── modelSettingsSlice.ts / selectors / ModelSettings.tsx / model_settings.py / browser_adapter.py
```

The pattern is identical to how VLM works. Every file has a VLM counterpart; image gen simply adds a parallel track.

---

## agent_core Layer

### `agent_core/core/models/types.py`
Defines the `InterfaceType` enum. A single value was added:
```python
IMAGE_GEN = "image_gen"
```
This enum is the key used everywhere (registry lookups, factory dispatch, validation) to refer to the image generation interface type.

### `agent_core/core/models/model_registry.py`
A dictionary mapping `provider → InterfaceType → default model name`. Two entries were added for `IMAGE_GEN`:
- `openai` → `"gpt-image-2"`
- `gemini` → `"gemini-3.1-flash-image-preview"`

### `agent_core/core/models/factory.py`
`ModelFactory.create()` was modified so a small guard was added: if the registry returns `None` for the requested interface+provider combination, and the caller hasn't opted into deferred init, it raises a clear `ValueError` listing supported providers instead of failing later with a confusing error.

No special image-gen code path was needed as the existing OpenAI and Gemini client construction already covers it.

### `agent_core/core/impl/image_gen/interface.py` *(new)*
The core engine. This is the most substantial new file. It:
- Accepts `provider`, `model`, `api_key`, `base_url`, and optional hooks for token counting and usage reporting (same constructor signature as `VLMInterface`)
- Initializes via `ModelFactory.create()` (same as VLM)
- Dispatches to `_openai_generate()` or `_gemini_generate()` based on provider
- Handles resolution (1K/2K/4K), aspect ratio, negative prompts, reference images, and safety filters
- Saves output images
- `reinitialize()` allows swapping providers at runtime without re-creating the object

VLMInterface has the identical structure with `ModelFactory` init, provider dispatch, sync+async public methods, same hooks. The main difference is the operation (describe vs. generate images).

### `agent_core/core/impl/image_gen/__init__.py` and `agent_core/core/image_gen_interface.py` *(new)*
`__init__.py` exports `ImageGenInterface` from the impl module; `image_gen_interface.py` re-exports it at the `agent_core.core` level. Identical in structure to the VLM equivalents (`vlm_interface.py`, `impl/vlm/__init__.py`).

### `agent_core/__init__.py`
Added `ImageGenInterface` to the package's public exports (`__all__`), making it importable as `from agent_core import ImageGenInterface`. Same treatment as `VLMInterface`.

---

## app Layer

### `app/image_gen_interface.py` *(new)*
CraftBot-specific subclass of the core `ImageGenInterface`. Its sole job is to inject the three CraftBot state hooks at construction time:
- `get_token_count` / `set_token_count` — persist per-session token usage to the `STATE` singleton
- `report_usage` — emit usage events to the billing/usage reporter

The core `ImageGenInterface` knows nothing about CraftBot's state system; this wrapper bridges that gap. Mirrors `app/vlm_interface.py` exactly.

### `app/config.py`
Two new config accessors added:
- `get_image_gen_provider()` — reads `model.image_gen_provider` from settings.json (default: `"openai"`)
- `get_image_gen_model()` — reads `model.image_gen_model` (optional override; `None` means use registry default)

The default settings dict also gets both keys. Pattern is identical to `get_vlm_provider()` / `get_vlm_model()`.

### `app/agent_base.py`
Manages the lifecycle of the `ImageGenInterface` instance for a running agent:
- **Constructor**: reads `image_gen_provider` and `image_gen_model` from config, creates `ImageGenInterface` with `deferred=True` (doesn't hit the API until first use), passes it to `InternalActionInterface.initialize()`
- **`reinitialize_image_gen()`**: creates a *fresh* `ImageGenInterface` instance and atomically replaces both `self.image_gen` and `InternalActionInterface.image_gen_interface`. Fresh-instance approach means any in-flight actions that hold a reference to the old instance complete cleanly. Mirrors the pattern used by the existing `reinitialize_llm()`.

### `app/internal_action_interface.py`
The shared class-level registry that actions use to reach CraftBot services without importing the full agent. Two changes:
- Added `image_gen_interface: Optional[ImageGenInterface]` class variable
- Added `generate_image(**kwargs)` classmethod that delegates to `cls.image_gen_interface.generate_image(**kwargs)`

Pattern is identical to how `describe_image()` is wired through the VLM interface.

### `app/data/action/generate_image.py`
The `@action`-decorated function that the agent calls. It:
1. Returns early in `simulated_mode` (for tests)
2. Checks the registry to confirm the current provider supports image generation — returns a user-friendly error if not
3. Validates that `prompt` is non-empty
4. Delegates to `InternalActionInterface.generate_image()` with normalized parameters
5. Returns a `{"status": "success", "image_paths": [...]}` dict

Follows the same pattern as `app/data/action/describe_image.py` (the VLM equivalent): thin action wrapper, provider guard, delegate to interface, return dict.

### `app/main.py`
Passes the configured `image_gen_provider` and `image_gen_model` through to the `AgentBase` constructor at startup, so the agent initializes with the right provider from the moment it starts.

---

## UI / Settings Layer

The UI layer lets users configure the image generation provider and API key separately from the LLM provider. Each piece mirrors what was already in place for VLM.

### `app/ui_layer/settings/model_settings.py`
Backend settings API. Changes:
- `get_available_providers()` now includes `has_image_gen: bool` and `image_gen_model: str|None` on each `ProviderInfo`, derived from the registry. The frontend uses `has_image_gen` to filter the provider dropdown.
- `get_model_settings()` returns `image_gen_provider` and `image_gen_model` alongside existing fields.
- `update_model_settings()` accepts and saves both, with validation: it rejects any `image_gen_provider` value not present in the registry before touching settings.json.

### `app/ui_layer/adapters/browser_adapter.py`
Handles the WebSocket `model_settings_update` message from the frontend. Added extraction of `imageGenProvider` / `imageGenModel` from the message payload, saving them via `update_model_settings()`, then calling `agent.reinitialize_image_gen()` so the running agent immediately switches to the new provider without a restart.

### `app/ui_layer/browser/frontend/src/store/slices/modelSettingsSlice.ts`
Redux slice managing model settings state. Added:
- `imageGenProvider: string` and `currentImageGenModel: string` state fields
- `setImageGenProvider` and `setCurrentImageGenModel` actions
- `ProviderInfo` interface extended with `has_image_gen` and `image_gen_model`
- Both `model_settings_get` and `model_settings_update` socket message handlers updated to populate the new fields

### `app/ui_layer/browser/frontend/src/store/selectors/modelSettings.ts`
Adds `selectImageGenProvider` and `selectCurrentImageGenModel` selectors for the two new state fields. Same pattern as the existing LLM/VLM selectors.

### `app/ui_layer/browser/frontend/src/pages/Settings/ModelSettings.tsx`
Adds an "Image Generation" section to the Settings page (after VLM, before Slow Mode). Contains:
- A provider dropdown filtered to only providers with `has_image_gen: true`
- An API key field (shown only when the provider `requires_api_key`) with configured/required badge
- A model override text input (auto-populated from the provider's default when the provider is switched)
- A Save button that sends a `model_settings_update` socket message

The section is self-contained with its own local state (`newImageGenProvider`, `newImageGenApiKey`, `newImageGenModel`, `imageGenHasChanges`, `isImageGenSaving`) and save handler, matching the existing LLM provider section's structure.
