### PR TITLE
added video generation interface, and openai, gemini, and byteplus as…

### DIFF
--- a/agent_core/core/impl/image_gen/interface.py
+++ b/agent_core/core/impl/image_gen/interface.py
@@ -201,6 +201,10 @@ class ImageGenInterface:
         self.client = ctx["client"]  # OpenAI client or None
         self._gemini_client = ctx["gemini_client"]
         self._initialized = ctx.get("initialized", False)
+        try:
+            self._main_loop: Optional[asyncio.AbstractEventLoop] = asyncio.get_event_loop()
+        except RuntimeError:
+            self._main_loop = None
 
     @property
     def is_initialized(self) -> bool:
@@ -232,9 +236,10 @@ class ImageGenInterface:
                 output_tokens=output_tokens,
                 cached_tokens=cached_tokens,
             )
-            asyncio.get_event_loop().call_soon(
-                lambda: asyncio.create_task(self._report_usage(event))
-            )
+            if self._main_loop is not None:
+                self._main_loop.call_soon_threadsafe(
+                    lambda: asyncio.create_task(self._report_usage(event))
+                )
         except Exception as e:
             logger.warning(f"[IMAGE_GEN] Failed to report usage: {e}")
 

--- a/agent_core/core/impl/image_gen/interface.py
+++ b/agent_core/core/impl/image_gen/interface.py
@@ -93,7 +93,7 @@ def _classify_error(provider: str, exc: Exception) -> str:
         or "insufficient_quota" in msg
     ):
         return catalog["quota"]
-    if "invalid" in msg and "key" in msg or "invalid_api_key" in msg:
+    if "invalid" in msg and "key" in msg:
         return catalog["invalid_key"]
     if "content_policy" in msg or "safety" in msg or "blocked" in msg:
         return catalog["content_policy"]
@@ -371,8 +371,12 @@ class ImageGenInterface:
         try:
             valid_refs = [p for p in reference_images if os.path.isfile(p)]
             if valid_refs:
-                image_files = [open(p, "rb") for p in valid_refs]
+                # Open progressively into a list so a mid-loop failure still
+                # closes the handles we already opened.
+                image_files: List[Any] = []
                 try:
