### PR TITLE
Feat/network interface port

### DIFF
--- a/agent_core/core/impl/llm/interface.py
+++ b/agent_core/core/impl/llm/interface.py
@@ -427,7 +427,7 @@ class LLMInterface:
                 response = self._generate_byteplus(system_prompt, user_prompt)
             elif self.provider == "anthropic":
                 response = self._generate_anthropic(system_prompt, user_prompt)
-            elif self.provider == "bedrock":
+            elif self.provider in ("bedrock", "craftbot"):
                 response = self._generate_bedrock(system_prompt, user_prompt)
             else:  # pragma: no cover
                 raise RuntimeError(f"Unknown provider {self.provider!r}")
@@ -592,7 +592,7 @@ class LLMInterface:
                 self.provider == "anthropic" and self._anthropic_client
             )  # Anthropic uses ephemeral caching with extended TTL
             or (
-                self.provider == "bedrock" and self._bedrock_client
+                self.provider in ("bedrock", "craftbot") and self._bedrock_client
             )  # Bedrock uses cachePoint (only Anthropic Claude models on Bedrock support it)
         )
 
@@ -718,7 +718,7 @@ class LLMInterface:
                 return True
             if self.provider == "anthropic" and self._anthropic_client:
                 return True
-            if self.provider == "bedrock" and self._bedrock_client:
+            if self.provider in ("bedrock", "craftbot") and self._bedrock_client:
                 return True
 
         # Check provider-specific actual session existence
@@ -1007,7 +1007,7 @@ class LLMInterface:
         # threshold and silently no-ops. Accumulating turns lets the prefix
         # grow until it crosses the threshold, after which caching activates
         # and serves all subsequent calls.
-        if self.provider == "bedrock" and self._bedrock_client:
+        if self.provider in ("bedrock", "craftbot") and self._bedrock_client:
             session_key = f"{task_id}:{call_type}"
             stored_system_prompt = self._session_system_prompts.get(session_key)
             effective_system_prompt = (

--- a/agent_core/core/impl/vlm/interface.py
+++ b/agent_core/core/impl/vlm/interface.py
@@ -270,7 +270,7 @@ class VLMInterface:
                 response = self._anthropic_describe_bytes(
                     image_bytes, system_prompt, user_prompt
                 )
-            elif self.provider == "bedrock":
+            elif self.provider in ("bedrock", "craftbot"):
                 response = self._bedrock_describe_bytes(
                     image_bytes, system_prompt, user_prompt
                 )

--- a/agent_core/core/models/connection_tester.py
+++ b/agent_core/core/models/connection_tester.py
@@ -85,6 +85,16 @@ def test_provider_connection(
                 timeout=timeout,
                 aws_credentials=aws_credentials,
             )
+        elif provider == "craftbot":
+            # Managed default: credentials come from container env (boto3
+            # default chain). No user-supplied AWS creds to test against —
+            # pass aws_credentials=None so the tester relies on the chain.
+            return _test_bedrock(
+                region=base_url,
+                model=model,
+                timeout=timeout,
+                aws_credentials=None,
+            )
         else:
             return {
                 "success": False,
@@ -244,6 +254,7 @@ _DISPLAY = {
     "grok": "Grok (xAI)",
     "openrouter": "OpenRouter",
     "bedrock": "AWS Bedrock",
+    "craftbot": "CraftBot default provider",
 }
 
 

--- a/agent_core/core/models/factory.py
+++ b/agent_core/core/models/factory.py
@@ -239,29 +239,31 @@ class ModelFactory:
                 "initialized": True,
             }
 
-        if provider == "bedrock":
-            # Bedrock uses the boto3 credential chain. CraftBot stores AWS
-            # credentials in settings.json (not env vars), so we pull them via
-            # app.config — mirroring how the OpenRouter fallback path also
-            # reaches into app.config to read its stored key.
-            #
+        if provider in ("bedrock", "craftbot"):
+            # Both BYOK `bedrock` and the managed `craftbot` provider route
+            # through the same bedrock-runtime client. They differ only in
+            # WHERE credentials come from:
+            #   - bedrock  → settings.json (user-stored AWS access/secret/region)
+            #   - craftbot → container env (boto3 default chain — AWS_ACCESS_KEY_ID
+            #                / AWS_SECRET_ACCESS_KEY / AWS_REGION injected by
+            #                craftbot.live's instance container)
             # `base_url` carries the region through the factory plumbing
             # (api_key/base_url are the only fields the callers thread through).
-            # If unset, fall back to settings → AWS_REGION env → default.
             region = resolved_base_url or "us-east-1"
             access_key = secret_key = session_token = None
-            try:
-                from app.config import get_aws_credentials  # type: ignore
+            if provider == "bedrock":
+                try:
+                    from app.config import get_aws_credentials  # type: ignore
 
-                creds = get_aws_credentials()
-                access_key = creds.get("access_key_id") or None
-                secret_key = creds.get("secret_access_key") or None
-                session_token = creds.get("session_token") or None
-                region = creds.get("region") or region
-            except Exception:
-                # Falling back to boto3's default credential chain (env, IAM
-                # role, SSO profile). Useful when running on an EC2/ECS host.
-                pass
+                    creds = get_aws_credentials()
+                    access_key = creds.get("access_key_id") or None
+                    secret_key = creds.get("secret_access_key") or None
+                    session_token = creds.get("session_token") or None
+                    region = creds.get("region") or region
+                except Exception:
+                    # Falling back to boto3's default credential chain (env, IAM
+                    # role, SSO profile). Useful when running on an EC2/ECS host.
+                    pass
 
             if boto3 is None:
                 if deferred:

--- a/agent_core/core/models/model_registry.py
+++ b/agent_core/core/models/model_registry.py
@@ -67,4 +67,14 @@ MODEL_REGISTRY = {
         InterfaceType.VLM: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
         InterfaceType.EMBEDDING: "amazon.titan-embed-text-v2:0",
     },
+    "craftbot": {
+        # CraftBot's managed default. Same Bedrock-backed Claude Haiku 4.5 as
+        # `bedrock`, but credentials come from container env (boto3 default
+        # chain) and usage is forwarded to the craftbot.live dashboard. The
+        # CRAFTBOT_DEFAULT_MODEL env var can override at boot — see
+        # app/network_interface/bootstrap.py.
+        InterfaceType.LLM: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        InterfaceType.VLM: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        InterfaceType.EMBEDDING: "amazon.titan-embed-text-v2:0",
+    },
 }

--- a/agent_core/core/models/provider_config.py
+++ b/agent_core/core/models/provider_config.py
@@ -50,4 +50,12 @@ PROVIDER_CONFIG = {
         base_url_env="AWS_REGION",
         default_base_url="us-east-1",
     ),
+    "craftbot": ProviderConfig(
+        # CraftBot's managed-default provider. Routes through AWS Bedrock under
+        # the hood, but credentials come from the container env (boto3 default
+        # chain) — NOT from settings.json. Usage is metered back to the
+        # craftbot.live dashboard; see app/network_interface/outbound.py.
+        base_url_env="AWS_REGION",
+        default_base_url="us-east-1",
+    ),
 }

--- a/app/agent_base.py
+++ b/app/agent_base.py
@@ -3462,6 +3462,25 @@ class AgentBase:
         self._usage_reporter = get_usage_reporter()
         self._usage_reporter.start_background_flush()
 
+        # Start the craftbot.live heartbeat loop. No-ops in any environment
+        # where CONTAINER_AUTH_TOKEN / CONTAINER_INSTANCE_ID /
+        # CONTAINER_DASHBOARD_URL aren't set (i.e. local dev, standalone
+        # agent), so this is safe to call unconditionally.
+        from app.network_interface import start_heartbeat, InboundServer
+
+        self._dashboard_heartbeat = start_heartbeat(self.task_manager)
+
+        # Start the dashboard inbound server (/__cb/state, /__cb/events,
+        # /__cb/healthz). Lives here rather than in the browser adapter so it
+        # comes up in CLI mode too — the dashboard's read path mustn't depend
+        # on the user UI choice. Port is independent of BROWSER_PORT; see
+        # app/network_interface/server.py for the env var.
+        self._dashboard_inbound = InboundServer(
+            task_manager=self.task_manager,
+            event_stream_manager=self.event_stream_manager,
+        )
+        await self._dashboard_inbound.start()
+
         # Configure integrations + start external comms manager
         step(6, 7, "Initializing integrations")
         await self._initialize_external_libraries()
@@ -3570,3 +3589,23 @@ class AgentBase:
             # Flush remaining usage events
             if hasattr(self, "_usage_reporter"):
                 await self._usage_reporter.shutdown()
+            # Stop the dashboard heartbeat + the inbound server, then drain
+            # any in-flight outbound HTTP calls so the dashboard sees a clean
+            # final state instead of getting one last stale heartbeat or a
+            # connection refused mid-poll after shutdown.
+            if hasattr(self, "_dashboard_heartbeat"):
+                try:
+                    await self._dashboard_heartbeat.stop()
+                except Exception as e:
+                    logger.warning(f"[SHUTDOWN] heartbeat stop error: {e}")
+            if hasattr(self, "_dashboard_inbound"):
+                try:
+                    await self._dashboard_inbound.stop()
+                except Exception as e:
+                    logger.warning(f"[SHUTDOWN] inbound server stop error: {e}")
+            if hasattr(self, "_dashboard_heartbeat"):
+                try:
+                    from app.network_interface import get_dashboard_client
+                    await get_dashboard_client().aclose()
+                except Exception as e:
+                    logger.warning(f"[SHUTDOWN] dashboard client close error: {e}")

--- a/app/llm/interface.py
+++ b/app/llm/interface.py
@@ -4,11 +4,22 @@ LLM interface for CraftBot.
 
 Re-exports LLMInterface from agent_core with CraftBot-specific hooks
 for state access (using STATE singleton) and usage reporting.
+
+Hosted-version addition: a managed-Bedrock quota guard. When the dashboard
+has set a usage lock (signalled back to the agent in the response body of
+the most recent /heartbeat or /usage callback), Bedrock calls short-circuit
+locally with a QUOTA-category error that prompts the user to switch to BYOK.
+The check itself is a pure local-memory read — no I/O on the LLM hot path.
 """
 
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from agent_core.core.impl.llm import LLMInterface as _LLMInterface
+from agent_core.core.impl.llm.errors import (
+    ErrorAction,
+    ErrorCategory,
+    LLMErrorInfo,
+)
 from agent_core.core.hooks.types import UsageEventData
 from app.state.agent_state import get_session_props
 
@@ -110,3 +121,62 @@ class LLMInterface(_LLMInterface):
             output_tokens,
             cached_tokens,
         )
+
+    def _generate_bedrock(
+        self,
+        system_prompt: Optional[str],
+        user_prompt: Optional[str],
+    ) -> Dict[str, Any]:
+        """Managed-Bedrock quota guard.
+
+        If the cached dashboard lock state says the user is over their monthly
+        budget, refuse the call locally — returning a structured error in the
+        same shape the base interface expects from a failed provider call.
+        The chat surface picks up `error_info_obj` and renders the QUOTA
+        bubble with the "Open settings" action so the user can switch to BYOK.
+
+        The check is `is_quota_locked()`, a pure local-memory read: no HTTP,
+        no DB, no lock contention with the dashboard. Keeps the LLM hot path
+        unaffected when the user is NOT locked.
+        """
+        from app.network_interface import is_quota_locked, get_quota_reset
+
+        if is_quota_locked():
+            reset_at = get_quota_reset()
+            reset_str = (
+                reset_at.strftime("%B %d, %Y")
+                if reset_at
+                else "the next billing period"
+            )
+            message = (
+                f"Your managed Bedrock quota has been used up for this month "
+                f"(resets {reset_str}). To keep using LLM features, configure "
+                f"your own API key under Settings > Models, or wait for the "
+                f"monthly reset."
+            )
+            info = LLMErrorInfo(
+                category=ErrorCategory.QUOTA,
+                title="Managed Bedrock quota exhausted",
+                message=message,
+                provider="bedrock",
+                model=self.model,
+                actions=[
+                    ErrorAction(
+                        label="Open settings",
+                        action="open_settings_model",
+                    ),
+                ],
+            )
+            # Return an empty-content error so the base interface's existing
+            # error-handling path (around line 442 of agent_core's LLM
+            # interface) picks up `error_info_obj`. Same code path that
+            # surfaces auth/rate-limit errors today — the chat bubble looks
+            # identical to other classified errors.
+            return {
+                "content": "",
+                "error": info.message,
+                "error_info_obj": info,
+                "tokens_used": 0,
+            }
+
+        return super()._generate_bedrock(system_prompt, user_prompt)

--- a/app/llm/interface.py
+++ b/app/llm/interface.py
@@ -127,56 +127,57 @@ class LLMInterface(_LLMInterface):
         system_prompt: Optional[str],
         user_prompt: Optional[str],
     ) -> Dict[str, Any]:
-        """Managed-Bedrock quota guard.
+        """Managed-provider quota guard.
 
-        If the cached dashboard lock state says the user is over their monthly
-        budget, refuse the call locally — returning a structured error in the
-        same shape the base interface expects from a failed provider call.
-        The chat surface picks up `error_info_obj` and renders the QUOTA
-        bubble with the "Open settings" action so the user can switch to BYOK.
+        Only fires when the active provider is `craftbot` (the managed default
+        that bills back to craftbot.live). BYOK `bedrock` uses the user's own
+        AWS account, so quota lock is not applicable and the call falls
+        through to the base interface unmodified.
+
+        For `craftbot`: if the cached dashboard lock state says the user is
+        over their monthly budget, refuse the call locally with a structured
+        error in the same shape the base interface expects from a failed
+        provider call. The chat surface picks up `error_info_obj` and renders
+        the QUOTA bubble with the "Open settings" action so the user can
+        switch to BYOK.
 
         The check is `is_quota_locked()`, a pure local-memory read: no HTTP,
-        no DB, no lock contention with the dashboard. Keeps the LLM hot path
-        unaffected when the user is NOT locked.
+        no DB, no lock contention with the dashboard.
         """
-        from app.network_interface import is_quota_locked, get_quota_reset
+        if self.provider == "craftbot":
+            from app.network_interface import is_quota_locked, get_quota_reset
 
-        if is_quota_locked():
-            reset_at = get_quota_reset()
-            reset_str = (
-                reset_at.strftime("%B %d, %Y")
-                if reset_at
-                else "the next billing period"
-            )
-            message = (
-                f"Your managed Bedrock quota has been used up for this month "
-                f"(resets {reset_str}). To keep using LLM features, configure "
-                f"your own API key under Settings > Models, or wait for the "
-                f"monthly reset."
-            )
-            info = LLMErrorInfo(
-                category=ErrorCategory.QUOTA,
-                title="Managed Bedrock quota exhausted",
-                message=message,
-                provider="bedrock",
-                model=self.model,
-                actions=[
-                    ErrorAction(
-                        label="Open settings",
-                        action="open_settings_model",
-                    ),
-                ],
-            )
-            # Return an empty-content error so the base interface's existing
-            # error-handling path (around line 442 of agent_core's LLM
-            # interface) picks up `error_info_obj`. Same code path that
-            # surfaces auth/rate-limit errors today — the chat bubble looks
-            # identical to other classified errors.
-            return {
-                "content": "",
-                "error": info.message,
-                "error_info_obj": info,
-                "tokens_used": 0,
-            }
+            if is_quota_locked():
+                reset_at = get_quota_reset()
+                reset_str = (
+                    reset_at.strftime("%B %d, %Y")
+                    if reset_at
+                    else "the next billing period"
+                )
+                message = (
+                    f"Your CraftBot managed quota has been used up for this "
+                    f"month (resets {reset_str}). To keep using LLM features, "
+                    f"switch to a BYOK provider under Settings > Models, or "
+                    f"wait for the monthly reset."
+                )
+                info = LLMErrorInfo(
+                    category=ErrorCategory.QUOTA,
+                    title="CraftBot managed quota exhausted",
+                    message=message,
+                    provider="craftbot",
+                    model=self.model,
+                    actions=[
+                        ErrorAction(
+                            label="Open settings",
+                            action="open_settings_model",
+                        ),
+                    ],
+                )
+                return {
+                    "content": "",
+                    "error": info.message,
+                    "error_info_obj": info,
+                    "tokens_used": 0,
+                }
 
         return super()._generate_bedrock(system_prompt, user_prompt)

--- a/app/llm/interface.py
+++ b/app/llm/interface.py
@@ -24,10 +24,21 @@ def _set_token_count(count: int) -> None:
 
 
 async def _report_usage(event: UsageEventData) -> None:
-    """Report usage to local storage via UsageReporter."""
+    """Report usage to local SQLite AND forward to the craftbot.live dashboard.
+
+    Local storage stays the source of truth for in-container analytics and
+    works offline. The dashboard mirror is fire-and-forget — if the dashboard
+    is unreachable, the network_interface drops/retries on its own and the
+    local copy is unaffected. See app/network_interface/outbound.py.
+    """
     from app.usage import get_usage_reporter
+    from app.network_interface import report_usage_to_dashboard
 
     await get_usage_reporter().report(event)
+    # Fire-and-forget: returns immediately, actual HTTP happens in a background
+    # task with bounded retry. Disabled (no-op) when CONTAINER_AUTH_TOKEN /
+    # CONTAINER_INSTANCE_ID / CONTAINER_DASHBOARD_URL are unset.
+    await report_usage_to_dashboard(event)
 
 
 class LLMInterface(_LLMInterface):

--- a/app/main.py
+++ b/app/main.py
@@ -61,6 +61,14 @@ from app.config import get_project_root
 StateRegistry.register(lambda: STATE)
 ConfigRegistry.register_workspace_root(str(get_project_root()))
 