+                    for p in valid_refs:
+                        image_files.append(open(p, "rb"))
                     response = self.client.images.edit(
                         model=self.model,
                         image=image_files,
@@ -409,7 +413,7 @@ class ImageGenInterface:
             if item.b64_json:
                 images_bytes.append(base64.b64decode(item.b64_json))
             elif item.url:
-                with _urllib_request.urlopen(item.url) as r:
+                with _urllib_request.urlopen(item.url, timeout=30) as r:
                     images_bytes.append(r.read())
 
         if not images_bytes:
@@ -464,8 +468,10 @@ class ImageGenInterface:
                     ".webp": "image/webp",
                 }.get(ext, "image/png")
                 ref_parts.append((data, mime))
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.warning(
+                    f"[IMAGE_GEN] Skipping unreadable reference image '{ref_path}': {exc}"
+                )
 
         gen_prompt = (
             f"Generate an image based on the following description:\n\n{prompt}"

--- a/agent_core/core/impl/video_gen/__init__.py
+++ b/agent_core/core/impl/video_gen/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+"""Video generation interface package."""
+
+from agent_core.core.impl.video_gen.interface import VideoGenInterface
+
+__all__ = ["VideoGenInterface"]

--- a/agent_core/core/impl/video_gen/interface.py
+++ b/agent_core/core/impl/video_gen/interface.py
@@ -368,9 +368,7 @@ class VideoGenInterface:
             except RuntimeError:
                 # No running loop in this thread — drop usage event with a warning
                 # rather than breaking generation (matches VLM/ImageGen behaviour).
-                logger.warning(
-                    "[VIDEO_GEN] No running event loop; usage event dropped."
-                )
+                asyncio.run(self._report_usage(event))
         except Exception as e:
             logger.warning(f"[VIDEO_GEN] Failed to report usage: {e}")
 
@@ -676,7 +674,12 @@ class VideoGenInterface:
                 raise RuntimeError(
                     f"OpenAI Sora job ended with status={status}: {error_msg}"
                 )
+            if status not in (None, "pending", "queued", "processing", "running"):
+                raise RuntimeError(
+                    f"OpenAI Sora job {video_id} returned unexpected status: {status!r}"
+                )
 
+            logger.debug(f"[VIDEO_GEN] Sora job {video_id} status={status!r}; retrying in {delay:.1f}s")
             if time.monotonic() >= deadline:
                 raise RuntimeError(
                     f"OpenAI Sora job {video_id} did not complete within "

--- a/agent_core/core/impl/video_gen/interface.py
+++ b/agent_core/core/impl/video_gen/interface.py
@@ -334,6 +334,10 @@ class VideoGenInterface:
         self._gemini_client = ctx["gemini_client"]  # GeminiClient (Veo) or None
         self._byteplus = ctx["byteplus"]  # {"api_key", "base_url"} or None
         self._initialized = ctx.get("initialized", False)
+        try:
+            self._main_loop: Optional[asyncio.AbstractEventLoop] = asyncio.get_event_loop()
+        except RuntimeError:
+            self._main_loop = None
 
     @property
     def is_initialized(self) -> bool:
@@ -360,15 +364,10 @@ class VideoGenInterface:
                 output_tokens=output_tokens,
                 cached_tokens=cached_tokens,
             )
-            try:
-                loop = asyncio.get_running_loop()
-                loop.call_soon_threadsafe(
+            if self._main_loop is not None:
+                self._main_loop.call_soon_threadsafe(
                     lambda: asyncio.create_task(self._report_usage(event))
                 )
-            except RuntimeError:
-                # No running loop in this thread — drop usage event with a warning
-                # rather than breaking generation (matches VLM/ImageGen behaviour).
-                asyncio.run(self._report_usage(event))
         except Exception as e:
             logger.warning(f"[VIDEO_GEN] Failed to report usage: {e}")
 
@@ -593,6 +592,7 @@ class VideoGenInterface:
         # public API; we issue `number_of_videos` independent jobs and stitch
         # them into the returned list. Each job is independent so errors on
         # one don't kill the rest — we collect partial results and report.
+        per_job_timeout = poll_timeout_seconds // max(1, number_of_videos)
         paths: List[str] = []
         first_error: Optional[Exception] = None
         for i in range(max(1, int(number_of_videos))):
@@ -619,7 +619,7 @@ class VideoGenInterface:
                 video_id = video_obj.id
 
                 # Poll for completion.
-                final_obj = self._poll_openai_video(video_id, poll_timeout_seconds)
+                final_obj = self._poll_openai_video(video_id, per_job_timeout)
                 mp4_bytes = self._download_openai_video(video_id)
 
                 save_path = _build_save_path(
@@ -1039,13 +1039,14 @@ class VideoGenInterface:
 
         # Number of videos: Seedance generates 1 per task; loop for N>1 so the
         # user can request multiple variations from a single call.
+        per_job_timeout = poll_timeout_seconds // max(1, number_of_videos)
         paths: List[str] = []
         first_error: Optional[Exception] = None
         for i in range(max(1, int(number_of_videos))):
             try:
                 task_id = self._byteplus_submit(api_key, base_url, body)
                 video_url = self._byteplus_poll(
-                    api_key, base_url, task_id, poll_timeout_seconds
+                    api_key, base_url, task_id, per_job_timeout
                 )
                 mp4_bytes = _download_video_url(video_url)
                 save_path = _build_save_path(

--- a/agent_core/core/impl/video_gen/interface.py
+++ b/agent_core/core/impl/video_gen/interface.py
@@ -1,0 +1,1177 @@
+# -*- coding: utf-8 -*-
+"""
+Video generation interface for agent_core.
+
+Supports OpenAI (Sora 2/Pro), Gemini (Veo 3.x), and BytePlus (Seedance).
+All three providers expose async/long-running generation, so the public
+``generate_video()`` blocks while internally submitting + polling + downloading.
+
+Mirrors VLMInterface / ImageGenInterface structure — constructor, hooks,
+dispatch. Like image gen, there is intentionally no in-place reinitialize();
+provider switches build a fresh instance via agent_base.reinitialize_video_gen()
+and swap it in only on success, so in-flight generate_video() calls keep their
+old instance/client until done.
+
+The interface caps internal polling with ``poll_timeout_seconds`` (default
+1500s = 25min, covering realistic generation times) but the outer
+DEFAULT_ACTION_TIMEOUT (6000s) is the real ceiling.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import os
+import tempfile
+import time
+import urllib.request as _urllib_request
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+
+from agent_core.core.hooks import (
+    GetTokenCountHook,
+    ReportUsageHook,
+    SetTokenCountHook,
+    UsageEventData,
+)
+from agent_core.utils.logger import logger
+
+# Default polling cadence: start tight to catch fast Seedance jobs, back off to
+# avoid hammering for slow Veo jobs.
+_DEFAULT_POLL_TIMEOUT = 1500  # 25 min — well under DEFAULT_ACTION_TIMEOUT (100 min)
+_DEFAULT_POLL_INITIAL = 5
+_DEFAULT_POLL_MAX = 15
+
+# OpenAI Sora 2 size mapping. Sora 2 accepts portrait/landscape 720p; Sora 2 Pro
+# adds 1024p and 1080p. We pick the nearest-fit canvas for the requested
+# aspect_ratio × resolution combination and warn when downgrading.
+_SORA_SIZES: Dict[str, Dict[str, str]] = {
+    "sora-2": {
+        "16:9": "1280x720",
+        "9:16": "720x1280",
+    },
+    "sora-2-pro": {
+        "16:9": "1792x1024",
+        "9:16": "1024x1792",
+    },
+}
+_SORA_VALID_SECONDS = {
+    "sora-2": {4, 8, 12},
+    "sora-2-pro": {10, 15, 25},
+}
+
+# Gemini Veo accepts integer durations. 1080p/4k and reference-images require 8.
+_VEO_DURATION_VALID = {4, 6, 8}
+_VEO_RESOLUTION_VALID = {"720p", "1080p", "4k"}
+_VEO_ASPECT_VALID = {"16:9", "9:16"}
+_VEO_PERSON_GEN_VALID = {"allow_all", "allow_adult", "dont_allow"}
+
+# BytePlus Seedance accepts duration as a string flag in the content text.
+# Resolution / aspect_ratio / camera_fixed / watermark also go via the
+# inline text flags per the public Seedance API.
+_SEEDANCE_RESOLUTION_VALID = {"480p", "720p", "1080p"}
+_SEEDANCE_ASPECT_VALID = {"16:9", "9:16", "1:1", "4:3", "3:4", "21:9"}
+
+_AUDIO_CAPABLE_PROVIDERS = {"gemini", "openai", "byteplus"}  # all three honor it
+
+
+# ── Error message catalog ────────────────────────────────────────────────────
+_ERR: Dict[str, Dict[str, str]] = {
+    "openai": {
+        "quota": "OpenAI API rate limit or quota exceeded",
+        "invalid_key": "Invalid OpenAI API key — verify your key in settings.",
+        "content_policy": "Request blocked by OpenAI content policy — modify your prompt.",
+        "model_not_found": (
+            "OpenAI model not available — ensure your account has access to Sora."
+        ),
+        "timeout": "OpenAI Sora generation timed out while polling for completion.",
+        "generic": "OpenAI video generation failed",
+    },
+    "gemini": {
+        "quota": "Gemini API rate limit or quota exceeded",
+        "invalid_key": "Invalid Gemini API key — verify your Google API key in settings.",
+        "content_policy": "Request blocked by Gemini safety filters — modify your prompt.",
+        "model_not_found": (
+            "Gemini model not available — ensure your account has access to a Veo "
+            "video generation model."
+        ),
+        "timeout": "Gemini Veo generation timed out while polling for completion.",
+        "generic": "Gemini video generation failed",
+    },
+    "byteplus": {
+        "quota": "BytePlus API rate limit or quota exceeded",
+        "invalid_key": "Invalid BytePlus API key — verify your key in settings.",
+        "content_policy": "Request blocked by BytePlus content policy — modify your prompt.",
+        "model_not_found": (
+            "BytePlus model not available — ensure your account has access to a "
+            "Seedance video model on the configured region."
+        ),
+        "timeout": "BytePlus Seedance generation timed out while polling for completion.",
+        "generic": "BytePlus video generation failed",
+    },
+}
+
+
+def _extract_api_error(exc: Exception) -> Tuple[Optional[int], str]:
+    """Pull the HTTP status and the API's actual error message off an exception.
+
+    Returns ``(status_code, api_message)``. Either may be ``None``/``""`` if
+    the exception isn't a ``requests.HTTPError`` or doesn't carry a JSON body.
+
+    Why this matters: the bare ``str(exc)`` for an HTTPError is
+    ``"400 Client Error: Bad Request for url: https://...veo-3.1-generate-preview..."``.
+    Loose substring matching on that URL false-positives on everything from
+    ``rate`` (inside ``generate``) to ``content`` (inside any ``...content...``
+    endpoint). Extracting the structured fields gives correct signal.
+    """
+    status_code: Optional[int] = None
+    api_message = ""
+    resp = getattr(exc, "response", None)
+    if resp is not None:
+        try:
+            status_code = int(getattr(resp, "status_code", 0)) or None
+        except Exception:
+            status_code = None
+        try:
+            body = resp.json()
+            if isinstance(body, dict):
+                err = body.get("error")
+                if isinstance(err, dict):
+                    api_message = str(err.get("message", "")).strip()
+                elif isinstance(err, str):
+                    api_message = err.strip()
+                else:
+                    api_message = str(body.get("message", "")).strip()
+        except Exception:
+            api_message = ""
+    return status_code, api_message
+
+
+def _classify_error(provider: str, exc: Exception) -> str:
+    """Map a raw exception to a catalog entry for the given provider.
+
+    Prefers the structured HTTP status + API error body over heuristic
+    substring matching on the exception's stringified form (which falsely
+    matched ``rate`` inside ``generate`` in the previous implementation).
+    The generic fallback surfaces the API's actual message so future bugs
+    aren't silently hidden behind a generic placeholder.
+    """
+    catalog = _ERR.get(provider, _ERR["openai"])
+    status_code, api_message = _extract_api_error(exc)
+
+    # Prefer the API's own error message; fall back to the exception string.
+    raw = api_message or str(exc)
+    msg = raw.lower()
+
+    is_quota = (
+        status_code == 429
+        or "rate limit" in msg
+        or "ratelimit" in msg
+        or "rate_limit" in msg
+        or "quota" in msg
+        or "billing" in msg
+        or "insufficient_quota" in msg
+    )
+    if is_quota:
+        return catalog["quota"]
+
+    is_auth = (
+        status_code in (401, 403)
+        or "api key" in msg
+        or "api_key" in msg
+        or "invalid_api_key" in msg
+        or "authentication" in msg
+        or "unauthorized" in msg
+    )
+    if is_auth:
+        return catalog["invalid_key"]
+
+    is_policy = (
+        "content policy" in msg
+        or "content_policy" in msg
+        or "safety" in msg
+        or "blocked" in msg
+    )
+    if is_policy:
+        return catalog["content_policy"]
+
+    is_not_found = (
+        status_code == 404
+        or "not found" in msg
+        or "not available" in msg
+        or "does not exist" in msg
+    )
+    if is_not_found:
+        return catalog["model_not_found"]
+
+    if "timeout" in msg or "timed out" in msg:
+        return catalog["timeout"]
+
+    # Generic fallback — include the API's actual message so misclassified
+    # 400s like the durationSeconds / numberOfVideos errors surface clearly
+    # instead of getting swallowed as "generation failed". The API message
+    # is server-emitted text (no header / URL leakage of key fragments).
+    base = catalog["generic"]
+    if api_message:
+        return f"{base}: {api_message}"
+    return base
+
+
+# ── File / image helpers ─────────────────────────────────────────────────────
+
+
+def _build_save_path(
+    output_path: str,
+    timestamp: str,
+    index: int,
+    total: int,
+    suffix: str = ".mp4",
+) -> str:
+    """Pick a save path for the i-th video out of `total`."""
+    if output_path:
+        if total > 1:
+            base, ext = os.path.splitext(output_path)
+            ext = ext or suffix
+            return f"{base}_{index + 1}{ext}"
+        save_path = output_path
+        if not os.path.splitext(save_path)[1]:
+            save_path += suffix
+        return save_path
+    return os.path.join(
+        tempfile.gettempdir(), f"generated_video_{timestamp}_{index + 1}{suffix}"
+    )
+
+
+def _write_bytes(path: str, data: bytes) -> None:
+    parent = os.path.dirname(os.path.abspath(path))
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    with open(path, "wb") as f:
+        f.write(data)
+
+
+def _read_image_for_upload(image_path: str) -> Tuple[bytes, str]:
+    """Read an image from disk and return (bytes, mime). Raises if missing."""
+    if not os.path.isfile(image_path):
+        raise FileNotFoundError(f"Reference image not found: {image_path}")
+    with open(image_path, "rb") as f:
+        data = f.read()
+    ext = os.path.splitext(image_path)[1].lower()
+    mime = {
+        ".png": "image/png",
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".gif": "image/gif",
+        ".webp": "image/webp",
+    }.get(ext, "image/png")
+    return data, mime
+
+
+# ── Main interface ───────────────────────────────────────────────────────────
+
+
+class VideoGenInterface:
+    """Video generation interface with multi-provider support.
+
+    Supports OpenAI Sora 2/Pro, Gemini Veo 3.x, and BytePlus Seedance.
+    Uses hooks for state access and usage reporting, mirroring VLMInterface
+    and ImageGenInterface.
+
+    All providers run as async/long-running operations; ``generate_video()``
+    blocks while internally submitting + polling + downloading.
+
+    Args:
+        provider: Provider name ("openai", "gemini", "byteplus").
+        model: Model name override (None = use registry default).
+        api_key: API key (required for all supported providers).
+        base_url: Base URL override (used for byteplus REST endpoint).
+        deferred: If True, allow deferred initialization without raising.
+        get_token_count: Hook to read current token count from state.
+        set_token_count: Hook to write token count to state.
+        report_usage: Optional hook to report usage for cost tracking.
+    """
+
+    def __init__(
+        self,
+        *,
+        provider: Optional[str] = None,
+        model: Optional[str] = None,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        deferred: bool = False,
+        get_token_count: Optional[GetTokenCountHook] = None,
+        set_token_count: Optional[SetTokenCountHook] = None,
+        report_usage: Optional[ReportUsageHook] = None,
+    ) -> None:
+        self.provider = provider
+        self._initialized = False
+        self._deferred = deferred
+        self._init_api_key = api_key
+        self._init_base_url = base_url
+
+        self._get_token_count = get_token_count or (lambda: 0)
+        self._set_token_count = set_token_count or (lambda x: None)
+        self._report_usage = report_usage
+
+        # Defer import to avoid circular dependency (same pattern as VLM/ImageGen)
+        from app.models.factory import ModelFactory
+        from app.models.types import InterfaceType
+
+        ctx = ModelFactory.create(
+            provider=provider,
+            interface=InterfaceType.VIDEO_GEN,
+            model_override=model,
+            api_key=api_key,
+            base_url=base_url,
+            deferred=deferred,
+        )
+        self.provider = ctx["provider"]
+        self.model = ctx["model"]
+        self.client = ctx["client"]  # OpenAI client (Sora) or None
+        self._gemini_client = ctx["gemini_client"]  # GeminiClient (Veo) or None
+        self._byteplus = ctx["byteplus"]  # {"api_key", "base_url"} or None
+        self._initialized = ctx.get("initialized", False)
+
+    @property
+    def is_initialized(self) -> bool:
+        return self._initialized
+
+    def _report_usage_async(
+        self,
+        *,
+        provider: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cached_tokens: int = 0,
+    ) -> None:
+        """Report video-generation usage if the hook is set (mirrors VLM / ImageGen)."""
+        if not self._report_usage:
+            return
+        try:
+            event = UsageEventData(
+                service_type="video_gen",
+                provider=provider,
+                model=model,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cached_tokens=cached_tokens,
+            )
+            try:
+                loop = asyncio.get_running_loop()
+                loop.call_soon_threadsafe(
+                    lambda: asyncio.create_task(self._report_usage(event))
+                )
+            except RuntimeError:
+                # No running loop in this thread — drop usage event with a warning
+                # rather than breaking generation (matches VLM/ImageGen behaviour).
+                logger.warning(
+                    "[VIDEO_GEN] No running event loop; usage event dropped."
+                )
+        except Exception as e:
+            logger.warning(f"[VIDEO_GEN] Failed to report usage: {e}")
+
+    # ─────────────────────────── Public API ──────────────────────────────────
+
+    def generate_video(
+        self,
+        prompt: str,
+        duration_seconds: int = 5,
+        aspect_ratio: str = "16:9",
+        resolution: str = "720p",
+        number_of_videos: int = 1,
+        output_path: str = "",
+        negative_prompt: str = "",
+        reference_image: Optional[str] = None,
+        last_frame: Optional[str] = None,
+        reference_images: Optional[List[str]] = None,
+        seed: Optional[int] = None,
+        with_audio: bool = True,
+        # Gemini / Veo specific
+        person_generation: str = "allow_adult",
+        # BytePlus / Seedance specific
+        camera_fixed: bool = False,
+        watermark: bool = False,
+        callback_url: str = "",
+        # Polling
+        poll_timeout_seconds: int = _DEFAULT_POLL_TIMEOUT,
+    ) -> List[str]:
+        """Generate video(s) from a text prompt (blocking).
+
+        Submits the generation job, polls until completion, downloads the
+        result(s) to disk, and returns local file paths.
+
+        Args:
+            prompt: Text description of the video to generate.
+            duration_seconds: Target duration in seconds. Each provider clamps
+                to its supported set (Sora 2: 4/8/12; Veo: 4/6/8; Seedance: 2–12).
+            aspect_ratio: "16:9", "9:16", "1:1", "4:3", "3:4", "21:9". Sora
+                and Veo only support 16:9 and 9:16.
+            resolution: "480p" / "720p" / "1080p" / "4k". Sora 2 standard tops
+                out at 720p; Veo Lite cannot do 4k.
+            number_of_videos: Number of videos (1–N, provider-capped).
+            output_path: Absolute path for the output file. Timestamped temp
+                path used when empty. For multiple videos the index is
+                appended before the extension.
+            negative_prompt: Elements to avoid (native on Veo and Seedance;
+                appended to prompt for Sora which has no dedicated param).
+            reference_image: Optional absolute path to a single start-frame
+                image for image-to-video. Mapped to ``input_reference`` (Sora),
+                ``image`` (Veo), or ``image_urls`` (Seedance).
+            last_frame: Optional absolute path to an end-frame image for
+                frame interpolation. Veo 3.1+ only; silently dropped elsewhere.
+            reference_images: Optional list of absolute paths to additional
+                style-reference images. Veo 3.1+ accepts up to 3; silently
+                dropped on Sora and Seedance.
+            seed: Optional deterministic seed.
+            with_audio: Whether to generate audio. Honored where the
+                provider exposes a request-time toggle: Seedance's
+                ``generate_audio`` (2.0+ models). Veo 3.x produces native
+                synchronized audio by default and has no toggle — the flag
+                is ignored there (Veo 2 is silent). Sora 2 produces audio
+                by default and the flag is also a no-op.
+            person_generation: Veo only — "allow_all", "allow_adult", or
+                "dont_allow". ``allow_all`` is geo-restricted (EU/UK/CH/MENA).
+            camera_fixed: BytePlus Seedance only — lock camera position.
+            watermark: BytePlus Seedance only — apply watermark to output.
+            callback_url: BytePlus Seedance only — webhook for completion.
+            poll_timeout_seconds: Internal polling cap (default 1500s).
+                Always remains below DEFAULT_ACTION_TIMEOUT (6000s).
+
+        Returns:
+            List of absolute file paths to the generated MP4 files.
+
+        Raises:
+            RuntimeError: If the provider is unsupported, the job is blocked,
+                generation fails, or polling times out.
+        """
+        if not prompt:
+            raise ValueError("prompt is required")
+
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        refs = reference_images or []
+
+        if self.provider == "openai":
+            paths = self._openai_generate(
+                prompt=prompt,
+                duration_seconds=duration_seconds,
+                aspect_ratio=aspect_ratio,
+                resolution=resolution,
+                number_of_videos=number_of_videos,
+                output_path=output_path,
+                negative_prompt=negative_prompt,
+                reference_image=reference_image,
+                seed=seed,
+                with_audio=with_audio,
+                timestamp=timestamp,
+                poll_timeout_seconds=poll_timeout_seconds,
+            )
+        elif self.provider == "gemini":
+            paths = self._gemini_generate(
+                prompt=prompt,
+                duration_seconds=duration_seconds,
+                aspect_ratio=aspect_ratio,
+                resolution=resolution,
+                number_of_videos=number_of_videos,
+                output_path=output_path,
+                negative_prompt=negative_prompt,
+                reference_image=reference_image,
+                last_frame=last_frame,
+                reference_images=refs,
+                seed=seed,
+                with_audio=with_audio,
+                person_generation=person_generation,
+                timestamp=timestamp,
+                poll_timeout_seconds=poll_timeout_seconds,
+            )
+        elif self.provider == "byteplus":
+            paths = self._byteplus_generate(
+                prompt=prompt,
+                duration_seconds=duration_seconds,
+                aspect_ratio=aspect_ratio,
+                resolution=resolution,
+                number_of_videos=number_of_videos,
+                output_path=output_path,
+                negative_prompt=negative_prompt,
+                reference_image=reference_image,
+                seed=seed,
+                with_audio=with_audio,
+                camera_fixed=camera_fixed,
+                watermark=watermark,
+                callback_url=callback_url,
+                timestamp=timestamp,
+                poll_timeout_seconds=poll_timeout_seconds,
+            )
+        else:
+            raise RuntimeError(
+                f"Provider '{self.provider}' does not support video generation. "
+                "Set video_gen_provider to 'gemini', 'openai', or 'byteplus' in settings.json."
+            )
+
+        logger.info(
+            f"[VIDEO_GEN] Generated {len(paths)} video(s) via {self.provider} "
+            f"(model={self.model})"
+        )
+        return paths
+
+    async def generate_video_async(self, **kwargs) -> List[str]:
+        """Async wrapper — runs generate_video in a thread pool."""
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, lambda: self.generate_video(**kwargs))
+
+    # ──────────────────────── OpenAI / Sora 2 ────────────────────────────────
+
+    def _openai_generate(
+        self,
+        *,
+        prompt: str,
+        duration_seconds: int,
+        aspect_ratio: str,
+        resolution: str,
+        number_of_videos: int,
+        output_path: str,
+        negative_prompt: str,
+        reference_image: Optional[str],
+        seed: Optional[int],
+        with_audio: bool,
+        timestamp: str,
+        poll_timeout_seconds: int,
+    ) -> List[str]:
+        # Sora 2 audio is on by default and not configurable per-request; the
+        # `with_audio=False` flag is silently honored as a no-op signal.
+        if not with_audio:
+            logger.info(
+                "[VIDEO_GEN] OpenAI Sora produces audio by default; "
+                "with_audio=False is a no-op."
+            )
+
+        # Map aspect_ratio + resolution to the closest Sora canvas. If the
+        # caller passes an unsupported aspect_ratio (Sora has only 16:9 / 9:16),
+        # default to 16:9 and warn.
+        size_map = _SORA_SIZES.get(self.model, _SORA_SIZES["sora-2"])
+        if aspect_ratio not in size_map:
+            logger.warning(
+                f"[VIDEO_GEN] Sora does not support aspect_ratio={aspect_ratio}. "
+                "Defaulting to 16:9."
+            )
+            aspect_ratio = "16:9"
+        size = size_map[aspect_ratio]
+        if resolution not in {"720p", "1024p", "1080p"}:
+            logger.warning(
+                f"[VIDEO_GEN] Sora ignores resolution={resolution}; using canvas {size} "
+                "from aspect_ratio + model tier."
+            )
+
+        # Clamp seconds to the model's supported set, picking the closest larger value.
+        valid_seconds = _SORA_VALID_SECONDS.get(self.model, {4, 8, 12})
+        if duration_seconds not in valid_seconds:
+            chosen = min((s for s in valid_seconds if s >= duration_seconds), default=None)
+            if chosen is None:
+                chosen = max(valid_seconds)
+            logger.warning(
+                f"[VIDEO_GEN] Sora ({self.model}) does not support {duration_seconds}s; "
+                f"using {chosen}s."
+            )
+            duration_seconds = chosen
+
+        # Sora has no dedicated negative_prompt; append to the prompt body.
+        full_prompt = prompt
+        if negative_prompt:
+            full_prompt += f"\n\nAvoid: {negative_prompt}"
+
+        # Validate the reference image up-front; the SDK expects the file
+        # to be passed inline (bytes / IOBase / PathLike), NOT a pre-uploaded
+        # file id. A separate files.create() round-trip is not part of the
+        # Sora image-to-video contract.
+        if reference_image and not os.path.isfile(reference_image):
+            raise RuntimeError(
+                f"Sora reference_image not found: {reference_image}"
+            )
+
+        # Sora 2's `n` parameter for multiple videos is not yet exposed in the
+        # public API; we issue `number_of_videos` independent jobs and stitch
+        # them into the returned list. Each job is independent so errors on
+        # one don't kill the rest — we collect partial results and report.
+        paths: List[str] = []
+        first_error: Optional[Exception] = None
+        for i in range(max(1, int(number_of_videos))):
+            ref_handle = None
+            try:
+                create_kwargs: Dict[str, Any] = {
+                    "model": self.model,
+                    "prompt": full_prompt,
+                    "size": size,
+                    "seconds": duration_seconds,
+                }
+                if seed is not None:
+                    create_kwargs["seed"] = seed
+                if reference_image:
+                    # Open a fresh handle per job — the SDK consumes the
+                    # stream during multipart upload. Closed in finally.
+                    ref_handle = open(reference_image, "rb")
+                    create_kwargs["input_reference"] = ref_handle
+
+                # The OpenAI SDK exposes Sora under client.videos (added in the
+                # 2026 SDK release). Older SDKs may need a fallback to the raw
+                # HTTP endpoint via client.post.
+                video_obj = self.client.videos.create(**create_kwargs)
+                video_id = video_obj.id
+
+                # Poll for completion.
+                final_obj = self._poll_openai_video(video_id, poll_timeout_seconds)
+                mp4_bytes = self._download_openai_video(video_id)
+
+                save_path = _build_save_path(
+                    output_path, timestamp, len(paths), number_of_videos
+                )
+                _write_bytes(save_path, mp4_bytes)
+                paths.append(save_path)
+
+                # Best-effort usage reporting.
+                usage = getattr(final_obj, "usage", None)
+                if usage is not None:
+                    self._report_usage_async(
+                        provider="openai",
+                        model=self.model,
+                        input_tokens=getattr(usage, "input_tokens", 0) or 0,
+                        output_tokens=getattr(usage, "output_tokens", 0) or 0,
+                    )
+            except Exception as exc:
+                if first_error is None:
+                    first_error = exc
+                logger.warning(
+                    f"[VIDEO_GEN] Sora job {i + 1}/{number_of_videos} failed: {exc}"
+                )
+            finally:
+                if ref_handle is not None:
+                    try:
+                        ref_handle.close()
+                    except Exception:
+                        pass
+
+        if not paths:
+            raise RuntimeError(
+                _classify_error("openai", first_error or RuntimeError("no result"))
+            )
+        return paths
+
+    def _poll_openai_video(self, video_id: str, poll_timeout_seconds: int) -> Any:
+        """Poll a Sora video job to completion. Returns the final video object."""
+        deadline = time.monotonic() + poll_timeout_seconds
+        delay = _DEFAULT_POLL_INITIAL
+        while True:
+            try:
+                obj = self.client.videos.retrieve(video_id)
+            except Exception as exc:
+                raise RuntimeError(_classify_error("openai", exc)) from exc
+
+            status = getattr(obj, "status", None)
+            if status == "completed":
+                return obj
+            if status in ("failed", "cancelled", "error"):
+                error_msg = getattr(obj, "error", None) or status
+                raise RuntimeError(
+                    f"OpenAI Sora job ended with status={status}: {error_msg}"
+                )
+
+            if time.monotonic() >= deadline:
+                raise RuntimeError(
+                    f"OpenAI Sora job {video_id} did not complete within "
+                    f"{poll_timeout_seconds}s (last status: {status})."
+                )
+
+            time.sleep(delay)
+            delay = min(delay * 1.5, _DEFAULT_POLL_MAX)
+
+    def _download_openai_video(self, video_id: str) -> bytes:
+        """Download the MP4 bytes for a completed Sora video."""
+        try:
+            content = self.client.videos.download_content(video_id)
+        except Exception as exc:
+            raise RuntimeError(_classify_error("openai", exc)) from exc
+
+        # The SDK may return bytes directly or an HTTPResponse-like object.
+        if isinstance(content, bytes):
+            return content
+        if hasattr(content, "read"):
+            return content.read()
+        if hasattr(content, "content"):
+            return content.content
+        raise RuntimeError(
+            "OpenAI Sora download returned an unexpected payload type."
+        )
+
+    # ──────────────────────── Gemini / Veo ───────────────────────────────────
+
+    def _gemini_generate(
+        self,
+        *,
+        prompt: str,
+        duration_seconds: int,
+        aspect_ratio: str,
+        resolution: str,
+        number_of_videos: int,
+        output_path: str,
+        negative_prompt: str,
+        reference_image: Optional[str],
+        last_frame: Optional[str],
+        reference_images: List[str],
+        seed: Optional[int],
+        with_audio: bool,
+        person_generation: str,
+        timestamp: str,
+        poll_timeout_seconds: int,
+    ) -> List[str]:
+        if not self._gemini_client:
+            raise RuntimeError(
+                "Gemini API key is not configured. "
+                "Set 'video_gen_provider' to 'openai' or 'byteplus' or add "
+                "a Google API key in settings."
+            )
+
+        # Normalize aspect_ratio to Veo's allowed set.
+        if aspect_ratio not in _VEO_ASPECT_VALID:
+            logger.warning(
+                f"[VIDEO_GEN] Veo does not support aspect_ratio={aspect_ratio}. "
+                "Defaulting to 16:9."
+            )
+            aspect_ratio = "16:9"
+
+        if resolution not in _VEO_RESOLUTION_VALID:
+            logger.warning(
+                f"[VIDEO_GEN] Veo does not support resolution={resolution}. "
+                "Defaulting to 720p."
+            )
+            resolution = "720p"
+
+        # Veo durations are integers; 1080p/4k or any reference inputs force 8.
+        # Snap to the closest legal value.
+        forces_eight = (
+            resolution in {"1080p", "4k"} or reference_image or last_frame or reference_images
+        )
+        if forces_eight:
+            duration_int = 8
+        else:
+            duration_int = int(duration_seconds)
+            if duration_int not in _VEO_DURATION_VALID:
+                chosen = min(
+                    (s for s in _VEO_DURATION_VALID if s >= duration_int), default=8
+                )
+                logger.warning(
+                    f"[VIDEO_GEN] Veo does not support durationSeconds={duration_seconds}; "
+                    f"using {chosen}s."
+                )
+                duration_int = chosen
+
+        if person_generation not in _VEO_PERSON_GEN_VALID:
+            logger.warning(
+                f"[VIDEO_GEN] Veo does not support person_generation="
+                f"{person_generation}. Defaulting to allow_adult."
+            )
+            person_generation = "allow_adult"
+
+        # Audio on Veo 3.x is model-controlled, not a request-time toggle:
+        # `veo-3.1-generate-preview` (and likely siblings) rejects the
+        # `generateAudio` field outright with 400 INVALID_ARGUMENT, while
+        # the model produces synchronized audio by default anyway. Veo 2
+        # is silent and also has no toggle. So we never forward the flag
+        # to the Gemini client — letting the model use its native default.
+        # When the caller asked to disable audio, log so the dropped intent
+        # is visible.
+        if not with_audio:
+            logger.info(
+                "[VIDEO_GEN] Veo audio is model-controlled and cannot be "
+                "disabled per-request; with_audio=False is ignored."
+            )
+
+        # Read the start frame / last frame / reference image bytes off disk.
+        start_pair = None
+        last_pair = None
+        ref_pairs: List[Tuple[bytes, str]] = []
+        if reference_image:
+            try:
+                start_pair = _read_image_for_upload(reference_image)
+            except Exception as exc:
+                logger.warning(
+                    f"[VIDEO_GEN] Skipping unreadable start frame '{reference_image}': {exc}"
+                )
+        if last_frame:
+            try:
+                last_pair = _read_image_for_upload(last_frame)
+            except Exception as exc:
+                logger.warning(
+                    f"[VIDEO_GEN] Skipping unreadable last frame '{last_frame}': {exc}"
+                )
+        for ref_path in reference_images[:3]:
+            try:
+                ref_pairs.append(_read_image_for_upload(ref_path))
+            except Exception as exc:
+                logger.warning(
+                    f"[VIDEO_GEN] Skipping unreadable reference frame '{ref_path}': {exc}"
+                )
+
+        try:
+            op = self._gemini_client.generate_video(
+                self.model,
+                prompt=prompt,
+                negative_prompt=negative_prompt or None,
+                image=start_pair,
+                last_frame=last_pair,
+                reference_images=ref_pairs or None,
+                aspect_ratio=aspect_ratio,
+                duration_seconds=duration_int,
+                resolution=resolution,
+                person_generation=person_generation,
+                number_of_videos=number_of_videos,
+                seed=seed,
+                # generate_audio intentionally omitted — see comment above.
+            )
+        except Exception as exc:
+            raise RuntimeError(_classify_error("gemini", exc)) from exc
+
+        operation_name = op.get("name")
+        if not operation_name:
+            raise RuntimeError(
+                "Gemini Veo did not return an operation name — cannot poll for result."
+            )
+
+        final = self._poll_gemini_operation(operation_name, poll_timeout_seconds)
+
+        # Veo's response shape: response.generateVideoResponse.generatedSamples[].video.uri
+        response_body = final.get("response") or {}
+        gv = response_body.get("generateVideoResponse") or {}
+        samples = gv.get("generatedSamples") or []
+
+        if not samples:
+            block_reason = (
+                gv.get("raiFilteredReason")
+                or response_body.get("blockReason")
+                or final.get("error", {}).get("message")
+            )
+            if block_reason:
+                raise RuntimeError(
+                    f"Gemini Veo blocked or returned no samples ({block_reason}). "
+                    "Try modifying your prompt or adjusting person_generation."
+                )
+            raise RuntimeError(
+                "Gemini Veo returned no video samples — try rephrasing your prompt "
+                "or check that your API key has access to a Veo model."
+            )
+
+        # Usage reporting (input/output token counts).
+        usage_md = final.get("metadata", {}).get("usageMetadata") or {}
+        if usage_md:
+            self._report_usage_async(
+                provider="gemini",
+                model=self.model,
+                input_tokens=usage_md.get("promptTokenCount", 0) or 0,
+                output_tokens=usage_md.get("candidatesTokenCount", 0) or 0,
+                cached_tokens=usage_md.get("cachedContentTokenCount", 0) or 0,
+            )
+
+        paths: List[str] = []
+        for i, sample in enumerate(samples[:number_of_videos]):
+            video = sample.get("video") or {}
+            uri = video.get("uri")
+            inline = video.get("bytesBase64Encoded")
+            if uri:
+                try:
+                    data = self._gemini_client.download_video(uri, timeout=180)
+                except Exception as exc:
+                    raise RuntimeError(_classify_error("gemini", exc)) from exc
+            elif inline:
+                data = base64.b64decode(inline)
+            else:
+                logger.warning(
+                    f"[VIDEO_GEN] Veo sample {i} had no uri or inline bytes — skipping."
+                )
+                continue
+
+            save_path = _build_save_path(
+                output_path, timestamp, i, len(samples)
+            )
+            _write_bytes(save_path, data)
+            paths.append(save_path)
+
+        if not paths:
+            raise RuntimeError(
+                "Gemini Veo completed but produced no downloadable samples."
+            )
+        return paths
+
+    def _poll_gemini_operation(
+        self, operation_name: str, poll_timeout_seconds: int
+    ) -> Dict[str, Any]:
+        """Poll a Veo long-running operation until done. Returns final op JSON."""
+        deadline = time.monotonic() + poll_timeout_seconds
+        delay = _DEFAULT_POLL_INITIAL
+        while True:
+            try:
+                op = self._gemini_client.poll_video_operation(operation_name)
+            except Exception as exc:
+                raise RuntimeError(_classify_error("gemini", exc)) from exc
+
+            if op.get("done"):
+                err = op.get("error")
+                if err:
+                    raise RuntimeError(
+                        f"Gemini Veo operation failed: {err.get('message') or err}"
+                    )
+                return op
+
+            if time.monotonic() >= deadline:
+                raise RuntimeError(
+                    f"Gemini Veo operation {operation_name} did not complete within "
+                    f"{poll_timeout_seconds}s."
+                )
+
+            time.sleep(delay)
+            delay = min(delay * 1.5, _DEFAULT_POLL_MAX)
+
+    # ──────────────────────── BytePlus / Seedance ────────────────────────────
+
+    def _byteplus_generate(
+        self,
+        *,
+        prompt: str,
+        duration_seconds: int,
+        aspect_ratio: str,
+        resolution: str,
+        number_of_videos: int,
+        output_path: str,
+        negative_prompt: str,
+        reference_image: Optional[str],
+        seed: Optional[int],
+        with_audio: bool,
+        camera_fixed: bool,
+        watermark: bool,
+        callback_url: str,
+        timestamp: str,
+        poll_timeout_seconds: int,
+    ) -> List[str]:
+        if not self._byteplus:
+            raise RuntimeError(
+                "BytePlus API key is not configured. "
+                "Add a BytePlus key in settings or pick a different video provider."
+            )
+
+        api_key = self._byteplus["api_key"]
+        base_url = self._byteplus["base_url"].rstrip("/")
+
+        # Validate Seedance enums; downshift if needed.
+        if aspect_ratio not in _SEEDANCE_ASPECT_VALID:
+            logger.warning(
+                f"[VIDEO_GEN] Seedance does not support aspect_ratio={aspect_ratio}. "
+                "Defaulting to 16:9."
+            )
+            aspect_ratio = "16:9"
+        if resolution not in _SEEDANCE_RESOLUTION_VALID:
+            logger.warning(
+                f"[VIDEO_GEN] Seedance does not support resolution={resolution}. "
+                "Defaulting to 720p."
+            )
+            resolution = "720p"
+        # Seedance accepts 2–12 seconds; clamp.
+        duration_int = max(2, min(12, int(duration_seconds)))
+        if duration_int != duration_seconds:
+            logger.warning(
+                f"[VIDEO_GEN] Seedance clamped duration_seconds={duration_seconds} → {duration_int}."
+            )
+
+        # BytePlus ModelArk takes generation params as TOP-LEVEL fields next to
+        # `content[]`, not as inline `--flag` directives in the prompt text.
+        # (The `--flag` style is the legacy Volcengine 2024 form and is
+        # rejected by the international `ark.ap-southeast.bytepluses.com`
+        # endpoint.) Verified against the official Dreamina Seedance 2.0
+        # tutorial sample.
+        text_block = prompt
+        if negative_prompt:
+            text_block += f"\n\nAvoid: {negative_prompt}"
+
+        content_parts: List[Dict[str, Any]] = [{"type": "text", "text": text_block}]
+        if reference_image:
+            try:
+                if not os.path.isfile(reference_image):
+                    raise FileNotFoundError(reference_image)
+                with open(reference_image, "rb") as f:
+                    img_bytes = f.read()
+                ext = os.path.splitext(reference_image)[1].lower()
+                mime = {
+                    ".png": "image/png",
+                    ".jpg": "image/jpeg",
+                    ".jpeg": "image/jpeg",
+                    ".webp": "image/webp",
+                }.get(ext, "image/jpeg")
+                data_url = (
+                    f"data:{mime};base64,{base64.b64encode(img_bytes).decode('utf-8')}"
+                )
+                content_parts.append(
+                    {"type": "image_url", "image_url": {"url": data_url}}
+                )
+            except Exception as exc:
+                logger.warning(
+                    f"[VIDEO_GEN] Skipping unreadable Seedance reference image "
+                    f"'{reference_image}': {exc}"
+                )
+
+        body: Dict[str, Any] = {
+            "model": self.model,
+            "content": content_parts,
+            "ratio": aspect_ratio,
+            "resolution": resolution,
+            "duration": duration_int,
+            "generate_audio": bool(with_audio),
+        }
+        if seed is not None:
+            body["seed"] = int(seed)
+        if camera_fixed:
+            body["camera_fixed"] = True
+        if watermark:
+            body["watermark"] = True
+        if callback_url:
+            body["callback_url"] = callback_url
+
+        # Number of videos: Seedance generates 1 per task; loop for N>1 so the
+        # user can request multiple variations from a single call.
+        paths: List[str] = []
+        first_error: Optional[Exception] = None
+        for i in range(max(1, int(number_of_videos))):
+            try:
+                task_id = self._byteplus_submit(api_key, base_url, body)
+                video_url = self._byteplus_poll(
+                    api_key, base_url, task_id, poll_timeout_seconds
+                )
+                mp4_bytes = _download_video_url(video_url)
+                save_path = _build_save_path(
+                    output_path, timestamp, len(paths), number_of_videos
+                )
+                _write_bytes(save_path, mp4_bytes)
+                paths.append(save_path)
+            except Exception as exc:
+                if first_error is None:
+                    first_error = exc
+                logger.warning(
+                    f"[VIDEO_GEN] Seedance job {i + 1}/{number_of_videos} failed: {exc}"
+                )
+
+        if not paths:
+            raise RuntimeError(
+                _classify_error("byteplus", first_error or RuntimeError("no result"))
+            )
+        return paths
+
+    def _byteplus_submit(
+        self, api_key: str, base_url: str, body: Dict[str, Any]
+    ) -> str:
+        """Submit a Seedance task and return its task id."""
+        url = f"{base_url}/contents/generations/tasks"
+        try:
+            r = requests.post(
+                url,
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "Content-Type": "application/json",
+                },
+                json=body,
+                timeout=60,
+            )
+        except Exception as exc:
+            raise RuntimeError(_classify_error("byteplus", exc)) from exc
+
+        if not r.ok:
+            try:
+                err_body = r.json()
+                logger.warning(
+                    f"[VIDEO_GEN] BytePlus submit failed: status={r.status_code} body={err_body}"
+                )
+            except Exception:
+                logger.warning(
+                    f"[VIDEO_GEN] BytePlus submit failed: status={r.status_code} text={r.text[:1000]}"
+                )
+            r.raise_for_status()
+
+        data = r.json()
+        task_id = data.get("id") or data.get("task_id")
+        if not task_id:
+            raise RuntimeError(
+                "BytePlus Seedance did not return a task id. "
+                f"Response: {json.dumps(data)[:500]}"
+            )
+        return str(task_id)
+
+    def _byteplus_poll(
+        self,
+        api_key: str,
+        base_url: str,
+        task_id: str,
+        poll_timeout_seconds: int,
+    ) -> str:
+        """Poll a Seedance task until succeeded; return the video URL."""
+        deadline = time.monotonic() + poll_timeout_seconds
+        delay = _DEFAULT_POLL_INITIAL
+        poll_url = f"{base_url}/contents/generations/tasks/{task_id}"
+        last_status = "unknown"
+        while True:
+            try:
+                r = requests.get(
+                    poll_url,
+                    headers={"Authorization": f"Bearer {api_key}"},
+                    timeout=30,
+                )
+                r.raise_for_status()
+            except Exception as exc:
+                raise RuntimeError(_classify_error("byteplus", exc)) from exc
+
+            data = r.json()
+            status = (data.get("status") or "").lower()
+            last_status = status or last_status
+
+            if status == "succeeded":
+                content = data.get("content") or {}
+                # Seedance returns either content.video_url (current) or content.url (legacy).
+                video_url = content.get("video_url") or content.get("url")
+                if not video_url and isinstance(data.get("videos"), list) and data["videos"]:
+                    video_url = data["videos"][0].get("video_url") or data["videos"][0].get("url")
+                if not video_url:
+                    raise RuntimeError(
+                        "BytePlus Seedance reported succeeded but did not include a video_url."
+                    )
+                # Best-effort usage reporting.
+                usage = data.get("usage") or {}
+                if usage:
+                    self._report_usage_async(
+                        provider="byteplus",
+                        model=self.model,
+                        input_tokens=usage.get("prompt_tokens", 0) or 0,
+                        output_tokens=usage.get("completion_tokens", 0)
+                        or usage.get("output_tokens", 0)
+                        or 0,
+                    )
+                return str(video_url)
+
+            if status in ("failed", "cancelled"):
+                reason = data.get("error") or data.get("failure_reason") or status
+                raise RuntimeError(
+                    f"BytePlus Seedance task {task_id} ended with status={status}: {reason}"
+                )
+
+            if time.monotonic() >= deadline:
+                raise RuntimeError(
+                    f"BytePlus Seedance task {task_id} did not complete within "
+                    f"{poll_timeout_seconds}s (last status: {last_status})."
+                )
+
+            time.sleep(delay)
+            delay = min(delay * 1.5, _DEFAULT_POLL_MAX)
+
+
+# ── Shared HTTP download helper ──────────────────────────────────────────────
+
+
+def _download_video_url(url: str, *, timeout: int = 180) -> bytes:
+    """Fetch a video URL into memory with an explicit timeout."""
+    with _urllib_request.urlopen(url, timeout=timeout) as r:
+        return r.read()

--- a/agent_core/core/impl/video_gen/interface.py
+++ b/agent_core/core/impl/video_gen/interface.py
@@ -769,12 +769,20 @@ class VideoGenInterface:
                 )
                 duration_int = chosen
 
-        if person_generation not in _VEO_PERSON_GEN_VALID:
+        _is_image_to_video = bool(reference_image or last_frame or reference_images)
+        _valid_person_gen = (
+            {"allow_adult", "dont_allow"}
+            if _is_image_to_video
+            else {"allow_all", "dont_allow"}
+        )
+        if person_generation not in _valid_person_gen:
             logger.warning(
-                f"[VIDEO_GEN] Veo does not support person_generation="
-                f"{person_generation}. Defaulting to allow_adult."
+                f"[VIDEO_GEN] Veo "
+                f"{'image-to-video' if _is_image_to_video else 'text-to-video'} "
+                f"does not support person_generation={person_generation}; "
+                "omitting it so the model uses its default."
             )
-            person_generation = "allow_adult"
+            person_generation = None
 
         # Audio on Veo 3.x is model-controlled, not a request-time toggle:
         # `veo-3.1-generate-preview` (and likely siblings) rejects the

--- a/agent_core/core/llm/google_gemini_client.py
+++ b/agent_core/core/llm/google_gemini_client.py
@@ -771,7 +771,8 @@ class GeminiClient:
         """
         sep = "&" if "?" in video_uri else "?"
         response = requests.get(
-            f"{video_uri}{sep}key={self._api_key}",
+            video_uri,
+            params={"key": self._api_key},
             timeout=timeout,
             stream=False,
         )

--- a/agent_core/core/llm/google_gemini_client.py
+++ b/agent_core/core/llm/google_gemini_client.py
@@ -403,7 +403,7 @@ class GeminiClient:
         url = self._endpoint(cache_id)
         response = requests.delete(
             url,
-            params={"key": self._api_key},
+            headers={"x-goog-api-key": self._api_key},
             timeout=self._timeout,
         )
         response.raise_for_status()
@@ -747,7 +747,7 @@ class GeminiClient:
         url = self._endpoint(path)
         response = requests.get(
             url,
-            params={"key": self._api_key},
+            headers={"x-goog-api-key": self._api_key},
             timeout=self._timeout,
         )
         if not response.ok:
@@ -790,7 +790,7 @@ class GeminiClient:
         """Send POST request and return JSON response."""
         response = requests.post(
             self._endpoint(path),
-            params={"key": self._api_key},
+            headers={"x-goog-api-key": self._api_key},
             json=payload,
             timeout=self._timeout,
         )

--- a/agent_core/core/llm/google_gemini_client.py
+++ b/agent_core/core/llm/google_gemini_client.py
@@ -766,13 +766,14 @@ class GeminiClient:
         """Download a Veo signed video URI as raw MP4 bytes.
 
         Veo returns a URI on the ``generativelanguage.googleapis.com`` host
-        that requires the API key. Appended via ``?key=`` for symmetry with
-        the rest of this client; the URI may already include other params.
+        that requires the API key. Sent via the ``x-goog-api-key`` header so
+        the key never appears in the URL — otherwise it would leak through
+        ``HTTPError`` messages (which include the request URL) and any
+        request/response logging.
         """
-        sep = "&" if "?" in video_uri else "?"
         response = requests.get(
             video_uri,
-            params={"key": self._api_key},
+            headers={"x-goog-api-key": self._api_key},
             timeout=timeout,
             stream=False,
         )

--- a/agent_core/core/llm/google_gemini_client.py
+++ b/agent_core/core/llm/google_gemini_client.py
@@ -631,6 +631,154 @@ class GeminiClient:
         }
 
     # ------------------------------------------------------------------
+    # Veo video generation (long-running operation)
+    # ------------------------------------------------------------------
+    def generate_video(
+        self,
+        model: str,
+        *,
+        prompt: str,
+        negative_prompt: Optional[str] = None,
+        image: Optional[tuple] = None,
+        last_frame: Optional[tuple] = None,
+        reference_images: Optional[List[tuple]] = None,
+        aspect_ratio: Optional[str] = None,
+        duration_seconds: Optional[str] = None,
+        resolution: Optional[str] = None,
+        person_generation: Optional[str] = None,
+        number_of_videos: Optional[int] = None,
+        seed: Optional[int] = None,
+        generate_audio: Optional[bool] = None,
+    ) -> Dict[str, Any]:
+        """Kick off a Veo video generation as a long-running operation.
+
+        Args:
+            model: Veo model identifier (e.g. ``veo-3.1-generate-preview``).
+            prompt: Text description of the video to generate.
+            negative_prompt: Optional text describing what to avoid.
+            image: Optional ``(bytes, mime_type)`` start-frame for image-to-video.
+            last_frame: Optional ``(bytes, mime_type)`` end-frame for frame
+                interpolation (Veo 3.1+).
+            reference_images: Optional list of ``(bytes, mime_type)`` reference
+                frames for style guidance (up to 3, Veo 3.1+).
+            aspect_ratio: ``"16:9"`` or ``"9:16"``.
+            duration_seconds: Duration as an INTEGER. Veo 3 accepts ``4`` /
+                ``6`` / ``8``; 1080p+/refs require ``8``. (Earlier docs showed
+                a string, but the live ``veo-3.1-generate-preview`` model
+                rejects strings with 400 INVALID_ARGUMENT.)
+            resolution: ``"720p"`` / ``"1080p"`` / ``"4k"`` (4k unavailable on Lite).
+            person_generation: ``"allow_all"`` / ``"allow_adult"`` / ``"dont_allow"``.
+                ``allow_all`` is geo-restricted (EU/UK/CH/MENA).
+            number_of_videos: Number of videos to generate (typically 1–4).
+            seed: Optional deterministic seed.
+            generate_audio: Whether to generate synchronized native audio.
+                Default behavior is provider-decided; set explicitly to control.
+
+        Returns:
+            Dict with the long-running operation ``{"name": "operations/..."}``.
+            Pass the returned name to :meth:`poll_video_operation` to wait for
+            completion.
+        """
+        instance: Dict[str, Any] = {"prompt": prompt}
+        if image is not None:
+            data, mime = image
+            instance["image"] = {
+                "bytesBase64Encoded": base64.b64encode(data).decode("utf-8"),
+                "mimeType": mime or "image/png",
+            }
+        if last_frame is not None:
+            data, mime = last_frame
+            instance["lastFrame"] = {
+                "bytesBase64Encoded": base64.b64encode(data).decode("utf-8"),
+                "mimeType": mime or "image/png",
+            }
+        if reference_images:
+            instance["referenceImages"] = [
+                {
+                    "image": {
+                        "bytesBase64Encoded": base64.b64encode(data).decode("utf-8"),
+                        "mimeType": mime or "image/png",
+                    }
+                }
+                for data, mime in reference_images
+            ]
+
+        parameters: Dict[str, Any] = {}
+        if aspect_ratio is not None:
+            parameters["aspectRatio"] = aspect_ratio
+        if duration_seconds is not None:
+            # Veo expects an integer; passing a string yields
+            # 400 INVALID_ARGUMENT ("durationSeconds needs to be a number").
+            parameters["durationSeconds"] = int(duration_seconds)
+        if resolution is not None:
+            parameters["resolution"] = resolution
+        if person_generation is not None:
+            parameters["personGeneration"] = person_generation
+        # numberOfVideos is rejected outright by some Veo variants (e.g.
+        # veo-3.1-generate-preview). Only include it when the caller asked
+        # for more than one — single-video requests omit the field.
+        if number_of_videos is not None and number_of_videos > 1:
+            parameters["numberOfVideos"] = number_of_videos
+        if seed is not None:
+            parameters["seed"] = seed
+        if negative_prompt:
+            parameters["negativePrompt"] = negative_prompt
+        if generate_audio is not None:
+            parameters["generateAudio"] = generate_audio
+
+        payload: Dict[str, Any] = {"instances": [instance]}
+        if parameters:
+            payload["parameters"] = parameters
+
+        return self._post_json(
+            f"{_normalise_model_name(model)}:predictLongRunning", payload
+        )
+
+    def poll_video_operation(self, operation_name: str) -> Dict[str, Any]:
+        """Poll a Veo long-running operation. Returns the raw operation JSON.
+
+        The caller should check ``response["done"]`` and, when true, extract
+        ``response["response"]["generateVideoResponse"]["generatedSamples"]``
+        for the resulting video URIs.
+        """
+        path = operation_name.lstrip("/")
+        if path.startswith(f"{self._api_version}/"):
+            path = path[len(f"{self._api_version}/"):]
+        url = self._endpoint(path)
+        response = requests.get(
+            url,
+            params={"key": self._api_key},
+            timeout=self._timeout,
+        )
+        if not response.ok:
+            try:
+                logger.warning(
+                    f"[GEMINI ERROR] Veo poll status={response.status_code} body={response.json()}"
+                )
+            except Exception:
+                logger.warning(
+                    f"[GEMINI ERROR] Veo poll status={response.status_code} text={response.text[:1000]}"
+                )
+        response.raise_for_status()
+        return response.json()
+
+    def download_video(self, video_uri: str, *, timeout: int = 120) -> bytes:
+        """Download a Veo signed video URI as raw MP4 bytes.
+
+        Veo returns a URI on the ``generativelanguage.googleapis.com`` host
+        that requires the API key. Appended via ``?key=`` for symmetry with
+        the rest of this client; the URI may already include other params.
+        """
+        sep = "&" if "?" in video_uri else "?"
+        response = requests.get(
+            f"{video_uri}{sep}key={self._api_key}",
+            timeout=timeout,
+            stream=False,
+        )
+        response.raise_for_status()
+        return response.content
+
+    # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------
     def _endpoint(self, path: str) -> str:

--- a/agent_core/core/models/model_registry.py
+++ b/agent_core/core/models/model_registry.py
@@ -9,54 +9,66 @@ MODEL_REGISTRY = {
         InterfaceType.VLM: "gpt-5.2-2025-12-11",
         InterfaceType.EMBEDDING: "text-embedding-3-small",
         InterfaceType.IMAGE_GEN: "gpt-image-2",
+        InterfaceType.VIDEO_GEN: "sora-2",
     },
     "gemini": {
         InterfaceType.LLM: "gemini-2.5-pro",
         InterfaceType.VLM: "gemini-2.5-pro",
         InterfaceType.EMBEDDING: "text-embedding-004",
         InterfaceType.IMAGE_GEN: "gemini-3-pro-image",
+        InterfaceType.VIDEO_GEN: "veo-3.1-generate-preview",
     },
     "anthropic": {
         InterfaceType.LLM: "claude-sonnet-4-5-20250929",
         InterfaceType.VLM: "claude-sonnet-4-5-20250929",
         InterfaceType.EMBEDDING: None,  # Anthropic does not provide native embedding models
         InterfaceType.IMAGE_GEN: None,
+        InterfaceType.VIDEO_GEN: None,
     },
     "byteplus": {
         InterfaceType.LLM: "seed-2-0-pro-260328",
         InterfaceType.VLM: "seed-2-0-pro-260328",
         InterfaceType.EMBEDDING: "skylark-embedding-vision-250615",
         InterfaceType.IMAGE_GEN: None,
+        # BytePlus international (ap-southeast.bytepluses.com) model IDs use
+        # dated build suffixes, no dots, no `doubao-` prefix (`doubao-*` is
+        # the Volcengine China naming). Verified from BytePlus ModelArk docs.
+        InterfaceType.VIDEO_GEN: "seedance-1-0-pro-fast-251015",
     },
     "remote": {
         InterfaceType.LLM: "llama3.2:3b",
         InterfaceType.VLM: "llava:7b",
         InterfaceType.EMBEDDING: "nomic-embed-text",
         InterfaceType.IMAGE_GEN: None,
+        InterfaceType.VIDEO_GEN: None,
     },
     "minimax": {
         InterfaceType.LLM: "MiniMax-Text-01",
         InterfaceType.VLM: "MiniMax-VL-01",
         InterfaceType.EMBEDDING: None,
         InterfaceType.IMAGE_GEN: None,
+        InterfaceType.VIDEO_GEN: None,
     },
     "deepseek": {
         InterfaceType.LLM: "deepseek-chat",
         InterfaceType.VLM: None,
         InterfaceType.EMBEDDING: None,
         InterfaceType.IMAGE_GEN: None,
+        InterfaceType.VIDEO_GEN: None,
     },
     "moonshot": {
         InterfaceType.LLM: "kimi-k2.5",
         InterfaceType.VLM: "moonshot-v1-8k-vision-preview",
         InterfaceType.EMBEDDING: None,
         InterfaceType.IMAGE_GEN: None,
+        InterfaceType.VIDEO_GEN: None,
     },
     "grok": {
         InterfaceType.LLM: "grok-3",
         InterfaceType.VLM: "grok-4-0709",
         InterfaceType.EMBEDDING: None,
         InterfaceType.IMAGE_GEN: None,
+        InterfaceType.VIDEO_GEN: None,
     },
     "openrouter": {
         # OpenRouter slugs follow `<provider>/<model>` format. Default to a Claude
@@ -65,6 +77,7 @@ MODEL_REGISTRY = {
         InterfaceType.VLM: "anthropic/claude-sonnet-4.5",
         InterfaceType.EMBEDDING: None,
         InterfaceType.IMAGE_GEN: None,
+        InterfaceType.VIDEO_GEN: None,
     },
     "bedrock": {
         # Default to Claude Haiku 4.5 — best price/performance on Bedrock with
@@ -82,5 +95,6 @@ MODEL_REGISTRY = {
         InterfaceType.VLM: "us.anthropic.claude-haiku-4-5-20251001-v1:0",
         InterfaceType.EMBEDDING: "amazon.titan-embed-text-v2:0",
         InterfaceType.IMAGE_GEN: None,
+        InterfaceType.VIDEO_GEN: None,
     },
 }

--- a/agent_core/core/models/types.py
+++ b/agent_core/core/models/types.py
@@ -16,9 +16,12 @@ class InterfaceType(str, Enum):
     - LLM: Language model for text generation
     - VLM: Vision-language model for image understanding
     - EMBEDDING: Embedding model for vector representations
+    - IMAGE_GEN: Text-to-image generation
+    - VIDEO_GEN: Text-to-video / image-to-video generation
     """
 
     LLM = "llm"
     VLM = "vlm"
     EMBEDDING = "embedding"
     IMAGE_GEN = "image_gen"
+    VIDEO_GEN = "video_gen"

--- a/app/agent_base.py
+++ b/app/agent_base.py
@@ -73,6 +73,7 @@ from agent_core.core.impl.llm.errors import (
 )
 from app.vlm_interface import VLMInterface
 from app.image_gen_interface import ImageGenInterface
+from app.video_gen_interface import VideoGenInterface
 from app.database_interface import DatabaseInterface
 from app.logger import logger
 from agent_core import (
@@ -231,6 +232,23 @@ class AgentBase:
             deferred=True,  # always deferred — many users won't have an image-gen key
         )
 
+        # Video generation uses its own provider/model settings (defaults to
+        # Gemini Veo since it's the strongest free-tier option). Always
+        # deferred — most users won't have a video-gen key configured.
+        from app.config import (
+            get_video_gen_provider as _get_vid_prov,
+            get_video_gen_model as _get_vid_model,
+        )
+
+        _vid_provider = _get_vid_prov()
+        _vid_api_key = get_api_key(_vid_provider)
+        self.video_gen = VideoGenInterface(
+            provider=_vid_provider,
+            model=_get_vid_model(),
+            api_key=_vid_api_key,
+            deferred=True,
+        )
+
         self.event_stream_manager = EventStreamManager(
             self.llm,
             agent_file_system_path=AGENT_FILE_SYSTEM_PATH,
@@ -328,6 +346,7 @@ class AgentBase:
             self.state_manager,
             vlm_interface=self.vlm,
             image_gen_interface=self.image_gen,
+            video_gen_interface=self.video_gen,
             memory_manager=self.memory_manager,
             context_engine=self.context_engine,
         )
@@ -3070,6 +3089,42 @@ class AgentBase:
             InternalActionInterface.image_gen_interface = new_interface
         logger.info(
             f"[AGENT] Image gen reinitialized: provider={target_provider}, success={ok}"
+        )
+        return ok
+
+    def reinitialize_video_gen(self, provider: str | None = None) -> bool:
+        """Reinitialize the video generation interface with updated configuration.
+
+        Creates a fresh VideoGenInterface instance rather than mutating the
+        existing one, so any in-flight action that holds a reference to the
+        old instance completes cleanly against the old provider/client.
+
+        Args:
+            provider: Optional provider to switch to. If None, reads from settings.
+
+        Returns:
+            True if reinitialization was successful.
+        """
+        from app.config import get_video_gen_provider, get_api_key, get_video_gen_model
+        from app.video_gen_interface import VideoGenInterface
+        from app.internal_action_interface import InternalActionInterface
+
+        target_provider = provider or get_video_gen_provider()
+        api_key = get_api_key(target_provider)
+        model = get_video_gen_model()
+
+        new_interface = VideoGenInterface(
+            provider=target_provider,
+            model=model,
+            api_key=api_key,
+            deferred=False,
+        )
+        ok = new_interface.is_initialized
+        if ok:
+            self.video_gen = new_interface
+            InternalActionInterface.video_gen_interface = new_interface
+        logger.info(
+            f"[AGENT] Video gen reinitialized: provider={target_provider}, success={ok}"
         )
         return ok
 

--- a/app/config.py
+++ b/app/config.py
@@ -92,9 +92,11 @@ def _get_default_settings() -> Dict[str, Any]:
             "llm_provider": "anthropic",
             "vlm_provider": "anthropic",
             "image_gen_provider": "openai",
+            "video_gen_provider": "gemini",
             "llm_model": None,
             "vlm_model": None,
             "image_gen_model": None,
+            "video_gen_model": None,
             "slow_mode": False,
             "slow_mode_tpm_limit": 30000,
         },
@@ -228,6 +230,27 @@ def get_image_gen_model() -> Optional[str]:
     """Get configured image generation model override (or None for default)."""
     settings = get_settings()
     return settings.get("model", {}).get("image_gen_model")
+
+
+def get_video_gen_provider() -> str:
+    """Get configured video generation provider.
+
+    Falls back to the image-gen provider, then to a sensible default
+    ('gemini' since Veo is the strongest free-tier video model).
+    """
+    settings = get_settings()
+    model = settings.get("model", {})
+    return (
+        model.get("video_gen_provider")
+        or model.get("image_gen_provider")
+        or "gemini"
+    )
+
+
+def get_video_gen_model() -> Optional[str]:
+    """Get configured video generation model override (or None for default)."""
+    settings = get_settings()
+    return settings.get("model", {}).get("video_gen_model")
 
 
 def get_api_key(provider: str) -> str:

--- a/app/data/action/generate_image.py
+++ b/app/data/action/generate_image.py
@@ -1,50 +1,6 @@
 from agent_core import action
 from agent_core.utils.logger import logger
 
-# Fallback priority when the configured provider can't generate images: prefer
-# Google (Gemini), then OpenAI, then any other provider the registry marks as
-# image-gen-capable. (Today only gemini/openai qualify, but this stays generic.)
-_IMAGE_GEN_PRIORITY = ["gemini", "openai"]
-
-
-def _resolve_image_gen_provider(configured_provider: str):
-    """Pick the provider to use for image generation.
-
-    Uses the configured provider when it both supports image generation and has
-    a configured API key. Otherwise falls back to the highest-priority provider
-    (see _IMAGE_GEN_PRIORITY) that is image-gen-capable AND has a key — so a user
-    on, say, an LLM-only provider can still generate images if they have a
-    Google/OpenAI key. Returns None when no provider can serve image generation.
-    """
-    from agent_core.core.models.model_registry import MODEL_REGISTRY
-    from agent_core.core.models.types import InterfaceType
-    from app.config import get_api_key
-
-    def supports(p: str) -> bool:
-        return bool(MODEL_REGISTRY.get(p, {}).get(InterfaceType.IMAGE_GEN))
-
-    def has_key(p: str) -> bool:
-        try:
-            return bool(get_api_key(p))
-        except Exception:
-            return False
-
-    if (
-        configured_provider
-        and supports(configured_provider)
-        and has_key(configured_provider)
-    ):
-        return configured_provider
-
-    candidates = list(_IMAGE_GEN_PRIORITY)
-    for p, caps in MODEL_REGISTRY.items():
-        if caps.get(InterfaceType.IMAGE_GEN) and p not in candidates:
-            candidates.append(p)
-    for p in candidates:
-        if supports(p) and has_key(p):
-            return p
-    return None
-
 
 @action(
     name="generate_image",
@@ -133,7 +89,9 @@ def generate_image(input_data: dict) -> dict:
         }
 
     import app.internal_action_interface as iai
-    from app.config import get_image_gen_provider
+    from agent_core.core.models.model_registry import MODEL_REGISTRY
+    from agent_core.core.models.types import InterfaceType
+    from app.config import get_api_key, get_image_gen_provider
 
     prompt = str(input_data.get("prompt", "")).strip()
     if not prompt:
@@ -142,6 +100,33 @@ def generate_image(input_data: dict) -> dict:
             "image_paths": [],
             "message": "prompt is required.",
         }
+
+    # Fallback priority when the configured provider can't generate images:
+    # prefer Gemini, then OpenAI, then any other image-gen-capable provider.
+    _IMAGE_GEN_PRIORITY = ["gemini", "openai"]
+
+    def _supports(p):
+        return bool(MODEL_REGISTRY.get(p, {}).get(InterfaceType.IMAGE_GEN))
+
+    def _has_key(p):
+        try:
+            return bool(get_api_key(p))
+        except Exception:
+            return False
+
+    def _resolve_image_gen_provider(configured):
+        """Configured provider if it can image-gen AND has a key, else highest-
+        priority capable provider with a key, else None."""
+        if configured and _supports(configured) and _has_key(configured):
+            return configured
+        candidates = list(_IMAGE_GEN_PRIORITY)
+        for p, caps in MODEL_REGISTRY.items():
+            if caps.get(InterfaceType.IMAGE_GEN) and p not in candidates:
+                candidates.append(p)
+        for p in candidates:
+            if _supports(p) and _has_key(p):
+                return p
+        return None
 
     configured_provider = get_image_gen_provider()
     effective_provider = _resolve_image_gen_provider(configured_provider)
@@ -167,7 +152,7 @@ def generate_image(input_data: dict) -> dict:
         or image_gen.provider != effective_provider
     ):
         from app.image_gen_interface import ImageGenInterface
-        from app.config import get_api_key, get_image_gen_model
+        from app.config import get_image_gen_model
 
         if effective_provider != configured_provider:
             logger.info(

--- a/app/data/action/generate_video.py
+++ b/app/data/action/generate_video.py
@@ -1,0 +1,270 @@
+from agent_core import action
+from agent_core.utils.logger import logger
+
+
+@action(
+    name="generate_video",
+    description="""Generates a video from a text prompt using the configured video generation provider (Google Gemini Veo, OpenAI Sora, or BytePlus Seedance).
+- The provider is determined by 'video_gen_provider' in settings.json (default: gemini). Supported: gemini, openai, byteplus.
+- The action BLOCKS while the long-running generation completes (typically 60-300s; up to ~25 min hard cap).
+- Saves the result as an MP4 file to output_path, or a timestamped temp file if omitted.
+- TIP: For image-to-video, pass an absolute path to a single start frame via 'reference_image'.
+- NOTE: Per-provider quirks — Veo supports last_frame + reference_images (style); Sora accepts a single reference_image (uploaded inline as the SDK file field); Seedance accepts camera_fixed and watermark flags. Audio: Veo and Sora 2 produce synchronized audio; Seedance honors with_audio on 2.0+ models (silent on older 1.0 builds).""",
+    default=True,
+    mode="CLI",
+    action_sets=["content_creation", "video"],
+    input_schema={
+        "prompt": {
+            "type": "string",
+            "example": "A drone shot of a misty mountain valley at dawn, cinematic",
+            "description": "Text description of the video to generate.",
+            "required": True,
+        },
+        "output_path": {
+            "type": "string",
+            "example": "C:/Users/user/Videos/generated.mp4",
+            "description": "Absolute path where the generated video will be saved. If omitted, saved to temp directory with a timestamped name.",
+        },
+        "duration_seconds": {
+            "type": "integer",
+            "example": 8,
+            "description": "Target duration in seconds. Per-provider clamping: Sora 2 = 4/8/12; Veo = 4/6/8 (forced to 8 with 1080p+/refs); Seedance = 2-12.",
+        },
+        "aspect_ratio": {
+            "type": "string",
+            "example": "16:9",
+            "description": "Aspect ratio: '16:9' (default), '9:16', '1:1', '4:3', '3:4', '21:9'. Sora and Veo only support 16:9 and 9:16.",
+        },
+        "resolution": {
+            "type": "string",
+            "example": "1080p",
+            "description": "Output resolution: '480p', '720p' (default), '1080p', '4k'. Sora 2 standard tops at 720p; 4k is Veo only.",
+        },
+        "number_of_videos": {
+            "type": "integer",
+            "example": 1,
+            "description": "Number of videos to generate (1-4). Default: 1. Multiple videos are submitted as independent jobs for Sora and Seedance.",
+        },
+        "negative_prompt": {
+            "type": "string",
+            "example": "blurry, low quality, distorted",
+            "description": "Elements to avoid. Native on Veo and Seedance; appended to prompt for Sora.",
+        },
+        "reference_image": {
+            "type": "string",
+            "example": "C:/Users/user/Pictures/start_frame.png",
+            "description": "Optional absolute path to a single start-frame image for image-to-video.",
+        },
+        "last_frame": {
+            "type": "string",
+            "example": "C:/Users/user/Pictures/end_frame.png",
+            "description": "Optional absolute path to an end-frame image for frame interpolation. Veo 3.1+ only; silently dropped elsewhere.",
+        },
+        "reference_images": {
+            "type": "array",
+            "example": ["C:/Users/user/Pictures/style1.png"],
+            "description": "Optional list of absolute paths to additional style-reference images. Veo 3.1+ accepts up to 3; silently dropped on Sora and Seedance.",
+        },
+        "seed": {
+            "type": "integer",
+            "example": 42,
+            "description": "Optional deterministic seed.",
+        },
+        "with_audio": {
+            "type": "boolean",
+            "example": True,
+            "description": "Whether to generate synchronized native audio. Veo 3.x and Sora 2 produce audio by default (no toggle — this flag is ignored on those providers). Honored on BytePlus Seedance 2.0+; silent on older Seedance 1.0 builds.",
+        },
+        "person_generation": {
+            "type": "string",
+            "example": "allow_adult",
+            "description": "Veo only — 'allow_all', 'allow_adult' (default), or 'dont_allow'. 'allow_all' is geo-restricted (EU/UK/CH/MENA).",
+        },
+        "camera_fixed": {
+            "type": "boolean",
+            "example": False,
+            "description": "BytePlus Seedance only — lock camera position throughout the clip.",
+        },
+        "watermark": {
+            "type": "boolean",
+            "example": False,
+            "description": "BytePlus Seedance only — apply watermark to output.",
+        },
+        "callback_url": {
+            "type": "string",
+            "example": "",
+            "description": "BytePlus Seedance only — webhook for task completion (optional).",
+        },
+    },
+    output_schema={
+        "status": {
+            "type": "string",
+            "example": "success",
+            "description": "'success' or 'error'.",
+        },
+        "video_paths": {
+            "type": "array",
+            "description": "Absolute paths to the generated MP4 files.",
+        },
+        "message": {
+            "type": "string",
+            "description": "Status message or error details.",
+        },
+    },
+    requirement=["openai", "requests"],
+    test_payload={
+        "prompt": "A cute corgi running through autumn leaves, slow motion",
+        "duration_seconds": 4,
+        "aspect_ratio": "16:9",
+        "resolution": "720p",
+        "number_of_videos": 1,
+        "simulated_mode": True,
+    },
+)
+def generate_video(input_data: dict) -> dict:
+    simulated_mode = input_data.get("simulated_mode", False)
+    if simulated_mode:
+        return {
+            "status": "success",
+            "video_paths": ["/tmp/simulated_video_001.mp4"],
+            "message": "Video generated successfully (simulated mode).",
+        }
+
+    import app.internal_action_interface as iai
+    from agent_core.core.models.model_registry import MODEL_REGISTRY
+    from agent_core.core.models.types import InterfaceType
+    from app.config import get_api_key, get_video_gen_provider
+
+    prompt = str(input_data.get("prompt", "")).strip()
+    if not prompt:
+        return {
+            "status": "error",
+            "video_paths": [],
+            "message": "prompt is required.",
+        }
+
+    # Fallback priority when the configured provider can't generate videos:
+    # prefer Gemini Veo, then OpenAI Sora, then BytePlus Seedance.
+    _VIDEO_GEN_PRIORITY = ["gemini", "openai", "byteplus"]
+
+    def _supports(p):
+        return bool(MODEL_REGISTRY.get(p, {}).get(InterfaceType.VIDEO_GEN))
+
+    def _has_key(p):
+        try:
+            return bool(get_api_key(p))
+        except Exception:
+            return False
+
+    def _resolve_video_gen_provider(configured):
+        """Configured provider if it can video-gen AND has a key, else highest-
+        priority capable provider with a key, else None."""
+        if configured and _supports(configured) and _has_key(configured):
+            return configured
+        candidates = list(_VIDEO_GEN_PRIORITY)
+        for p, caps in MODEL_REGISTRY.items():
+            if caps.get(InterfaceType.VIDEO_GEN) and p not in candidates:
+                candidates.append(p)
+        for p in candidates:
+            if _supports(p) and _has_key(p):
+                return p
+        return None
+
+    configured_provider = get_video_gen_provider()
+    effective_provider = _resolve_video_gen_provider(configured_provider)
+
+    if effective_provider is None:
+        return {
+            "status": "error",
+            "video_paths": [],
+            "message": (
+                "No video-generation provider is available. Video generation requires "
+                "Google (Gemini Veo), OpenAI (Sora), or BytePlus (Seedance) with a "
+                "configured API key. Set 'video_gen_provider' and add the matching "
+                "key under 'api_keys' in settings.json."
+            ),
+        }
+
+    # Use the live interface when it already serves the effective provider;
+    # otherwise build a transient interface for the fallback provider.
+    video_gen = iai.InternalActionInterface.video_gen_interface
+    if (
+        video_gen is None
+        or not getattr(video_gen, "is_initialized", False)
+        or video_gen.provider != effective_provider
+    ):
+        from app.video_gen_interface import VideoGenInterface
+        from app.config import get_video_gen_model
+
+        if effective_provider != configured_provider:
+            logger.info(
+                f"[VIDEO_GEN] Configured provider '{configured_provider}' can't generate "
+                f"videos; falling back to '{effective_provider}' (has a configured key)."
+            )
+        try:
+            video_gen = VideoGenInterface(
+                provider=effective_provider,
+                # Honor the configured model override only when it matches the
+                # configured provider; a fallback provider uses its own default.
+                model=(
+                    get_video_gen_model()
+                    if effective_provider == configured_provider
+                    else None
+                ),
+                api_key=get_api_key(effective_provider),
+                deferred=False,
+            )
+        except Exception as e:
+            return {
+                "status": "error",
+                "video_paths": [],
+                "message": f"Failed to initialize video generation ({effective_provider}): {e}",
+            }
+        if not video_gen.is_initialized:
+            return {
+                "status": "error",
+                "video_paths": [],
+                "message": (
+                    f"Video generation provider '{effective_provider}' could not be "
+                    "initialized — check its API key in settings.json."
+                ),
+            }
+
+    try:
+        paths = video_gen.generate_video(
+            prompt=prompt,
+            duration_seconds=int(input_data.get("duration_seconds", 5)),
+            aspect_ratio=str(input_data.get("aspect_ratio", "16:9")),
+            resolution=str(input_data.get("resolution", "720p")),
+            number_of_videos=min(
+                max(int(input_data.get("number_of_videos", 1)), 1), 4
+            ),
+            output_path=str(input_data.get("output_path") or ""),
+            negative_prompt=str(input_data.get("negative_prompt") or ""),
+            reference_image=(input_data.get("reference_image") or None),
+            last_frame=(input_data.get("last_frame") or None),
+            reference_images=list(input_data.get("reference_images") or []),
+            seed=(
+                int(input_data["seed"])
+                if input_data.get("seed") not in (None, "")
+                else None
+            ),
+            with_audio=bool(input_data.get("with_audio", True)),
+            person_generation=str(
+                input_data.get("person_generation") or "allow_adult"
+            ),
+            camera_fixed=bool(input_data.get("camera_fixed", False)),
+            watermark=bool(input_data.get("watermark", False)),
+            callback_url=str(input_data.get("callback_url") or ""),
+        )
+        return {
+            "status": "success",
+            "video_paths": paths,
+            "message": f"Generated {len(paths)} video(s) via {effective_provider}.",
+        }
+    except Exception as e:
+        return {
+            "status": "error",
+            "video_paths": [],
+            "message": str(e),
+        }

--- a/app/internal_action_interface.py
+++ b/app/internal_action_interface.py
@@ -11,6 +11,7 @@ from typing import Dict, Any, Optional, List, TYPE_CHECKING
 from app.llm import LLMInterface, LLMCallType
 from app.vlm_interface import VLMInterface
 from app.image_gen_interface import ImageGenInterface
+from app.video_gen_interface import VideoGenInterface
 from app.task.task_manager import TaskManager
 from app.task import Task
 from app.state.state_manager import StateManager
@@ -45,6 +46,7 @@ class InternalActionInterface:
     state_manager: Optional[StateManager] = None
     vlm_interface: Optional[VLMInterface] = None
     image_gen_interface: Optional[ImageGenInterface] = None
+    video_gen_interface: Optional[VideoGenInterface] = None
     context_engine: Optional["ContextEngine"] = None
     gui_module: Optional["GUIModule"] = None
     memory_manager: Optional[MemoryManager] = None
@@ -60,6 +62,7 @@ class InternalActionInterface:
         state_manager: StateManager,
         vlm_interface: Optional[VLMInterface] = None,
         image_gen_interface: Optional[ImageGenInterface] = None,
+        video_gen_interface: Optional[VideoGenInterface] = None,
         context_engine: Optional["ContextEngine"] = None,
         gui_module: Optional["GUIModule"] = None,
         memory_manager: MemoryManager | None = None,
@@ -78,6 +81,7 @@ class InternalActionInterface:
         cls.state_manager = state_manager
         cls.vlm_interface = vlm_interface
         cls.image_gen_interface = image_gen_interface
+        cls.video_gen_interface = video_gen_interface
         cls.context_engine = context_engine
         cls.gui_module = gui_module
         cls.memory_manager = memory_manager
@@ -131,6 +135,26 @@ class InternalActionInterface:
                 "InternalActionInterface not initialized with ImageGenInterface."
             )
         return cls.image_gen_interface.generate_image(**kwargs)
+
+    @classmethod
+    def generate_video(cls, **kwargs) -> List[str]:
+        """Generate video(s) from a prompt using the video generation interface.
+
+        Delegates all arguments to VideoGenInterface.generate_video(). Blocks
+        until the long-running generation completes (or the executor's action
+        timeout kills it).
+
+        Returns:
+            List of absolute file paths to the generated MP4 files.
+
+        Raises:
+            RuntimeError: If video_gen_interface is not initialized or generation fails.
+        """
+        if cls.video_gen_interface is None:
+            raise RuntimeError(
+                "InternalActionInterface not initialized with VideoGenInterface."
+            )
+        return cls.video_gen_interface.generate_video(**kwargs)
 
     @classmethod
     def perform_ocr(cls, image_path: str, user_prompt: Optional[str] = None) -> dict:

--- a/app/ui_layer/adapters/browser_adapter.py
+++ b/app/ui_layer/adapters/browser_adapter.py
@@ -4708,6 +4708,7 @@ A quick Q&A will now begin to understand your objectives to serve you better:"""
             new_provider = data.get("llmProvider")
             vlm_provider = data.get("vlmProvider")
             image_gen_provider = data.get("imageGenProvider")
+            video_gen_provider = data.get("videoGenProvider")
             api_key = data.get("apiKey")
             provider_for_key = data.get("providerForKey")
             base_url = data.get("baseUrl")
@@ -4780,14 +4781,27 @@ A quick Q&A will now begin to understand your objectives to serve you better:"""
                 prev_image_gen_provider = _get_ig_provider()
                 prev_image_gen_model = _get_ig_model()
 
+            prev_video_gen_provider = None
+            prev_video_gen_model = None
+            if video_gen_provider:
+                from app.config import (
+                    get_video_gen_provider as _get_vg_provider,
+                    get_video_gen_model as _get_vg_model,
+                )
+
+                prev_video_gen_provider = _get_vg_provider()
+                prev_video_gen_model = _get_vg_model()
+
             # Step 3: Now save settings (validation and connection test passed)
             result = update_model_settings(
                 llm_provider=new_provider,
                 vlm_provider=vlm_provider,
                 image_gen_provider=image_gen_provider,
+                video_gen_provider=video_gen_provider,
                 llm_model=data.get("llmModel"),
                 vlm_model=data.get("vlmModel"),
                 image_gen_model=data.get("imageGenModel"),
+                video_gen_model=data.get("videoGenModel"),
                 api_key=api_key,
                 provider_for_key=provider_for_key,
                 base_url=base_url,
@@ -4838,6 +4852,32 @@ A quick Q&A will now begin to understand your objectives to serve you better:"""
                     msg = (
                         f"Image generation provider '{image_gen_provider}' could not be "
                         f"initialized — check its API key. Kept '{prev_image_gen_provider}'."
+                    )
+                    logger.warning(f"[BROWSER] {msg}")
+                    result["warning"] = result.get("warning") or msg
+
+            # Reinitialize video gen interface when its provider changes.
+            # Mirrors the image gen pattern: roll back on reinit failure.
+            if result.get("success") and video_gen_provider:
+                reinit_vid_ok = False
+                try:
+                    agent = self._controller.agent
+                    reinit_vid_ok = agent.reinitialize_video_gen(video_gen_provider)
+                except Exception as e:
+                    logger.warning(f"[BROWSER] Failed to reinitialize video gen: {e}")
+
+                if reinit_vid_ok:
+                    logger.info(
+                        f"[BROWSER] Video gen reinitialized with provider: {video_gen_provider}"
+                    )
+                else:
+                    update_model_settings(
+                        video_gen_provider=prev_video_gen_provider,
+                        video_gen_model=prev_video_gen_model,
+                    )
+                    msg = (
+                        f"Video generation provider '{video_gen_provider}' could not be "
+                        f"initialized — check its API key. Kept '{prev_video_gen_provider}'."
                     )
                     logger.warning(f"[BROWSER] {msg}")
                     result["warning"] = result.get("warning") or msg

--- a/app/ui_layer/browser/frontend/src/pages/Settings/ModelSettings.tsx
+++ b/app/ui_layer/browser/frontend/src/pages/Settings/ModelSettings.tsx
@@ -32,6 +32,8 @@ import {
   selectModelHasLoadedSlowMode,
   selectImageGenProvider,
   selectCurrentImageGenModel,
+  selectVideoGenProvider,
+  selectCurrentVideoGenModel,
 } from '../../store/selectors/modelSettings'
 import { getOllamaInstallPercent } from '../../utils/ollamaInstall'
 import {
@@ -94,6 +96,8 @@ export function ModelSettings() {
   const awsCredentialsStatus = useAppSelector(selectAwsCredentials)
   const imageGenProvider = useAppSelector(selectImageGenProvider)
   const currentImageGenModel = useAppSelector(selectCurrentImageGenModel)
+  const videoGenProvider = useAppSelector(selectVideoGenProvider)
+  const currentVideoGenModel = useAppSelector(selectCurrentVideoGenModel)
   const hasLoadedProviders = useAppSelector(selectModelHasLoadedProviders)
   const hasLoadedSettings = useAppSelector(selectModelHasLoadedSettings)
   const hasLoadedSlowMode = useAppSelector(selectModelHasLoadedSlowMode)
@@ -123,6 +127,13 @@ export function ModelSettings() {
   const [newImageGenApiKey, setNewImageGenApiKey] = useState('')
   const [imageGenHasChanges, setImageGenHasChanges] = useState(false)
   const [isImageGenSaving, setIsImageGenSaving] = useState(false)
+
+  // Video generation form state (transient — local).
+  const [newVideoGenProvider, setNewVideoGenProvider] = useState('')
+  const [newVideoGenModel, setNewVideoGenModel] = useState('')
+  const [newVideoGenApiKey, setNewVideoGenApiKey] = useState('')
+  const [videoGenHasChanges, setVideoGenHasChanges] = useState(false)
+  const [isVideoGenSaving, setIsVideoGenSaving] = useState(false)
 
   // UI state (transient — local).
   const [isSaving, setIsSaving] = useState(false)
@@ -174,6 +185,8 @@ export function ModelSettings() {
         if (!hasInitialized.current) {
           setNewLlmModel('')
           setNewVlmModel('')
+          setNewVideoGenProvider('')
+          setNewVideoGenModel('')
           hasInitialized.current = true
         }
       }),
@@ -181,6 +194,7 @@ export function ModelSettings() {
         const d = data as { success: boolean; error?: string }
         setIsSaving(false)
         setIsImageGenSaving(false)
+        setIsVideoGenSaving(false)
         if (d.success) {
           setNewApiKey('')
           setNewBaseUrl('')
@@ -195,6 +209,10 @@ export function ModelSettings() {
           setNewImageGenModel('')
           setNewImageGenApiKey('')
           setImageGenHasChanges(false)
+          setNewVideoGenProvider('')
+          setNewVideoGenModel('')
+          setNewVideoGenApiKey('')
+          setVideoGenHasChanges(false)
           showToast('success', 'Settings saved')
         } else {
           showToast('error', d.error || 'Failed to save')
@@ -445,6 +463,19 @@ export function ModelSettings() {
       imageGenModel: newImageGenModel || currentImageGenModel || undefined,
       ...(newImageGenApiKey ? {
         apiKey: newImageGenApiKey,
+        providerForKey: effectiveProvider,
+      } : {}),
+    })
+  }
+
+  const handleVideoGenSave = () => {
+    setIsVideoGenSaving(true)
+    const effectiveProvider = newVideoGenProvider || videoGenProvider
+    send('model_settings_update', {
+      videoGenProvider: effectiveProvider,
+      videoGenModel: newVideoGenModel || currentVideoGenModel || undefined,
+      ...(newVideoGenApiKey ? {
+        apiKey: newVideoGenApiKey,
         providerForKey: effectiveProvider,
       } : {}),
     })
@@ -992,6 +1023,90 @@ export function ModelSettings() {
                     disabled={isImageGenSaving || !imageGenHasChanges}
                   >
                     {isImageGenSaving ? (
+                      <>
+                        <Loader2 size={14} className={styles.spinning} />
+                        Saving...
+                      </>
+                    ) : (
+                      'Save'
+                    )}
+                  </Button>
+                </div>
+              </div>
+            )
+          })()}
+
+          {/* Video Generation */}
+          <hr style={{ border: 'none', borderTop: '1px solid var(--border-primary)', margin: 'var(--space-4) 0' }} />
+          <div className={styles.sectionHeader} style={{ marginBottom: 'var(--space-3)' }}>
+            <h3>Video Generation</h3>
+            <p>Configure the provider used for video generation</p>
+          </div>
+          {(() => {
+            const videoGenProviders = providers.filter(p => p.has_video_gen)
+            const effectiveVidProvider = newVideoGenProvider || videoGenProvider
+            const vidProviderInfo = videoGenProviders.find(p => p.id === effectiveVidProvider)
+            return (
+              <div className={styles.settingsForm} style={{ paddingTop: 0 }}>
+                <div className={styles.formGroup}>
+                  <label>Provider</label>
+                  <select
+                    value={effectiveVidProvider}
+                    onChange={(e) => {
+                      const sel = videoGenProviders.find(p => p.id === e.target.value)
+                      setNewVideoGenProvider(e.target.value)
+                      setNewVideoGenModel(sel?.video_gen_model || '')
+                      setNewVideoGenApiKey('')
+                      setVideoGenHasChanges(true)
+                    }}
+                  >
+                    {videoGenProviders.map(p => (
+                      <option key={p.id} value={p.id}>{p.name}</option>
+                    ))}
+                  </select>
+                </div>
+
+                {/* API Key for video gen provider */}
+                {vidProviderInfo?.requires_api_key && (
+                  <div className={styles.formGroup}>
+                    <label>
+                      API Key
+                      {apiKeys[effectiveVidProvider]?.has_key ? (
+                        <Badge variant="success" style={{ marginLeft: 8 }}>Configured</Badge>
+                      ) : (
+                        <Badge variant="warning" style={{ marginLeft: 8 }}>Required</Badge>
+                      )}
+                    </label>
+                    {apiKeys[effectiveVidProvider]?.has_key && (
+                      <div className={styles.maskedKey}>{apiKeys[effectiveVidProvider].masked_key}</div>
+                    )}
+                    <input
+                      type="password"
+                      value={newVideoGenApiKey}
+                      onChange={(e) => { setNewVideoGenApiKey(e.target.value); setVideoGenHasChanges(true) }}
+                      placeholder={apiKeys[effectiveVidProvider]?.has_key ? 'Enter new key to replace...' : 'Enter API key...'}
+                    />
+                  </div>
+                )}
+
+                {/* Model override */}
+                <div className={styles.formGroup}>
+                  <label>Model</label>
+                  <input
+                    type="text"
+                    value={newVideoGenModel || currentVideoGenModel || ''}
+                    onChange={(e) => { setNewVideoGenModel(e.target.value); setVideoGenHasChanges(true) }}
+                    placeholder={vidProviderInfo?.video_gen_model || 'Default model'}
+                  />
+                </div>
+
+                <div className={styles.sectionFooter} style={{ borderTop: 'none', paddingTop: 0 }}>
+                  <Button
+                    variant="primary"
+                    onClick={handleVideoGenSave}
+                    disabled={isVideoGenSaving || !videoGenHasChanges}
+                  >
+                    {isVideoGenSaving ? (
                       <>
                         <Loader2 size={14} className={styles.spinning} />
                         Saving...

--- a/app/ui_layer/browser/frontend/src/store/selectors/modelSettings.ts
+++ b/app/ui_layer/browser/frontend/src/store/selectors/modelSettings.ts
@@ -8,6 +8,8 @@ export const selectCurrentLlmModel = (state: RootState) => state.modelSettings.c
 export const selectCurrentVlmModel = (state: RootState) => state.modelSettings.currentVlmModel
 export const selectImageGenProvider = (state: RootState) => state.modelSettings.imageGenProvider
 export const selectCurrentImageGenModel = (state: RootState) => state.modelSettings.currentImageGenModel
+export const selectVideoGenProvider = (state: RootState) => state.modelSettings.videoGenProvider
+export const selectCurrentVideoGenModel = (state: RootState) => state.modelSettings.currentVideoGenModel
 export const selectSlowModeEnabled = (state: RootState) => state.modelSettings.slowModeEnabled
 export const selectOllamaModels = (state: RootState) => state.modelSettings.ollamaModels
 export const selectOllamaAvailable = (state: RootState) => state.modelSettings.ollamaAvailable

--- a/app/ui_layer/browser/frontend/src/store/slices/modelSettingsSlice.ts
+++ b/app/ui_layer/browser/frontend/src/store/slices/modelSettingsSlice.ts
@@ -10,8 +10,10 @@ export interface ProviderInfo {
   llm_model: string | null
   vlm_model: string | null
   image_gen_model: string | null
+  video_gen_model: string | null
   has_vlm: boolean
   has_image_gen: boolean
+  has_video_gen: boolean
   supports_catalog?: boolean
   is_bedrock?: boolean
 }
@@ -33,11 +35,13 @@ interface ModelSettingsState {
   providers: ProviderInfo[]
   provider: string
   imageGenProvider: string
+  videoGenProvider: string
   apiKeys: Record<string, ApiKeyStatus>
   baseUrls: Record<string, string>
   currentLlmModel: string
   currentVlmModel: string
   currentImageGenModel: string
+  currentVideoGenModel: string
   slowModeEnabled: boolean
   ollamaModels: string[]
   ollamaAvailable: boolean | null
@@ -51,11 +55,13 @@ const initialState: ModelSettingsState = {
   providers: [],
   provider: 'anthropic',
   imageGenProvider: 'openai',
+  videoGenProvider: 'gemini',
   apiKeys: {},
   baseUrls: {},
   currentLlmModel: '',
   currentVlmModel: '',
   currentImageGenModel: '',
+  currentVideoGenModel: '',
   slowModeEnabled: false,
   ollamaModels: [],
   ollamaAvailable: null,
@@ -76,18 +82,22 @@ const modelSettingsSlice = createSlice({
     setSettings(state, action: PayloadAction<{
       provider: string
       imageGenProvider: string
+      videoGenProvider: string
       llmModel: string
       vlmModel: string
       imageGenModel: string
+      videoGenModel: string
       apiKeys: Record<string, ApiKeyStatus>
       baseUrls: Record<string, string>
       awsCredentials?: AwsCredentialsStatus | null
     }>) {
       state.provider = action.payload.provider
       state.imageGenProvider = action.payload.imageGenProvider
+      state.videoGenProvider = action.payload.videoGenProvider
       state.currentLlmModel = action.payload.llmModel
       state.currentVlmModel = action.payload.vlmModel
       state.currentImageGenModel = action.payload.imageGenModel
+      state.currentVideoGenModel = action.payload.videoGenModel
       state.apiKeys = action.payload.apiKeys
       state.baseUrls = action.payload.baseUrls
       if (action.payload.awsCredentials !== undefined) {
@@ -113,6 +123,12 @@ const modelSettingsSlice = createSlice({
     setCurrentImageGenModel(state, action: PayloadAction<string>) {
       state.currentImageGenModel = action.payload
     },
+    setVideoGenProvider(state, action: PayloadAction<string>) {
+      state.videoGenProvider = action.payload
+    },
+    setCurrentVideoGenModel(state, action: PayloadAction<string>) {
+      state.currentVideoGenModel = action.payload
+    },
     setApiKeys(state, action: PayloadAction<Record<string, ApiKeyStatus>>) {
       state.apiKeys = action.payload
     },
@@ -135,9 +151,11 @@ export const {
   setSettings,
   setProvider,
   setImageGenProvider,
+  setVideoGenProvider,
   setCurrentLlmModel,
   setCurrentVlmModel,
   setCurrentImageGenModel,
+  setCurrentVideoGenModel,
   setApiKeys,
   setBaseUrls,
   setSlowModeEnabled,
@@ -157,9 +175,11 @@ register('model_settings_get', (data, dispatch) => {
     success: boolean
     llm_provider: string
     image_gen_provider: string
+    video_gen_provider: string
     llm_model: string | null
     vlm_model: string | null
     image_gen_model: string | null
+    video_gen_model: string | null
     api_keys: Record<string, ApiKeyStatus>
     base_urls: Record<string, string>
     aws_credentials?: AwsCredentialsStatus | null
@@ -168,9 +188,11 @@ register('model_settings_get', (data, dispatch) => {
     dispatch(setSettings({
       provider: d.llm_provider || 'anthropic',
       imageGenProvider: d.image_gen_provider || 'openai',
+      videoGenProvider: d.video_gen_provider || 'gemini',
       llmModel: d.llm_model || '',
       vlmModel: d.vlm_model || '',
       imageGenModel: d.image_gen_model || '',
+      videoGenModel: d.video_gen_model || '',
       apiKeys: d.api_keys || {},
       baseUrls: d.base_urls || {},
       awsCredentials: d.aws_credentials ?? null,
@@ -183,24 +205,28 @@ register('model_settings_update', (data, dispatch) => {
     success: boolean
     llm_provider?: string
     image_gen_provider?: string
+    video_gen_provider?: string
     llm_model?: string | null
     vlm_model?: string | null
     image_gen_model?: string | null
+    video_gen_model?: string | null
     api_keys?: Record<string, ApiKeyStatus>
     base_urls?: Record<string, string>
     aws_credentials?: AwsCredentialsStatus | null
   }
   if (!d.success) return
   if (d.llm_provider) dispatch(setProvider(d.llm_provider))
-  // Always update imageGenProvider when the field is present (even on partial saves);
-  // using `!== undefined` mirrors model_settings_get so version-mismatched backends
-  // that omit the field don't silently leave the UI showing a stale provider.
+  // Always update imageGenProvider/videoGenProvider when present (even on partial saves);
+  // using `!== undefined` so version-mismatched backends that omit the field don't
+  // silently leave the UI showing a stale provider.
   if (d.image_gen_provider !== undefined) dispatch(setImageGenProvider(d.image_gen_provider || 'openai'))
+  if (d.video_gen_provider !== undefined) dispatch(setVideoGenProvider(d.video_gen_provider || 'gemini'))
   if (d.api_keys) dispatch(setApiKeys(d.api_keys))
   if (d.base_urls) dispatch(setBaseUrls(d.base_urls))
   if (d.llm_model !== undefined) dispatch(setCurrentLlmModel(d.llm_model || ''))
   if (d.vlm_model !== undefined) dispatch(setCurrentVlmModel(d.vlm_model || ''))
   if (d.image_gen_model !== undefined) dispatch(setCurrentImageGenModel(d.image_gen_model || ''))
+  if (d.video_gen_model !== undefined) dispatch(setCurrentVideoGenModel(d.video_gen_model || ''))
   if (d.aws_credentials !== undefined) dispatch(setAwsCredentials(d.aws_credentials))
 })
 

--- a/app/ui_layer/settings/model_settings.py
+++ b/app/ui_layer/settings/model_settings.py
@@ -176,6 +176,7 @@ def get_available_providers() -> Dict[str, Any]:
             llm_model = provider_models.get(InterfaceType.LLM)
             vlm_model = provider_models.get(InterfaceType.VLM)
             image_gen_model = provider_models.get(InterfaceType.IMAGE_GEN)
+            video_gen_model = provider_models.get(InterfaceType.VIDEO_GEN)
 
             providers.append(
                 {
@@ -189,6 +190,8 @@ def get_available_providers() -> Dict[str, Any]:
                     "has_vlm": vlm_model is not None,
                     "image_gen_model": image_gen_model,
                     "has_image_gen": image_gen_model is not None,
+                    "video_gen_model": video_gen_model,
+                    "has_video_gen": video_gen_model is not None,
                     "supports_catalog": info.get("supports_catalog", False),
                     "is_bedrock": info.get("is_bedrock", False),
                 }
@@ -249,6 +252,16 @@ def get_model_settings() -> Dict[str, Any]:
         image_gen_model = model_settings.get("image_gen_model") or MODEL_REGISTRY.get(
             image_gen_provider, {}
         ).get(InterfaceType.IMAGE_GEN)
+
+        video_gen_provider = model_settings.get("video_gen_provider")
+        if not video_gen_provider:
+            if MODEL_REGISTRY.get(vlm_provider, {}).get(InterfaceType.VIDEO_GEN):
+                video_gen_provider = vlm_provider
+            else:
+                video_gen_provider = "gemini"
+        video_gen_model = model_settings.get("video_gen_model") or MODEL_REGISTRY.get(
+            video_gen_provider, {}
+        ).get(InterfaceType.VIDEO_GEN)
 
         # Check API key status for each provider (settings.json only)
         api_keys = {}
@@ -316,9 +329,11 @@ def get_model_settings() -> Dict[str, Any]:
             "llm_provider": llm_provider,
             "vlm_provider": vlm_provider,
             "image_gen_provider": image_gen_provider,
+            "video_gen_provider": video_gen_provider,
             "llm_model": llm_model,
             "vlm_model": vlm_model,
             "image_gen_model": image_gen_model,
+            "video_gen_model": video_gen_model,
             "api_keys": api_keys,
             "base_urls": base_urls,
             "aws_credentials": aws_creds_status,
@@ -334,9 +349,11 @@ def update_model_settings(
     llm_provider: Optional[str] = None,
     vlm_provider: Optional[str] = None,
     image_gen_provider: Optional[str] = None,
+    video_gen_provider: Optional[str] = None,
     llm_model: Optional[str] = None,
     vlm_model: Optional[str] = None,
     image_gen_model: Optional[str] = None,
+    video_gen_model: Optional[str] = None,
     api_key: Optional[str] = None,
     provider_for_key: Optional[str] = None,
     base_url: Optional[str] = None,
@@ -414,6 +431,26 @@ def update_model_settings(
             if image_gen_provider != old_img_provider and image_gen_model is None:
                 settings["model"]["image_gen_model"] = None
 
+        # Update video generation provider (validate before saving)
+        if video_gen_provider:
+            supported_vid_providers = {
+                p
+                for p, caps in MODEL_REGISTRY.items()
+                if caps.get(InterfaceType.VIDEO_GEN)
+            }
+            if video_gen_provider not in supported_vid_providers:
+                return {
+                    "success": False,
+                    "error": (
+                        f"'{video_gen_provider}' does not support video generation. "
+                        f"Supported providers: {', '.join(sorted(supported_vid_providers))}"
+                    ),
+                }
+            old_vid_provider = settings["model"].get("video_gen_provider")
+            settings["model"]["video_gen_provider"] = video_gen_provider
+            if video_gen_provider != old_vid_provider and video_gen_model is None:
+                settings["model"]["video_gen_model"] = None
+
         # Update custom models (explicit values override the auto-clear above)
         if llm_model is not None:
             settings["model"]["llm_model"] = llm_model if llm_model else None
@@ -422,6 +459,10 @@ def update_model_settings(
         if image_gen_model is not None:
             settings["model"]["image_gen_model"] = (
                 image_gen_model if image_gen_model else None
+            )
+        if video_gen_model is not None:
+            settings["model"]["video_gen_model"] = (
+                video_gen_model if video_gen_model else None
             )
 
         # Update API key in settings.json

--- a/app/video_gen_interface.py
+++ b/app/video_gen_interface.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+"""
+Video generation interface for CraftBot.
+
+Re-exports VideoGenInterface from agent_core with CraftBot-specific hooks
+for state access (using STATE singleton) and usage reporting.
+"""
+
+from typing import Optional
+
+from agent_core.core.impl.video_gen import VideoGenInterface as _VideoGenInterface
+from agent_core.core.hooks.types import UsageEventData
+from app.state.agent_state import get_session_props
+
+
+def _get_token_count() -> int:
+    return get_session_props().get_property("token_count", 0)
+
+
+def _set_token_count(count: int) -> None:
+    get_session_props().set_property("token_count", count)
+
+
+async def _report_usage(event: UsageEventData) -> None:
+    from app.usage import get_usage_reporter
+
+    await get_usage_reporter().report(event)
+
+
+class VideoGenInterface(_VideoGenInterface):
+    """VideoGenInterface configured for CraftBot's STATE singleton.
+
+    Automatically injects the get_token_count and set_token_count hooks
+    that use CraftBot's global STATE object.
+    """
+
+    def __init__(
+        self,
+        *,
+        provider: Optional[str] = None,
+        model: Optional[str] = None,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        deferred: bool = False,
+    ) -> None:
+        super().__init__(
+            provider=provider,
+            model=model,
+            api_key=api_key,
+            base_url=base_url,
+            deferred=deferred,
+            get_token_count=_get_token_count,
+            set_token_count=_set_token_count,
+            report_usage=_report_usage,
+        )


### PR DESCRIPTION
What and why:
Allow Craftbot to generate video directly with provider/model API calling. Minor fix for image generation too.

Feature added:
- New VideoGenInterface
- Support for Google Gemini Veo 3.x, OpenAI Sora 2/Pro, and BytePlus Seedance
- full per-provider parameters (durations, ratios, image-to-video reference + last-frame, person_generation, watermark, camera_fixed, callback_url)
- Blocking generate_video() handles the async long-running flow internally: submit → poll → download MP4 → return file paths
- generate_video action
- InterfaceType.VIDEO_GEN + MODEL_REGISTRY entries (Veo 3.1 preview, Sora 2, Seedance 1.0 Pro Fast)