+# Seed settings.json with managed Bedrock defaults BEFORE the first settings
+# read. Only runs when CRAFTBOT_DEFAULT_PROVIDER is set in the env AND no
+# settings.json exists yet — so dev runs (no env vars) and BYOK users with an
+# existing settings file are both untouched. Used by craftbot.live to skip the
+# agent's onboarding screen on first container boot.
+from app.network_interface import seed_default_provider_from_env as _seed_default_provider
+_seed_default_provider()
+
 # Import settings reader (reads directly from settings.json)
 from app.config import (
     get_llm_provider,

--- a/app/network_interface/__init__.py
+++ b/app/network_interface/__init__.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+"""
+app.network_interface
+
+Single owner of every inbound and outbound HTTP call between the CraftBot
+agent (running inside a container) and the craftbot.live dashboard backend.
+
+Why centralise:
+  - One place to read the spawn-injected env vars (CONTAINER_AUTH_TOKEN,
+    CONTAINER_INSTANCE_ID, CONTAINER_DASHBOARD_URL).
+  - One place to do the bearer-auth handshake on both directions.
+  - Outbound calls (heartbeat, usage) batch + retry here so callers can
+    fire-and-forget without stalling LLM work when the dashboard is unreachable.
+  - Inbound endpoints (added in later slices) live next to the outbound client
+    so they share auth + config.
+
+Slice 1 scope: outbound `report_usage` only. The agent's existing
+`UsageReporter` keeps writing to local SQLite; this client *additionally*
+forwards each event to the dashboard so the dashboard's `UsageRecord` table
+becomes the source of truth for billing.
+"""
+
+from app.network_interface.config import (
+    NetworkInterfaceConfig,
+    get_config,
+    is_enabled,
+)
+from app.network_interface.outbound import (
+    DashboardClient,
+    get_dashboard_client,
+    report_usage_to_dashboard,
+)
+from app.network_interface.heartbeat import (
+    HeartbeatLoop,
+    get_heartbeat_loop,
+    start_heartbeat,
+)
+from app.network_interface.snapshot import (
+    build_events_snapshot,
+    build_state_snapshot,
+    derive_agent_state,
+    process_uptime_seconds,
+)
+from app.network_interface.inbound import (
+    INBOUND_PREFIX,
+    register_routes,
+)
+from app.network_interface.server import (
+    InboundServer,
+)
+from app.network_interface.bootstrap import (
+    seed_default_provider_from_env,
+)
+
+__all__ = [
+    "NetworkInterfaceConfig",
+    "get_config",
+    "is_enabled",
+    "DashboardClient",
+    "get_dashboard_client",
+    "report_usage_to_dashboard",
+    "HeartbeatLoop",
+    "get_heartbeat_loop",
+    "start_heartbeat",
+    "derive_agent_state",
+    "process_uptime_seconds",
+    "build_state_snapshot",
+    "build_events_snapshot",
+    "INBOUND_PREFIX",
+    "register_routes",
+    "InboundServer",
+    "seed_default_provider_from_env",
+]

--- a/app/network_interface/__init__.py
+++ b/app/network_interface/__init__.py
@@ -51,6 +51,14 @@ from app.network_interface.server import (
 from app.network_interface.bootstrap import (
     seed_default_provider_from_env,
 )
+from app.network_interface.state import (
+    is_quota_locked,
+    get_quota_reset,
+    set_quota_lock,
+)
+from app.network_interface.errors import (
+    ManagedQuotaExceededError,
+)
 
 __all__ = [
     "NetworkInterfaceConfig",
@@ -70,4 +78,8 @@ __all__ = [
     "register_routes",
     "InboundServer",
     "seed_default_provider_from_env",
+    "is_quota_locked",
+    "get_quota_reset",
+    "set_quota_lock",
+    "ManagedQuotaExceededError",
 ]

--- a/app/network_interface/bootstrap.py
+++ b/app/network_interface/bootstrap.py
@@ -7,9 +7,12 @@ craftbot.live before it boots.
 
 `seed_default_provider_from_env`
     The dashboard's instances/index.ts containerEnv() injects
-    `CRAFTBOT_DEFAULT_PROVIDER` and `CRAFTBOT_DEFAULT_MODEL` (plus the matching
-    AWS_* creds) into every container so a fresh agent boots straight into
-    managed Bedrock without an onboarding prompt.
+    `CRAFTBOT_DEFAULT_PROVIDER=craftbot` and `CRAFTBOT_DEFAULT_MODEL` (plus the
+    underlying AWS_* creds for the boto3 default chain) into every container
+    so a fresh agent boots straight into the managed CraftBot provider without
+    an onboarding prompt. `craftbot` is the metered managed provider — usage
+    is reported back to the dashboard. The unrelated BYOK `bedrock` provider
+    is for users supplying their own AWS account.
 
     But we MUST NOT trample a user who has already chosen BYOK — settings.json
     is the user's preference. So we only seed when no settings.json exists yet

--- a/app/network_interface/bootstrap.py
+++ b/app/network_interface/bootstrap.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+"""
+app.network_interface.bootstrap
+
+One-shot startup helpers that prepare the agent for managed-LLM hosting on
+craftbot.live before it boots.
+
+`seed_default_provider_from_env`
+    The dashboard's instances/index.ts containerEnv() injects
+    `CRAFTBOT_DEFAULT_PROVIDER` and `CRAFTBOT_DEFAULT_MODEL` (plus the matching
+    AWS_* creds) into every container so a fresh agent boots straight into
+    managed Bedrock without an onboarding prompt.
+
+    But we MUST NOT trample a user who has already chosen BYOK — settings.json
+    is the user's preference. So we only seed when no settings.json exists yet
+    (first boot of a brand-new container). Subsequent restarts re-read whatever
+    the user last chose.
+
+    Idempotent and tolerant of missing env vars: when CRAFTBOT_DEFAULT_PROVIDER
+    is unset, or settings.json already exists, it's a no-op.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+try:
+    from app.logger import logger
+except Exception:  # pragma: no cover
+    import logging
+    logger = logging.getLogger(__name__)
+
+
+def seed_default_provider_from_env() -> None:
+    """Write settings.json with the env-supplied managed provider/model when
+    no settings file exists yet. No-op when CRAFTBOT_DEFAULT_PROVIDER is unset
+    or the user already has a settings.json (their choices win)."""
+    provider = os.environ.get("CRAFTBOT_DEFAULT_PROVIDER", "").strip()
+    if not provider:
+        return
+
+    # Late import so this module loads cleanly even before app.config is wired
+    # (e.g. in test harnesses that haven't constructed PROJECT_ROOT yet).
+    from app.config import SETTINGS_CONFIG_PATH, _get_default_settings  # type: ignore
+
+    if SETTINGS_CONFIG_PATH.exists():
+        # User-controlled settings present — don't touch.
+        return
+
+    model = os.environ.get("CRAFTBOT_DEFAULT_MODEL", "").strip() or None
+
+    settings = _get_default_settings()
+    # Overlay just the model section; everything else stays at agent defaults.
+    settings.setdefault("model", {})
+    settings["model"]["llm_provider"] = provider
+    settings["model"]["vlm_provider"] = provider
+    settings["model"]["llm_model"] = model
+    settings["model"]["vlm_model"] = model
+
+    try:
+        SETTINGS_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with open(SETTINGS_CONFIG_PATH, "w", encoding="utf-8") as f:
+            json.dump(settings, f, indent=2)
+        logger.info(
+            f"[network_interface] seeded settings.json with default provider={provider!r} model={model!r}"
+        )
+    except OSError as exc:
+        # Filesystem errors here are best-effort — the agent can still boot
+        # using in-memory defaults; the user will just see an onboarding screen.
+        logger.warning(f"[network_interface] failed to seed settings.json: {exc}")

--- a/app/network_interface/config.py
+++ b/app/network_interface/config.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+"""
+app.network_interface.config
+
+Reads the three env vars the dashboard's instance-provisioning step injects
+into every container at spawn time (see
+apps/backend/src/api/instances/index.ts `containerEnv`):
+
+    CONTAINER_AUTH_TOKEN     # per-instance shared bearer secret
+    CONTAINER_INSTANCE_ID    # dashboard's Instance.id (cuid)
+    CONTAINER_DASHBOARD_URL  # dashboard backend base URL (no trailing slash)
+
+If any is missing the interface is "disabled" — the agent keeps running, all
+outbound calls become silent no-ops, and inbound endpoints (when added) refuse
+to start. This matches the dashboard's own degradation pattern: a half-
+configured deployment must boot rather than crash-loop.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class NetworkInterfaceConfig:
+    """Resolved env-var view; immutable per-process."""
+
+    auth_token: str
+    instance_id: str
+    dashboard_url: str
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.auth_token and self.instance_id and self.dashboard_url)
+
+
+_DEFAULT_DASHBOARD_URL_FALLBACK = "http://localhost:4000"
+
+
+def _load_from_env() -> NetworkInterfaceConfig:
+    raw_url = os.environ.get("CONTAINER_DASHBOARD_URL", "").strip()
+    # Strip a single trailing slash so we can concatenate paths cleanly.
+    dashboard_url = raw_url.rstrip("/") if raw_url else ""
+    return NetworkInterfaceConfig(
+        auth_token=os.environ.get("CONTAINER_AUTH_TOKEN", "").strip(),
+        instance_id=os.environ.get("CONTAINER_INSTANCE_ID", "").strip(),
+        dashboard_url=dashboard_url,
+    )
+
+
+_config: Optional[NetworkInterfaceConfig] = None
+
+
+def get_config() -> NetworkInterfaceConfig:
+    """Process-wide cached config. Env reads happen once at first call."""
+    global _config
+    if _config is None:
+        _config = _load_from_env()
+    return _config
+
+
+def is_enabled() -> bool:
+    """True iff all three spawn-injected env vars are present and non-empty."""
+    return get_config().enabled
+
+
+def reset_for_tests() -> None:
+    """Drop the cached config; used by tests that monkeypatch env vars."""
+    global _config
+    _config = None
+
+
+def dashboard_endpoint(path: str) -> str:
+    """Join a relative path like `/api/instance-callback/usage` onto the
+    configured dashboard URL, preserving any base path the URL already has.
+    Returns empty string when disabled so callers can short-circuit cleanly."""
+    cfg = get_config()
+    if not cfg.enabled:
+        return ""
+    if not path.startswith("/"):
+        path = "/" + path
+    return f"{cfg.dashboard_url}{path}"
+
+
+def fallback_dashboard_url() -> str:
+    """The dev-mode default when CONTAINER_DASHBOARD_URL is unset. Exposed
+    only so tests / dev tooling can reference the same constant."""
+    return _DEFAULT_DASHBOARD_URL_FALLBACK

--- a/app/network_interface/errors.py
+++ b/app/network_interface/errors.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+"""
+app.network_interface.errors
+
+Exceptions raised by the hosted-version managed-LLM integration. Catching
+them is the hosted fork's responsibility — upstream CraftBot's LLM error
+classifier (agent_core/core/impl/llm/errors.py) is intentionally NOT modified;
+the hosted callers in app/llm/interface.py and app/vlm_interface.py catch
+these and synthesise an `LLMErrorInfo` themselves so the chat surface gets
+a QUOTA-category bubble identical in shape to one classified from an
+upstream provider exception.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+from typing import Optional
+
+
+class ManagedQuotaExceededError(Exception):
+    """Raised by the LLM/VLM interface when a managed-Bedrock call is
+    attempted while `is_quota_locked()` is true. The dashboard set
+    Profile.usageLockedUntil after monthly spend crossed the plan budget;
+    the agent learned about it through the response body of a previous
+    /usage or /heartbeat callback (see app/network_interface/state.py).
+
+    Carries the reset timestamp so the chat error message can tell the user
+    exactly when Bedrock will resume.
+    """
+
+    def __init__(self, reset_at: Optional[_dt.datetime] = None) -> None:
+        self.reset_at = reset_at
+        ts = reset_at.isoformat() if reset_at else "next billing period"
+        super().__init__(
+            f"Managed Bedrock quota exhausted; resets at {ts}. "
+            f"Configure your own API key under Settings > Models to keep using LLM features."
+        )

--- a/app/network_interface/heartbeat.py
+++ b/app/network_interface/heartbeat.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+"""
+app.network_interface.heartbeat
+
+Periodic heartbeat loop. Sends one `POST /api/instance-callback/heartbeat`
+per interval, carrying the agent's currently-derived state and its uptime.
+
+This is the *only* place that pushes proactively — usage events ride along
+with LLM calls, and slice-3 state/events/tasks are pulled by the dashboard.
+So the loop's failure modes are simple: if the loop crashes the agent keeps
+working and the dashboard just stops seeing fresh state until restart.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Optional
+
+from app.network_interface.config import is_enabled
+from app.network_interface.outbound import get_dashboard_client
+from app.network_interface.snapshot import derive_agent_state, process_uptime_seconds
+
+try:
+    from app.logger import logger
+except Exception:  # pragma: no cover
+    import logging
+    logger = logging.getLogger(__name__)
+
+
+DEFAULT_INTERVAL_SECONDS = 30
+
+
+class HeartbeatLoop:
+    """Background task that periodically reports state to the dashboard.
+
+    Holds a weak reference to the task_manager so it can be GC'd if the
+    agent ever tears it down — the loop itself never owns task_manager
+    lifecycle.
+    """
+
+    def __init__(
+        self,
+        task_manager: Any,
+        *,
+        interval_seconds: int = DEFAULT_INTERVAL_SECONDS,
+    ) -> None:
+        self._task_manager = task_manager
+        self._interval = max(5, int(interval_seconds))
+        self._task: Optional[asyncio.Task[None]] = None
+        self._stopped = asyncio.Event()
+        self._last_state: Optional[str] = None
+
+    def start(self) -> None:
+        """Schedule the loop on the running event loop. Idempotent — calling
+        start() twice is a no-op. No-op when the network interface is
+        disabled (no env vars), so dev-mode agents stay quiet."""
+        if self._task is not None and not self._task.done():
+            return
+        if not is_enabled():
+            logger.info("[network_interface] heartbeat skipped (no CONTAINER_* env vars)")
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            logger.warning("[network_interface] no running loop; heartbeat not started")
+            return
+        self._stopped.clear()
+        self._task = loop.create_task(self._run())
+        logger.info(f"[network_interface] heartbeat started ({self._interval}s interval)")
+
+    async def stop(self) -> None:
+        """Stop the loop and wait briefly for the current iteration to finish."""
+        self._stopped.set()
+        if self._task is not None and not self._task.done():
+            try:
+                await asyncio.wait_for(self._task, timeout=5.0)
+            except (asyncio.TimeoutError, asyncio.CancelledError):
+                self._task.cancel()
+        self._task = None
+
+    async def send_now(self) -> None:
+        """Send one heartbeat immediately. Used at startup so the dashboard
+        sees the agent's state without waiting for the first interval."""
+        await self._tick()
+
+    async def _run(self) -> None:
+        # Touch the uptime counter so its `started_monotonic` anchor is now,
+        # not whenever the first /api/instance-callback/usage call happened.
+        process_uptime_seconds()
+        # Immediate first send so the dashboard reflects "running" right away.
+        await self._tick()
+        while not self._stopped.is_set():
+            try:
+                # Sleep with cancel-aware wait so stop() returns quickly.
+                await asyncio.wait_for(self._stopped.wait(), timeout=self._interval)
+                # If wait returned True the stop event was set — exit.
+                break
+            except asyncio.TimeoutError:
+                pass
+            await self._tick()
+
+    async def _tick(self) -> None:
+        state = derive_agent_state(self._task_manager)
+        uptime = process_uptime_seconds()
+        # Only log when state changes — at idle this is one line per agent
+        # session, which is what you want for ops.
+        if state != self._last_state:
+            logger.info(f"[network_interface] agent_state -> {state}")
+            self._last_state = state
+        try:
+            await get_dashboard_client().heartbeat(
+                agent_state=state,
+                uptime_seconds=uptime,
+            )
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning(f"[network_interface] heartbeat tick failed: {exc}")
+
+
+_singleton: Optional[HeartbeatLoop] = None
+
+
+def get_heartbeat_loop(task_manager: Any) -> HeartbeatLoop:
+    """Process-wide singleton. The first call wins on which task_manager
+    the loop reads from; subsequent calls return the same loop regardless."""
+    global _singleton
+    if _singleton is None:
+        _singleton = HeartbeatLoop(task_manager)
+    return _singleton
+
+
+def start_heartbeat(task_manager: Any) -> HeartbeatLoop:
+    """Convenience: get-or-create the loop and start it."""
+    loop = get_heartbeat_loop(task_manager)
+    loop.start()
+    return loop

--- a/app/network_interface/inbound.py
+++ b/app/network_interface/inbound.py
@@ -1,0 +1,186 @@
+# -*- coding: utf-8 -*-
+"""
+app.network_interface.inbound
+
+aiohttp handler factories + `register_routes` for the dashboard-facing pull
+endpoints. The actual server (Application + AppRunner + TCPSite) lives in
+`app.network_interface.server` and is owned by agent_base — running
+independently of any UI adapter so the dashboard can reach the agent in CLI
+mode too. This file is just the routing/auth layer.
+
+Routes:
+    GET /__cb/state                → snapshot.build_state_snapshot
+    GET /__cb/events?since=&limit= → snapshot.build_events_snapshot
+    GET /__cb/healthz              → unauthenticated liveness probe (safe for
+                                     load-balancer health checks; never
+                                     returns secrets)
+
+Auth: `Authorization: Bearer <CONTAINER_AUTH_TOKEN>`. The dashboard proxy at
+`/api/instances/:id/proxy/*` already injects the same secret on every
+request, so the browser → dashboard → container hop authenticates end-to-end
+with the per-instance shared secret. Slice-1's `requireInstanceAuth`
+middleware on the dashboard side is the mirror of this check.
+
+Why aiohttp and not FastAPI: the agent already depends on aiohttp (the
+browser UI uses it), so reusing it costs nothing. Adding FastAPI just to
+serve two GETs would double the runtime footprint for no benefit.
+"""
+
+from __future__ import annotations
+
+from hmac import compare_digest
+from typing import Any, Awaitable, Callable, Optional, TYPE_CHECKING
+
+from app.network_interface.config import get_config, is_enabled
+from app.network_interface.snapshot import (
+    build_events_snapshot,
+    build_state_snapshot,
+)
+
+try:
+    from app.logger import logger
+except Exception:  # pragma: no cover
+    import logging
+    logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from aiohttp import web
+
+
+# Path prefix for all dashboard-facing endpoints. Matches the `/__cbauth`
+# convention from docs/container-access.md — `__cb` marks "craftbot.live
+# control plane" and shouldn't collide with anything the user routes to.
+INBOUND_PREFIX = "/__cb"
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Auth helpers
+# ───────────────────────────────────────────────────────────────────────────
+
+
+def _extract_bearer(header: Optional[str]) -> Optional[str]:
+    if not header:
+        return None
+    if not header.lower().startswith("bearer "):
+        return None
+    return header[7:].strip() or None
+
+
+def _check_auth(request: "web.Request") -> bool:
+    """Constant-time compare against CONTAINER_AUTH_TOKEN. Returns False (and
+    the handler should answer 401) when:
+      - the network interface is disabled (no env vars) — refusing all calls
+        prevents leaking state from a misconfigured deployment;
+      - the Authorization header is missing or not bearer;
+      - the token doesn't match.
+    """
+    cfg = get_config()
+    if not cfg.enabled:
+        return False
+    provided = _extract_bearer(request.headers.get("Authorization"))
+    if provided is None:
+        return False
+    # compare_digest needs equal-length inputs; pad on length mismatch so we
+    # always do a full constant-time compare and don't leak length info.
+    a = provided.encode("utf-8")
+    b = cfg.auth_token.encode("utf-8")
+    if len(a) != len(b):
+        # Compare against itself to keep the timing identical, then fail.
+        compare_digest(a, a)
+        return False
+    return compare_digest(a, b)
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Handlers
+# ───────────────────────────────────────────────────────────────────────────
+
+
+HandlerFn = Callable[["web.Request"], Awaitable[Any]]
+
+
+def _make_state_handler(task_manager: Any) -> HandlerFn:
+    from aiohttp import web
+
+    async def handler(request: "web.Request") -> "web.Response":
+        if not _check_auth(request):
+            return web.json_response({"error": "unauthorized"}, status=401)
+        try:
+            body = build_state_snapshot(task_manager)
+            return web.json_response(body)
+        except Exception as exc:
+            logger.warning(f"[network_interface] /state failed: {exc}")
+            return web.json_response({"error": "snapshot_failed"}, status=500)
+
+    return handler
+
+
+def _make_events_handler(event_stream_manager: Any) -> HandlerFn:
+    from aiohttp import web
+
+    async def handler(request: "web.Request") -> "web.Response":
+        if not _check_auth(request):
+            return web.json_response({"error": "unauthorized"}, status=401)
+        since = request.rel_url.query.get("since") or None
+        limit_raw = request.rel_url.query.get("limit")
+        try:
+            limit = int(limit_raw) if limit_raw is not None else 50
+        except ValueError:
+            return web.json_response({"error": "invalid limit"}, status=400)
+        try:
+            body = build_events_snapshot(
+                event_stream_manager,
+                since_iso=since,
+                limit=limit,
+            )
+            return web.json_response(body)
+        except Exception as exc:
+            logger.warning(f"[network_interface] /events failed: {exc}")
+            return web.json_response({"error": "snapshot_failed"}, status=500)
+
+    return handler
+
+
+async def _healthz(request: "web.Request") -> Any:
+    """Public liveness probe — no auth, no state. Useful for the dashboard's
+    `waitForContainerReady` probe to confirm the agent's HTTP layer is up
+    before flipping `Instance.status` to running."""
+    from aiohttp import web
+
+    return web.json_response({"ok": True, "enabled": is_enabled()})
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Registration
+# ───────────────────────────────────────────────────────────────────────────
+
+
+def register_routes(
+    app: "web.Application",
+    *,
+    task_manager: Any,
+    event_stream_manager: Any,
+) -> None:
+    """Attach the dashboard pull endpoints to an existing aiohttp Application.
+
+    Safe to call when the network interface is disabled — the routes are still
+    registered, they just answer 401 for /state and /events (healthz stays
+    public). That keeps the surface stable across dev and prod so the
+    dashboard's probe code can assume the URL exists either way.
+    """
+    app.router.add_get(f"{INBOUND_PREFIX}/healthz", _healthz)
+    app.router.add_get(
+        f"{INBOUND_PREFIX}/state",
+        _make_state_handler(task_manager),
+    )
+    app.router.add_get(
+        f"{INBOUND_PREFIX}/events",
+        _make_events_handler(event_stream_manager),
+    )
+    if is_enabled():
+        logger.info(f"[network_interface] inbound routes mounted at {INBOUND_PREFIX}/*")
+    else:
+        logger.info(
+            f"[network_interface] inbound routes mounted at {INBOUND_PREFIX}/* "
+            "(auth disabled — 401 until CONTAINER_AUTH_TOKEN is set)"
+        )

--- a/app/network_interface/outbound.py
+++ b/app/network_interface/outbound.py
@@ -101,9 +101,9 @@ class DashboardClient:
     ) -> None:
         """Forward a single LLM/VLM usage event to the dashboard.
 
-        BYOK filter: only `provider="bedrock"` events reach the dashboard. Every
-        other provider (anthropic-direct, openai, gemini, byteplus, openrouter,
-        etc.) is BYOK — the user pays the upstream provider directly and
+        BYOK filter: only `provider="craftbot"` events reach the dashboard.
+        Every other provider — including BYOK `bedrock` where the user supplies
+        their own AWS credentials — is paid for upstream by the user, and
         craftbot.live MUST NOT count those tokens against their plan budget
         or display them in the dashboard's "Managed usage" surfaces. The
         agent's local UsageReporter (SQLite) keeps logging all calls regardless,
@@ -121,7 +121,7 @@ class DashboardClient:
         # Single point of truth for the managed-LLM allowlist. Keep in sync
         # with apps/backend/prisma/seed-llm-rates.sql — any provider added
         # there must be added here too.
-        if (event.provider or "").lower() != "bedrock":
+        if (event.provider or "").lower() != "craftbot":
             return
 
         body: Dict[str, Any] = {

--- a/app/network_interface/outbound.py
+++ b/app/network_interface/outbound.py
@@ -231,6 +231,11 @@ class DashboardClient:
                     if self._outage_logged:
                         logger.info("[network_interface] dashboard reachable again")
                         self._outage_logged = False
+                    # Parse the response body to pull out any quota-lock state
+                    # the dashboard included. Defensive — failure here MUST NOT
+                    # break the retry/queue contract; the call already
+                    # succeeded as far as the dashboard is concerned.
+                    self._absorb_response_body(resp)
                     return
 
                 # 4xx is the dashboard rejecting our payload — retrying won't
@@ -258,6 +263,37 @@ class DashboardClient:
                 f"[network_interface] giving up on {path} after {MAX_RETRIES} attempts: {last_err}"
             )
             self._outage_logged = True
+
+    def _absorb_response_body(self, resp: "httpx.Response") -> None:
+        """Pull dashboard-side state out of a 2xx response body.
+
+        Today the only field of interest is `usageLockedUntil` — the dashboard
+        includes it on /heartbeat and /usage so the agent can refuse Bedrock
+        calls in-process when the user's monthly budget is exhausted. The cache
+        update is delegated to app.network_interface.state, which is what the
+        LLM/VLM hot path consults via `is_quota_locked()` (zero I/O).
+
+        Defensive at every step: a missing field, malformed JSON, even a body
+        that isn't a dict, all become no-ops. We never want a response-shape
+        bug to break the outbound retry/queue contract.
+        """
+        try:
+            data = resp.json()
+        except Exception:
+            return
+        if not isinstance(data, dict):
+            return
+        # Use sentinel so we can distinguish "field present with value null"
+        # (explicit clear) from "field absent" (no info — keep current state).
+        sentinel = object()
+        raw = data.get("usageLockedUntil", sentinel)
+        if raw is sentinel:
+            return
+        try:
+            from app.network_interface.state import set_quota_lock
+            set_quota_lock(raw if isinstance(raw, str) else None)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning(f"[network_interface] failed to update quota cache: {exc}")
 
 
 _singleton: Optional[DashboardClient] = None

--- a/app/network_interface/outbound.py
+++ b/app/network_interface/outbound.py
@@ -1,0 +1,280 @@
+# -*- coding: utf-8 -*-
+"""
+app.network_interface.outbound
+
+DashboardClient — the only place the agent writes to the dashboard.
+
+Authentication (mirrors apps/backend/src/middleware/requireInstanceAuth.ts):
+
+    Authorization: Bearer <CONTAINER_AUTH_TOKEN>
+    X-Instance-Id:  <CONTAINER_INSTANCE_ID>
+
+Slice 1 only implements `report_usage`. The contract — including the body
+shape — must match the dashboard side at
+apps/backend/src/api/instance-callback/index.ts.
+
+Resilience policy: outbound calls MUST NOT block LLM work. Every public
+method is fire-and-forget — it schedules an async task with bounded retry +
+exponential backoff and drops events on a backpressure threshold so a long
+dashboard outage cannot grow memory without bound.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+import httpx
+
+from agent_core.core.hooks.types import UsageEventData
+from app.network_interface.config import (
+    NetworkInterfaceConfig,
+    dashboard_endpoint,
+    get_config,
+)
+
+try:
+    from app.logger import logger
+except Exception:  # pragma: no cover - import-time fallback for tooling
+    logger = logging.getLogger(__name__)
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+
+# How big the in-memory queue can grow before we start dropping the *oldest*
+# event to keep memory bounded. ~30 minutes of LLM activity at one event/sec.
+MAX_QUEUE = 2048
+
+# Retry policy for a single event. After this many attempts we drop the event
+# and log a warning — the local SQLite mirror still has it, so the truth isn't
+# lost; only the dashboard's view of it is.
+MAX_RETRIES = 5
+BASE_BACKOFF_SECONDS = 1.0
+MAX_BACKOFF_SECONDS = 30.0
+
+# HTTP timeouts (connect, read) — kept short so a wedged dashboard cannot
+# stall the worker.
+REQUEST_TIMEOUT_SECONDS = 10.0
+
+
+def _start_of_current_hour_iso() -> str:
+    """The dashboard upserts usage rows keyed by (instanceId, periodStart,
+    provider, model) where periodStart is the start-of-hour. Defaulting here
+    means a client that doesn't supply `period_start` still aggregates into
+    the same row as the dashboard's own default."""
+    now = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
+    return now.isoformat()
+
+
+class DashboardClient:
+    """Async outbound client. Singleton via `get_dashboard_client()`."""
+
+    def __init__(self, config: Optional[NetworkInterfaceConfig] = None) -> None:
+        self._config: NetworkInterfaceConfig = config or get_config()
+        self._client: Optional[httpx.AsyncClient] = None
+        # Tasks we've spawned; used only to drop them from the set on completion
+        # so a long-lived process doesn't accumulate finished-task references.
+        self._inflight: "set[asyncio.Task[None]]" = set()
+        # Coarse backpressure counter — number of currently-queued events.
+        self._queued: int = 0
+        # One warning per outage instead of per failed call, to avoid log floods.
+        self._outage_logged: bool = False
+
+    # ------------------------------------------------------------------ #
+    # public API
+    # ------------------------------------------------------------------ #
+
+    @property
+    def enabled(self) -> bool:
+        return self._config.enabled
+
+    async def report_usage(
+        self,
+        event: UsageEventData,
+        *,
+        period_start: Optional[str] = None,
+        requests: int = 1,
+        compute_seconds: int = 0,
+        storage_gb: Optional[float] = None,
+    ) -> None:
+        """Forward a single LLM/VLM usage event to the dashboard.
+
+        BYOK filter: only `provider="bedrock"` events reach the dashboard. Every
+        other provider (anthropic-direct, openai, gemini, byteplus, openrouter,
+        etc.) is BYOK — the user pays the upstream provider directly and
+        craftbot.live MUST NOT count those tokens against their plan budget
+        or display them in the dashboard's "Managed usage" surfaces. The
+        agent's local UsageReporter (SQLite) keeps logging all calls regardless,
+        so per-container analytics remain complete.
+
+        Maps `UsageEventData` to the `POST /api/instance-callback/usage` body.
+        `requests` defaults to 1 because each event corresponds to one LLM call.
+
+        Fire-and-forget — returns immediately, the actual HTTP call happens
+        in a background task. Returns without scheduling anything if the
+        interface is disabled OR the event is from a non-managed provider.
+        """
+        if not self._config.enabled:
+            return
+        # Single point of truth for the managed-LLM allowlist. Keep in sync
+        # with apps/backend/prisma/seed-llm-rates.sql — any provider added
+        # there must be added here too.
+        if (event.provider or "").lower() != "bedrock":
+            return
+
+        body: Dict[str, Any] = {
+            "periodStart": period_start or _start_of_current_hour_iso(),
+            "provider": event.provider or None,
+            "model": event.model or None,
+            "requests": requests,
+            "tokensInput": int(event.input_tokens or 0),
+            "tokensOutput": int(event.output_tokens or 0),
+            "tokensCached": int(event.cached_tokens or 0),
+            "computeSeconds": int(compute_seconds or 0),
+        }
+        if storage_gb is not None:
+            body["storageGb"] = float(storage_gb)
+
+        self._schedule("/api/instance-callback/usage", body)
+
+    async def heartbeat(
+        self,
+        *,
+        agent_state: Optional[str] = None,
+        uptime_seconds: Optional[int] = None,
+    ) -> None:
+        """Liveness ping. Slice 2 will fill in agent state; for now the
+        endpoint already accepts the empty body and just bumps lastActiveAt."""
+        if not self._config.enabled:
+            return
+        body: Dict[str, Any] = {}
+        if agent_state is not None:
+            body["agentState"] = agent_state
+        if uptime_seconds is not None:
+            body["uptimeSeconds"] = int(uptime_seconds)
+        self._schedule("/api/instance-callback/heartbeat", body)
+
+    async def aclose(self) -> None:
+        """Wait for any in-flight tasks (briefly) and close the HTTP client.
+        Called at agent shutdown so the last few events have a chance to drain."""
+        if self._inflight:
+            try:
+                await asyncio.wait(self._inflight, timeout=5.0)
+            except Exception:  # pragma: no cover
+                pass
+        if self._client is not None:
+            try:
+                await self._client.aclose()
+            finally:
+                self._client = None
+
+    # ------------------------------------------------------------------ #
+    # internals
+    # ------------------------------------------------------------------ #
+
+    def _schedule(self, path: str, body: Dict[str, Any]) -> None:
+        """Spawn a background send. Drops the event when queued >= MAX_QUEUE
+        so a downed dashboard cannot grow memory without bound. Logs at most
+        once per outage."""
+        if self._queued >= MAX_QUEUE:
+            if not self._outage_logged:
+                logger.warning(
+                    "[network_interface] outbound queue saturated "
+                    f"({self._queued}/{MAX_QUEUE}); dropping events until dashboard recovers"
+                )
+                self._outage_logged = True
+            return
+
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # No running loop — shouldn't happen in the agent runtime, but if it
+            # does we can't send. Don't crash; we already logged once below.
+            if not self._outage_logged:
+                logger.warning("[network_interface] no running asyncio loop; cannot send")
+                self._outage_logged = True
+            return
+
+        self._queued += 1
+        task = loop.create_task(self._send_with_retry(path, body))
+        self._inflight.add(task)
+        task.add_done_callback(self._on_task_done)
+
+    def _on_task_done(self, task: "asyncio.Task[None]") -> None:
+        self._inflight.discard(task)
+        self._queued = max(0, self._queued - 1)
+
+    async def _client_get(self) -> httpx.AsyncClient:
+        if self._client is None:
+            self._client = httpx.AsyncClient(
+                timeout=httpx.Timeout(REQUEST_TIMEOUT_SECONDS),
+                headers={
+                    "Authorization": f"Bearer {self._config.auth_token}",
+                    "X-Instance-Id": self._config.instance_id,
+                    "Content-Type": "application/json",
+                },
+            )
+        return self._client
+
+    async def _send_with_retry(self, path: str, body: Dict[str, Any]) -> None:
+        url = dashboard_endpoint(path)
+        if not url:
+            return  # config disabled mid-flight; nothing to do
+
+        for attempt in range(MAX_RETRIES):
+            try:
+                client = await self._client_get()
+                resp = await client.post(url, json=body)
+                if 200 <= resp.status_code < 300:
+                    if self._outage_logged:
+                        logger.info("[network_interface] dashboard reachable again")
+                        self._outage_logged = False
+                    return
+
+                # 4xx is the dashboard rejecting our payload — retrying won't
+                # help and would mask a bug. Log and drop.
+                if 400 <= resp.status_code < 500:
+                    logger.warning(
+                        "[network_interface] dashboard rejected request "
+                        f"{path}: {resp.status_code} {resp.text[:200]}"
+                    )
+                    return
+
+                # 5xx / unexpected — fall through to retry below.
+                last_err: Any = f"HTTP {resp.status_code}"
+            except (httpx.HTTPError, OSError) as exc:
+                last_err = exc
+
+            # Backoff with jitter. Cap so a long outage doesn't sleep forever
+            # while still holding a slot in the queue.
+            delay = min(MAX_BACKOFF_SECONDS, BASE_BACKOFF_SECONDS * (2 ** attempt))
+            delay = delay * (0.5 + random.random() * 0.5)
+            await asyncio.sleep(delay)
+
+        if not self._outage_logged:
+            logger.warning(
+                f"[network_interface] giving up on {path} after {MAX_RETRIES} attempts: {last_err}"
+            )
+            self._outage_logged = True
+
+
+_singleton: Optional[DashboardClient] = None
+
+
+def get_dashboard_client() -> DashboardClient:
+    """Process-wide singleton."""
+    global _singleton
+    if _singleton is None:
+        _singleton = DashboardClient()
+    return _singleton
+
+
+async def report_usage_to_dashboard(event: UsageEventData) -> None:
+    """Convenience hook with the exact `ReportUsageHook` signature.
+
+    Use this when you only need usage reporting and don't want to import the
+    client class. It just delegates to `get_dashboard_client().report_usage`.
+    """
+    await get_dashboard_client().report_usage(event)

--- a/app/network_interface/server.py
+++ b/app/network_interface/server.py
@@ -1,0 +1,199 @@
+# -*- coding: utf-8 -*-
+"""
+app.network_interface.server
+
+Standalone aiohttp server hosting the dashboard-facing pull endpoints
+(/__cb/state, /__cb/events, /__cb/healthz). Runs independently of any UI
+adapter — the browser adapter owns the user-facing port 7926, this server
+owns whatever port the dashboard control plane lives on.
+
+Why separate:
+  - The dashboard's surface MUST be reachable in any UI mode (CLI, browser,
+    or none at all). Mounting it on the browser adapter's app would mean a
+    CLI-mode container has no /__cb/* surface — the dashboard would think
+    that container is dead.
+  - Browser adapter is user-facing UI; it shouldn't carry control-plane code.
+  - Two separate servers = independent failure domains. A bug in the user UI
+    can't take down the dashboard's read path (and vice versa).
+
+Port: `CONTAINER_INBOUND_PORT` env var, default 7928. Production deployments
+should configure the platform-side reverse proxy (Traefik on craftbot-platform)
+to route `/__cb/*` on the customer hostname to this port; the rest of the
+hostname routes to the browser adapter's port 7926 as today. For local dev
+you can hit the port directly: `curl localhost:7928/__cb/healthz`.
+
+Host: 0.0.0.0 inside the container so Traefik in another container can reach
+it. The container's network namespace plus Traefik's route rules are the
+real perimeter — binding to localhost would defeat external reachability
+without buying us extra safety.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Optional, TYPE_CHECKING
+
+from app.network_interface.config import is_enabled
+from app.network_interface.inbound import register_routes
+
+try:
+    from app.logger import logger
+except Exception:  # pragma: no cover
+    import logging
+    logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from aiohttp import web
+
+
+DEFAULT_PORT = 7928
+DEFAULT_HOST = "0.0.0.0"
+
+
+def _resolve_port() -> int:
+    """Read CONTAINER_INBOUND_PORT, fall back to DEFAULT_PORT. Invalid values
+    fall back too (with a warning) rather than crashing the agent."""
+    raw = os.environ.get("CONTAINER_INBOUND_PORT", "").strip()
+    if not raw:
+        return DEFAULT_PORT
+    try:
+        port = int(raw)
+        if not (0 < port < 65536):
+            raise ValueError(f"out of range: {port}")
+        return port
+    except ValueError as exc:
+        logger.warning(
+            f"[network_interface] invalid CONTAINER_INBOUND_PORT={raw!r} ({exc}); "
+            f"falling back to {DEFAULT_PORT}"
+        )
+        return DEFAULT_PORT
+
+
+class InboundServer:
+    """Owns the aiohttp app + AppRunner + TCPSite for /__cb/* endpoints.
+
+    Lifecycle is driven from agent_base.boot()/shutdown — there is no global
+    singleton because the agent decides when its task_manager + event_stream_manager
+    are ready to be served (you can't snapshot state from half-initialised
+    managers). Pass them in on construction and the server keeps live refs.
+    """
+
+    def __init__(
+        self,
+        *,
+        task_manager: Any,
+        event_stream_manager: Any,
+        host: Optional[str] = None,
+        port: Optional[int] = None,
+    ) -> None:
+        self._task_manager = task_manager
+        self._event_stream_manager = event_stream_manager
+        self._host = host or DEFAULT_HOST
+        self._port = port if port is not None else _resolve_port()
+        self._app: Optional["web.Application"] = None
+        self._runner: Optional["web.AppRunner"] = None
+        self._site: Optional["web.TCPSite"] = None
+        self._started: bool = False
+
+    @property
+    def port(self) -> int:
+        return self._port
+
+    @property
+    def host(self) -> str:
+        return self._host
+
+    @property
+    def started(self) -> bool:
+        return self._started
+
+    async def start(self) -> None:
+        """Create the aiohttp app, mount the routes, bind the TCP site.
+
+        Best-effort: if the port is already in use (another agent process on
+        the same host, perhaps), we log and stay degraded rather than crash
+        the agent. The dashboard will see missing /__cb/* responses and fall
+        back to its placeholder states.
+
+        Safe to call when the network interface is disabled (no env vars) —
+        we still start the server so /__cb/healthz answers; /__cb/state and
+        /__cb/events answer 401 until CONTAINER_AUTH_TOKEN is set.
+        """
+        if self._started:
+            return
+
+        try:
+            from aiohttp import web
+        except ImportError:
+            logger.warning("[network_interface] aiohttp not installed; inbound server disabled")
+            return
+
+        self._app = web.Application()
+        register_routes(
+            self._app,
+            task_manager=self._task_manager,
+            event_stream_manager=self._event_stream_manager,
+        )
+
+        self._runner = web.AppRunner(self._app)
+        try:
+            await self._runner.setup()
+            self._site = web.TCPSite(self._runner, self._host, self._port)
+            await self._site.start()
+        except OSError as exc:
+            # Port in use, permission denied, etc. Don't crash the agent — the
+            # rest of the runtime is independent of the dashboard reachability.
+            logger.warning(
+                f"[network_interface] inbound server failed to bind "
+                f"{self._host}:{self._port}: {exc}"
+            )
+            # Best-effort cleanup of the half-built runner.
+            try:
+                await self._runner.cleanup()
+            except Exception:
+                pass
+            self._runner = None
+            self._site = None
+            self._app = None
+            return
+
+        self._started = True
+        if is_enabled():
+            logger.info(
+                f"[network_interface] inbound server listening on "
+                f"http://{self._host}:{self._port}/__cb/*"
+            )
+        else:
+            logger.info(
+                f"[network_interface] inbound server listening on "
+                f"http://{self._host}:{self._port}/__cb/* "
+                "(auth disabled — set CONTAINER_AUTH_TOKEN to enable state/events)"
+            )
+
+    async def stop(self) -> None:
+        """Tear down the server. Idempotent; safe to call without start()."""
+        if not self._started:
+            # If start() failed mid-setup we might still have a half-built
+            # runner that needs cleanup.
+            if self._runner is not None:
+                try:
+                    await self._runner.cleanup()
+                except Exception:
+                    pass
+                self._runner = None
+            return
+        try:
+            if self._site is not None:
+                await self._site.stop()
+        except Exception as exc:
+            logger.warning(f"[network_interface] inbound site stop error: {exc}")
+        try:
+            if self._runner is not None:
+                await self._runner.cleanup()
+        except Exception as exc:
+            logger.warning(f"[network_interface] inbound runner cleanup error: {exc}")
+        self._site = None
+        self._runner = None
+        self._app = None
+        self._started = False
+        logger.info("[network_interface] inbound server stopped")

--- a/app/network_interface/snapshot.py
+++ b/app/network_interface/snapshot.py
@@ -1,0 +1,301 @@
+# -*- coding: utf-8 -*-
+"""
+app.network_interface.snapshot
+
+Read-only assemblers for the dashboard. Two responsibilities:
+
+  - derive_agent_state(task_manager) — collapse the TaskManager's view of the
+    world into the dashboard's coarse vocabulary
+    ("idle" | "thinking" | "working" | "waiting" | "error").
+  - process_uptime_seconds() — how long this agent process has been alive,
+    used by the heartbeat.
+
+Slice 3 will extend this module with snapshot builders for /state, /events,
+and /tasks — keeping all dashboard-facing read paths next to each other.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import time
+from typing import Any, Dict, List, Optional
+
+
+# Agent state vocabulary mirrors the AgentState type the dashboard exports
+# (apps/web/lib/types.ts). Keep them in sync — if the agent adds a state, the
+# dashboard accepts it verbatim (rendered capitalised) without a release.
+AGENT_STATE_IDLE = "idle"
+AGENT_STATE_THINKING = "thinking"
+AGENT_STATE_WORKING = "working"
+AGENT_STATE_WAITING = "waiting"
+AGENT_STATE_ERROR = "error"
+
+
+# Recorded the first time process_uptime_seconds() is called, so a heartbeat
+# can report a monotonic uptime regardless of wall-clock skew.
+_started_monotonic: Optional[float] = None
+
+
+def process_uptime_seconds() -> int:
+    """Whole seconds since the agent process started (first call to this fn).
+
+    Uses time.monotonic so it's immune to wall-clock jumps (NTP, suspend).
+    The dashboard treats this as advisory — it's not persisted, just shown
+    on the instance detail page.
+    """
+    global _started_monotonic
+    if _started_monotonic is None:
+        _started_monotonic = time.monotonic()
+        return 0
+    return int(time.monotonic() - _started_monotonic)
+
+
+def derive_agent_state(task_manager: Any) -> str:
+    """Map TaskManager state to the dashboard's coarse agent_state.
+
+    Precedence (highest first):
+      error   — last terminal task ended with status="error" recently
+      waiting — a running task is flagged waiting_for_user_reply
+      working — any task is in status "running"
+      idle    — nothing else applies (default)
+
+    "thinking" is reserved for finer-grained signals (e.g. mid-LLM-call) that
+    the agent_base will eventually push as transient overrides. For now we
+    collapse everything-LLM-busy into "working" since the task_manager doesn't
+    distinguish.
+
+    Defensive against a missing or partially-initialised task_manager — the
+    heartbeat loop must not crash the agent if startup ordering changes.
+    """
+    if task_manager is None:
+        return AGENT_STATE_IDLE
+
+    tasks_attr = getattr(task_manager, "tasks", None)
+    if not tasks_attr:
+        return AGENT_STATE_IDLE
+
+    # `tasks` is a dict[task_id -> Task] on the upstream TaskManager.
+    try:
+        all_tasks = list(tasks_attr.values()) if hasattr(tasks_attr, "values") else list(tasks_attr)
+    except Exception:
+        return AGENT_STATE_IDLE
+
+    if not all_tasks:
+        return AGENT_STATE_IDLE
+
+    # Waiting beats working — a task that's blocked on the user is not actively
+    # consuming LLM time even though its status is still "running".
+    for t in all_tasks:
+        if getattr(t, "status", None) == "running" and getattr(t, "waiting_for_user_reply", False):
+            return AGENT_STATE_WAITING
+
+    for t in all_tasks:
+        if getattr(t, "status", None) == "running":
+            return AGENT_STATE_WORKING
+
+    # No running tasks. Surface "error" if the most recently ended task errored
+    # within the last ~5 minutes; older errors are stale.
+    recent_error = _has_recent_error(all_tasks, window_seconds=300)
+    if recent_error:
+        return AGENT_STATE_ERROR
+
+    return AGENT_STATE_IDLE
+
+
+def _has_recent_error(tasks: list, *, window_seconds: int) -> bool:
+    """True iff any task ended with status="error" within the window.
+
+    Best-effort — tolerates Task objects that don't carry ended_at, in which
+    case we can't tell freshness and conservatively return False.
+    """
+    now = _dt.datetime.now(_dt.timezone.utc)
+    for t in tasks:
+        if getattr(t, "status", None) != "error":
+            continue
+        ended_at = getattr(t, "ended_at", None)
+        if not ended_at:
+            continue
+        try:
+            ts = _dt.datetime.fromisoformat(str(ended_at))
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=_dt.timezone.utc)
+            if (now - ts).total_seconds() <= window_seconds:
+                return True
+        except Exception:
+            continue
+    return False
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Dashboard pull endpoints — assemblers for GET /__cb/state and /__cb/events.
+# ───────────────────────────────────────────────────────────────────────────
+
+
+def _current_task_brief(task_manager: Any) -> Optional[Dict[str, Any]]:
+    """The running task's id + name, or None when nothing is running. Returned
+    as a small dict because the dashboard only needs to label the screen, not
+    render the full task object."""
+    if task_manager is None:
+        return None
+    tasks_attr = getattr(task_manager, "tasks", None)
+    if not tasks_attr:
+        return None
+    try:
+        all_tasks = list(tasks_attr.values()) if hasattr(tasks_attr, "values") else list(tasks_attr)
+    except Exception:
+        return None
+    for t in all_tasks:
+        if getattr(t, "status", None) == "running":
+            return {
+                "id": getattr(t, "id", None),
+                "name": getattr(t, "name", None),
+            }
+    return None
+
+
+def _read_system_metrics() -> Dict[str, Any]:
+    """CPU / memory / disk percentages from the existing metrics collector.
+    Returns zeros when psutil is unavailable so the dashboard can render
+    placeholder bars without special-casing missing data."""
+    try:
+        import psutil  # type: ignore
+    except Exception:
+        return {"cpuPct": 0.0, "memPct": 0.0, "diskPct": 0.0, "diskUsedGb": 0.0, "diskTotalGb": 0.0}
+
+    # interval=None makes cpu_percent non-blocking; the first call after import
+    # returns 0.0, subsequent calls return the delta since the previous call.
+    # That's fine — the dashboard polls every few seconds, so it warms quickly.
+    try:
+        cpu_pct = float(psutil.cpu_percent(interval=None))
+    except Exception:
+        cpu_pct = 0.0
+    try:
+        mem = psutil.virtual_memory()
+        mem_pct = float(mem.percent)
+    except Exception:
+        mem_pct = 0.0
+    try:
+        disk = psutil.disk_usage("/")
+        disk_pct = float(disk.percent)
+        disk_used_gb = round(disk.used / (1024**3), 2)
+        disk_total_gb = round(disk.total / (1024**3), 2)
+    except Exception:
+        disk_pct = 0.0
+        disk_used_gb = 0.0
+        disk_total_gb = 0.0
+
+    return {
+        "cpuPct": cpu_pct,
+        "memPct": mem_pct,
+        "diskPct": disk_pct,
+        "diskUsedGb": disk_used_gb,
+        "diskTotalGb": disk_total_gb,
+    }
+
+
+def build_state_snapshot(task_manager: Any) -> Dict[str, Any]:
+    """Body for `GET /__cb/state`. Cheap to compute — meant to be polled at
+    a few-second cadence."""
+    return {
+        "agentState": derive_agent_state(task_manager),
+        "currentTask": _current_task_brief(task_manager),
+        "uptimeSeconds": process_uptime_seconds(),
+        "system": _read_system_metrics(),
+    }
+
+
+def _serialise_event(rec: Any) -> Optional[Dict[str, Any]]:
+    """Map an EventRecord to the dashboard's event JSON shape.
+
+    The dashboard renders a compact activity feed: one row per record, with
+    `displayMessage` preferred over `message` when present. We pass the full
+    `message` too so the user can hover/inspect.
+
+    Returns None for malformed records — the caller filters them out rather
+    than crash the whole response on one bad event.
+    """
+    try:
+        ev = getattr(rec, "event", None)
+        if ev is None:
+            return None
+        ts = getattr(rec, "ts", None) or getattr(ev, "ts", None)
+        if ts is None:
+            return None
+        ts_iso = ts.isoformat() if hasattr(ts, "isoformat") else str(ts)
+        return {
+            "kind": getattr(ev, "kind", ""),
+            "message": getattr(ev, "message", ""),
+            "displayMessage": getattr(ev, "display_message", None),
+            "severity": getattr(ev, "severity", "INFO"),
+            "ts": ts_iso,
+            "repeatCount": int(getattr(rec, "repeat_count", 1) or 1),
+        }
+    except Exception:
+        return None
+
+
+def build_events_snapshot(
+    event_stream_manager: Any,
+    *,
+    since_iso: Optional[str] = None,
+    limit: int = 50,
+) -> Dict[str, Any]:
+    """Body for `GET /__cb/events`. Returns up to `limit` events across all
+    task streams, newest last (so the dashboard can render top-down and let
+    the latest event float to the top of the list).
+
+    `since_iso` lets the dashboard ask for "everything after the last event
+    I saw" — saves bandwidth on poll, and avoids the dashboard having to
+    de-dupe by ts/kind/message on the client.
+    """
+    if event_stream_manager is None:
+        return {"events": []}
+
+    # Best-effort timestamp parse; bad inputs are treated as "no filter".
+    since_ts: Optional[_dt.datetime] = None
+    if since_iso:
+        try:
+            since_ts = _dt.datetime.fromisoformat(since_iso)
+            if since_ts.tzinfo is None:
+                since_ts = since_ts.replace(tzinfo=_dt.timezone.utc)
+        except Exception:
+            since_ts = None
+
+    # Pull tail_events from every task stream the manager knows about. We can't
+    # assume a single canonical stream — multi-tasking agents have one per task.
+    streams_attr = getattr(event_stream_manager, "_task_streams", None)
+    if not streams_attr:
+        return {"events": []}
+    try:
+        streams = list(streams_attr.values()) if hasattr(streams_attr, "values") else list(streams_attr)
+    except Exception:
+        return {"events": []}
+
+    collected: List[Dict[str, Any]] = []
+    for s in streams:
+        tail = getattr(s, "tail_events", None)
+        if not tail:
+            continue
+        for rec in tail:
+            item = _serialise_event(rec)
+            if item is None:
+                continue
+            if since_ts is not None:
+                try:
+                    rec_ts = _dt.datetime.fromisoformat(item["ts"])
+                    if rec_ts.tzinfo is None:
+                        rec_ts = rec_ts.replace(tzinfo=_dt.timezone.utc)
+                    if rec_ts <= since_ts:
+                        continue
+                except Exception:
+                    pass
+            collected.append(item)
+
+    # Sort by ts ascending, then trim to the most recent `limit` so the cap
+    # is on the *newest* events. Clamp `limit` to a sane upper bound.
+    collected.sort(key=lambda e: e.get("ts", ""))
+    effective_limit = max(1, min(int(limit or 50), 500))
+    if len(collected) > effective_limit:
+        collected = collected[-effective_limit:]
+
+    return {"events": collected}

--- a/app/network_interface/state.py
+++ b/app/network_interface/state.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+"""
+app.network_interface.state
+
+Process-wide cache of the managed-Bedrock quota-lock state. The dashboard is
+the source of truth; this module just remembers what we last heard back.
+
+Signal flow:
+    /api/instance-callback/usage     → DashboardClient parses response body  ┐
+    /api/instance-callback/heartbeat → DashboardClient parses response body  ┴→ set_quota_lock()
+                                                                               │
+                                                                               ▼
+    LLMInterface / VLMInterface, before each Bedrock call: is_quota_locked()
+        true  → raise ManagedQuotaExceededError; chat surfaces a QUOTA bubble
+        false → call proceeds
+
+Critically: `is_quota_locked()` is a *local* check — no HTTP, no DB, no I/O.
+It must never block the LLM hot path. The dashboard's lock state is pulled in
+opportunistically when our own outbound calls return, so the cache is always
+at most one round-trip stale.
+
+Failure modes:
+  - Dashboard unreachable → cache retains last value. Stays locked if it was
+    locked; stays unlocked otherwise. Next successful heartbeat resyncs.
+  - Agent restart → cache resets to "unlocked". The heartbeat loop's
+    immediate-first-send (see app/network_interface/heartbeat.py) repopulates
+    it within seconds. Tiny window where one Bedrock call may slip through
+    before the first heartbeat lands; acceptable.
+  - Lock expires (month rollover) → dashboard returns `usageLockedUntil: null`
+    in the next heartbeat response → set_quota_lock(None) clears.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import threading
+from typing import Optional
+
+
+# Guards the module-level state — set/read from multiple coroutines (heartbeat
+# task, LLM call sites). The lock is held only for trivial reads/writes; never
+# during HTTP work, so contention is effectively nil.
+_lock = threading.Lock()
+_quota_locked_until: Optional[_dt.datetime] = None
+
+
+def _parse_iso(value: Optional[str]) -> Optional[_dt.datetime]:
+    """Best-effort ISO-8601 → aware datetime. Returns None on bad input —
+    callers treat that as "no lock state change"."""
+    if not value:
+        return None
+    try:
+        dt = _dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=_dt.timezone.utc)
+    return dt
+
+
+def set_quota_lock(iso_or_none: Optional[str]) -> None:
+    """Update the cached lock. None / empty / unparseable → clear the lock.
+
+    Called by the DashboardClient after every successful /heartbeat or /usage
+    response. The dashboard always sends the field (null when not locked), so
+    receiving the field is the auth signal that the cache should be trusted.
+    """
+    parsed = _parse_iso(iso_or_none) if iso_or_none else None
+    with _lock:
+        global _quota_locked_until
+        _quota_locked_until = parsed
+
+
+def is_quota_locked() -> bool:
+    """Returns True iff we currently believe a managed-Bedrock lock is in
+    effect. Treats locks whose timestamp has already passed as expired (we
+    self-clear lazily so a missed heartbeat doesn't leave a stale lock pinned).
+
+    This is the hot-path predicate called before every Bedrock LLM/VLM call —
+    pure local check, no I/O.
+    """
+    now = _dt.datetime.now(_dt.timezone.utc)
+    with _lock:
+        global _quota_locked_until
+        if _quota_locked_until is None:
+            return False
+        if _quota_locked_until <= now:
+            _quota_locked_until = None
+            return False
+        return True
+
+
+def get_quota_reset() -> Optional[_dt.datetime]:
+    """The cached reset timestamp, or None when not locked. Used by the LLM
+    error message to tell the user when managed Bedrock will resume."""
+    now = _dt.datetime.now(_dt.timezone.utc)
+    with _lock:
+        global _quota_locked_until
+        if _quota_locked_until is None:
+            return None
+        if _quota_locked_until <= now:
+            _quota_locked_until = None
+            return None
+        return _quota_locked_until
+
+
+def _reset_for_tests() -> None:
+    """Clear the cache. Tests that want a clean slate between cases."""
+    with _lock:
+        global _quota_locked_until
+        _quota_locked_until = None

--- a/app/onboarding/interfaces/steps.py
+++ b/app/onboarding/interfaces/steps.py
@@ -107,8 +107,11 @@ class ProviderStep:
     description = "Choose which AI provider to use for the agent."
     required = True
 
-    # Provider options with their display names
+    # Provider options with their display names. `craftbot` is the managed
+    # default — routes through AWS Bedrock with container-injected credentials
+    # and skips the API-key step (see OnboardingFlowController.next_step).
     PROVIDERS = [
+        ("craftbot", "CraftBot default provider", "Managed by craftbot.live — no API key required"),
         ("openai", "OpenAI", "GPT models"),
         ("gemini", "Google Gemini", "Gemini models"),
         ("byteplus", "BytePlus", "Kimi models"),
@@ -125,7 +128,7 @@ class ProviderStep:
                 value=provider_id,
                 label=label,
                 description=desc,
-                default=(provider_id == "openai"),
+                default=(provider_id == "craftbot"),
             )
             for provider_id, label, desc in self.PROVIDERS
         ]
@@ -143,7 +146,7 @@ class ProviderStep:
         current_provider = get_llm_provider().lower()
         if current_provider and current_provider in [p[0] for p in self.PROVIDERS]:
             return current_provider
-        return "openai"
+        return "craftbot"
 
 
 class ApiKeyStep:

--- a/app/ui_layer/browser/frontend/src/pages/Settings/ModelSettings.tsx
+++ b/app/ui_layer/browser/frontend/src/pages/Settings/ModelSettings.tsx
@@ -46,6 +46,7 @@ interface ProviderInfo {
   has_vlm: boolean
   supports_catalog?: boolean
   is_bedrock?: boolean
+  is_managed?: boolean
 }
 
 interface ApiKeyStatus {
@@ -318,56 +319,42 @@ export function ModelSettings() {
             </select>
           </div>
 
-          {/* Model Configuration */}
+          {/* Model Configuration — locked, read-only display. The model is
+              fixed per provider in agent_core/core/models/model_registry.py
+              and cannot be changed from this page. */}
           {currentProvider && (
             <>
-              {provider === 'openrouter' && currentProvider.supports_catalog ? (
-                <OpenRouterModelPicker
-                  models={orCatalog.models}
-                  loading={orCatalog.loading}
-                  error={orCatalog.error}
-                  onRefresh={orCatalog.refresh}
-                  label="LLM Model"
-                  value={newLlmModel || currentLlmModel || ''}
-                  onChange={(v) => { setNewLlmModel(v); setHasChanges(true) }}
-                />
-              ) : (
-                <div className={styles.formGroup}>
-                  <label>LLM Model</label>
-                  <input
-                    type="text"
-                    value={newLlmModel || currentLlmModel || ''}
-                    onChange={(e) => { setNewLlmModel(e.target.value); setHasChanges(true) }}
-                    placeholder={currentLlmModel || 'Enter LLM model name...'}
-                  />
+              <div className={styles.formGroup}>
+                <label>LLM Model</label>
+                <div className={styles.maskedKey}>
+                  {currentLlmModel || currentProvider.llm_model || '—'}
                 </div>
-              )}
+              </div>
 
               {currentProvider.has_vlm && (
-                provider === 'openrouter' && currentProvider.supports_catalog ? (
-                  <OpenRouterModelPicker
-                    models={orCatalog.models}
-                    loading={orCatalog.loading}
-                    error={orCatalog.error}
-                    onRefresh={orCatalog.refresh}
-                    label="VLM Model"
-                    requireVision
-                    value={newVlmModel || currentVlmModel || ''}
-                    onChange={(v) => { setNewVlmModel(v); setHasChanges(true) }}
-                  />
-                ) : (
                 <div className={styles.formGroup}>
                   <label>VLM Model</label>
-                  <input
-                    type="text"
-                    value={newVlmModel || currentVlmModel || ''}
-                    onChange={(e) => { setNewVlmModel(e.target.value); setHasChanges(true) }}
-                    placeholder={currentVlmModel || 'Enter VLM model name...'}
-                  />
+                  <div className={styles.maskedKey}>
+                    {currentVlmModel || currentProvider.vlm_model || '—'}
+                  </div>
                 </div>
-                )
               )}
             </>
+          )}
+
+          {/* Managed-provider notice — shown for craftbot (no API key or AWS
+              credentials needed because the container env supplies them). */}
+          {currentProvider?.is_managed && (
+            <div className={styles.formGroup}>
+              <label>
+                Credentials
+                <Badge variant="success" style={{ marginLeft: 8 }}>Managed</Badge>
+              </label>
+              <p style={{ fontSize: '0.78rem', color: 'var(--text-muted, #888)', marginTop: 6, lineHeight: 1.4 }}>
+                Powered by craftbot.live. Usage is metered to your account — no
+                API key or AWS credentials required.
+              </p>
+            </div>
           )}
 
           {/* API Key */}

--- a/app/ui_layer/onboarding/controller.py
+++ b/app/ui_layer/onboarding/controller.py
@@ -183,6 +183,10 @@ class OnboardingFlowController:
         """
         Move to the next step.
 
+        When the active provider is `craftbot` (the managed default) and the
+        next step is `ApiKeyStep`, auto-skip past it — managed Bedrock uses
+        container-injected AWS credentials and there is no user key to enter.
+
         Returns:
             True if there are more steps, False if onboarding is complete
         """
@@ -191,6 +195,17 @@ class OnboardingFlowController:
         if self._state.current_step >= len(self.STEP_CLASSES):
             self._complete()
             return False
+
+        if (
+            self.STEP_CLASSES[self._state.current_step] is ApiKeyStep
+            and self._state.collected_data.get("provider") == "craftbot"
+        ):
+            # Record an empty api_key so _complete()'s no-key branch fires.
+            self._state.collected_data["api_key"] = ""
+            self._state.current_step += 1
+            if self._state.current_step >= len(self.STEP_CLASSES):
+                self._complete()
+                return False
 
         return True
 
@@ -295,6 +310,10 @@ class OnboardingFlowController:
             else:
                 # User has direct access — save key under the native provider.
                 save_settings_to_json(provider, api_key)
+        elif provider == "craftbot":
+            # Managed default — no API key to save. Persist just the provider
+            # choice so future boots read settings.json and find craftbot.
+            save_settings_to_json(provider, "")
         elif provider and api_key:
             save_settings_to_json(provider, api_key)
 

--- a/app/ui_layer/settings/model_settings.py
+++ b/app/ui_layer/settings/model_settings.py
@@ -95,6 +95,14 @@ PROVIDER_INFO = {
         # generic "Server URL" field for an AWS-specific form.
         "base_url_env": "AWS_REGION",
     },
+    "craftbot": {
+        "name": "CraftBot default provider",
+        # Managed default — credentials come from the container env (boto3
+        # default chain), so neither an API key field nor an AWS credentials
+        # block is shown. Usage is metered back to the craftbot.live dashboard.
+        "requires_api_key": False,
+        "is_managed": True,
+    },
 }
 
 
@@ -181,6 +189,7 @@ def get_available_providers() -> Dict[str, Any]:
                     "has_vlm": vlm_model is not None,
                     "supports_catalog": info.get("supports_catalog", False),
                     "is_bedrock": info.get("is_bedrock", False),
+                    "is_managed": info.get("is_managed", False),
                 }
             )
 
@@ -330,34 +339,23 @@ def update_model_settings(
         if "aws_credentials" not in settings:
             settings["aws_credentials"] = {}
 
-        # Update providers
-        # When provider changes, clear the model override so default model is used
-        old_llm_provider = settings["model"].get("llm_provider")
-        old_vlm_provider = settings["model"].get("vlm_provider")
+        # Update providers. Model overrides are intentionally NOT honored —
+        # the model is locked to whatever MODEL_REGISTRY returns for the chosen
+        # provider. The `llm_model` / `vlm_model` parameters are kept in the
+        # signature for backwards compatibility with existing websocket
+        # adapters but their values are discarded.
+        settings["model"]["llm_model"] = None
+        settings["model"]["vlm_model"] = None
 
         if llm_provider:
             settings["model"]["llm_provider"] = llm_provider
-            # Clear LLM model if provider changed (unless new model explicitly provided)
-            if llm_provider != old_llm_provider and llm_model is None:
-                settings["model"]["llm_model"] = None
 
         if vlm_provider:
             settings["model"]["vlm_provider"] = vlm_provider
-            # Clear VLM model if provider changed (unless new model explicitly provided)
-            if vlm_provider != old_vlm_provider and vlm_model is None:
-                settings["model"]["vlm_model"] = None
-        elif llm_provider and llm_provider != old_llm_provider:
-            # If only llm_provider changed and vlm_provider not specified,
-            # also update vlm_provider to match and clear vlm_model
+        elif llm_provider:
+            # If only llm_provider was specified, mirror it onto vlm_provider
+            # so they stay in lockstep.
             settings["model"]["vlm_provider"] = llm_provider
-            if vlm_model is None:
-                settings["model"]["vlm_model"] = None
-
-        # Update custom models (explicit values override the auto-clear above)
-        if llm_model is not None:
-            settings["model"]["llm_model"] = llm_model if llm_model else None
-        if vlm_model is not None:
-            settings["model"]["vlm_model"] = vlm_model if vlm_model else None
 
         # Update API key in settings.json
         if provider_for_key and api_key is not None:

--- a/app/vlm_interface.py
+++ b/app/vlm_interface.py
@@ -4,9 +4,18 @@ VLM interface for CraftBot.
 
 Re-exports VLMInterface from agent_core with CraftBot-specific hooks
 for state access (using STATE singleton) and usage reporting.
+
+Hosted-version addition: managed-Bedrock quota guard. Symmetric with
+app/llm/interface.py — when the dashboard has set a quota lock, the Bedrock
+vision path short-circuits with a ManagedQuotaExceededError instead of
+calling AWS. VLM doesn't use the LLMErrorInfo classifier (the upstream VLM
+interface just re-raises), so we raise an exception; the calling code's
+error handling surfaces the message. By the time a VLM-only path actually
+hits this guard, the LLM path will usually have already surfaced the QUOTA
+chat bubble (LLM is the user-facing surface), so the user has context.
 """
 
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from agent_core.core.impl.vlm import VLMInterface as _VLMInterface
 from agent_core.core.hooks.types import UsageEventData
@@ -98,3 +107,30 @@ class VLMInterface(_VLMInterface):
             output_tokens,
             cached_tokens,
         )
+
+    def _bedrock_describe_bytes(
+        self,
+        image_bytes,
+        system_prompt: Optional[str],
+        user_prompt: Optional[str],
+    ) -> Dict[str, Any]:
+        """Managed-Bedrock vision quota guard.
+
+        Mirrors LLMInterface._generate_bedrock: if the cached dashboard lock
+        state says the user is over their monthly budget, refuse locally with
+        a ManagedQuotaExceededError. The upstream VLM interface re-raises any
+        exception from this method, so the error propagates to the caller.
+
+        The check is a pure local-memory read (no I/O) — keeps the VLM hot
+        path unaffected when the user is NOT locked.
+        """
+        from app.network_interface import (
+            is_quota_locked,
+            get_quota_reset,
+            ManagedQuotaExceededError,
+        )
+
+        if is_quota_locked():
+            raise ManagedQuotaExceededError(reset_at=get_quota_reset())
+
+        return super()._bedrock_describe_bytes(image_bytes, system_prompt, user_prompt)

--- a/app/vlm_interface.py
+++ b/app/vlm_interface.py
@@ -24,10 +24,17 @@ def _set_token_count(count: int) -> None:
 
 
 async def _report_usage(event: UsageEventData) -> None:
-    """Report usage to local storage via UsageReporter."""
+    """Report usage to local SQLite AND forward to the craftbot.live dashboard.
+
+    Symmetric with LLMInterface._report_usage — VLM calls are billed too, so
+    they need to land in the same dashboard UsageRecord rows. See
+    app/network_interface/outbound.py for the fire-and-forget semantics.
+    """
     from app.usage import get_usage_reporter
+    from app.network_interface import report_usage_to_dashboard
 
     await get_usage_reporter().report(event)
+    await report_usage_to_dashboard(event)
 
 
 class VLMInterface(_VLMInterface):

--- a/app/vlm_interface.py
+++ b/app/vlm_interface.py
@@ -114,23 +114,25 @@ class VLMInterface(_VLMInterface):
         system_prompt: Optional[str],
         user_prompt: Optional[str],
     ) -> Dict[str, Any]:
-        """Managed-Bedrock vision quota guard.
+        """Managed-provider vision quota guard.
+
+        Only fires for `craftbot` (the managed default that bills back to
+        craftbot.live). BYOK `bedrock` uses the user's own AWS account and
+        falls through unmodified.
 
         Mirrors LLMInterface._generate_bedrock: if the cached dashboard lock
         state says the user is over their monthly budget, refuse locally with
         a ManagedQuotaExceededError. The upstream VLM interface re-raises any
         exception from this method, so the error propagates to the caller.
-
-        The check is a pure local-memory read (no I/O) — keeps the VLM hot
-        path unaffected when the user is NOT locked.
         """
-        from app.network_interface import (
-            is_quota_locked,
-            get_quota_reset,
-            ManagedQuotaExceededError,
-        )
+        if self.provider == "craftbot":
+            from app.network_interface import (
+                is_quota_locked,
+                get_quota_reset,
+                ManagedQuotaExceededError,
+            )
 
-        if is_quota_locked():
-            raise ManagedQuotaExceededError(reset_at=get_quota_reset())
+            if is_quota_locked():
+                raise ManagedQuotaExceededError(reset_at=get_quota_reset())
 
         return super()._bedrock_describe_bytes(image_bytes, system_prompt, user_prompt)


### PR DESCRIPTION
Ports the managed-cloud dashboard integration layer from
`craftbot-hosted-version/staging` (3 feature commits) onto `CraftBot_live`.
The module is fully gated behind `CONTAINER_*` env vars — when unset, every
subsystem degrades to a no-op and CraftBot runs identically to before. No
existing files conflict; the 3 commits CraftBot_live added since the common
base `ef88965` touch a disjoint file set.

## Added to CraftBot_live

- **`app/network_interface/`** — new module owning every HTTP call between the
  agent and the craftbot.live dashboard. Submodules:
  - `config.py` — reads `CONTAINER_AUTH_TOKEN` / `CONTAINER_INSTANCE_ID` /
    `CONTAINER_DASHBOARD_URL`; `is_enabled()` is the on/off switch.
  - `outbound.py` — `DashboardClient`: fire-and-forget async httpx with bounded
    queue, exponential backoff, **BYOK filter (Bedrock-only)** for usage events.
  - `inbound.py` + `server.py` — aiohttp `/__cb/{state,events,healthz}`
    endpoints on `CONTAINER_INBOUND_PORT` (default 7928), bearer-auth via
    `hmac.compare_digest`. Runs in both CLI and browser modes.
  - `heartbeat.py` — 30s heartbeat loop; logs only on state change.
  - `snapshot.py` — read-only assemblers for state/events pull endpoints.
  - `bootstrap.py` — `seed_default_provider_from_env()` for first-boot
    Bedrock defaults (no-op on subsequent boots, never overwrites BYOK).
  - `state.py` + `errors.py` — managed-quota lock state and
    `ManagedQuotaExceededError`.
- **Injection points** in existing files:
  - `app/agent_base.py` — `boot()` starts heartbeat + inbound server;
    shutdown stops them.
  - `app/main.py` — calls `seed_default_provider_from_env()` before settings
    reads.
  - `app/llm/interface.py`, `app/vlm_interface.py` — `_report_usage` also
    forwards to the dashboard (Bedrock-only via the BYOK filter).
- **Bedrock provider polish** (`984e153`) — updates to
  `agent_core/core/models/{factory,model_registry,provider_config,connection_tester}.py`,
  `app/llm/interface.py`, onboarding + `ModelSettings` UI to match the
  managed-Bedrock defaults.