### PR TITLE
Feature/agent profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ agent_file_system/TASK_HISTORY.md
 !build_template.py
 docs/LIVING_UI_DEVELOPER_GUIDE.md
 agent_file_system/ACTIONS.md
+agent_bundle/

--- a/agent_core/core/impl/skill/loader.py
+++ b/agent_core/core/impl/skill/loader.py
@@ -90,37 +90,29 @@ class SkillLoader:
 
         content = skill_path.read_text(encoding="utf-8")
 
-        # Parse frontmatter and instructions
+        # Frontmatter is optional. Files without a `---` block (hand-written
+        # skills, imported skills from agent bundles) load with metadata
+        # derived from the folder name + first body paragraph.
         match = SkillLoader.FRONTMATTER_PATTERN.match(content)
+        if match:
+            frontmatter_str = match.group(1)
+            instructions = match.group(2).strip()
+            try:
+                frontmatter = yaml.safe_load(frontmatter_str)
+                if not isinstance(frontmatter, dict):
+                    raise ValueError("Frontmatter must be a YAML dictionary")
+            except yaml.YAMLError as e:
+                raise ValueError(f"Invalid YAML frontmatter: {e}")
+        else:
+            frontmatter = {}
+            instructions = content.strip()
 
-        if not match:
-            raise ValueError(
-                f"Invalid SKILL.md format (missing frontmatter): {skill_path}"
-            )
-
-        frontmatter_str = match.group(1)
-        instructions = match.group(2).strip()
-
-        # Parse YAML frontmatter
-        try:
-            frontmatter = yaml.safe_load(frontmatter_str)
-            if not isinstance(frontmatter, dict):
-                raise ValueError("Frontmatter must be a YAML dictionary")
-        except yaml.YAMLError as e:
-            raise ValueError(f"Invalid YAML frontmatter: {e}")
-
-        # Validate required fields
         if "name" not in frontmatter:
-            # Try to infer name from directory
             frontmatter["name"] = skill_path.parent.name
 
         if "description" not in frontmatter:
-            # Try to extract description from first paragraph
-            first_para = instructions.split("\n\n")[0] if instructions else ""
-            # Remove markdown headers
-            first_para = re.sub(r"^#+\s+.*\n", "", first_para).strip()
             frontmatter["description"] = (
-                first_para[:200] if first_para else "No description"
+                SkillLoader._derive_description(instructions) or "No description"
             )
 
         # Create metadata
@@ -134,6 +126,22 @@ class SkillLoader:
             directory=skill_path.parent,
             enabled=True,
         )
+
+    @staticmethod
+    def _derive_description(instructions: str) -> str:
+        """Pick a description out of the body when frontmatter doesn't supply one.
+
+        Walks paragraphs, strips leading markdown headings and blockquote
+        markers, and returns the first non-empty result (capped at 200 chars).
+        Matches the convention used by the agent_bundle SKILL.md files, where
+        the first non-heading paragraph is a `> tagline` blockquote.
+        """
+        for para in instructions.split("\n\n"):
+            para = re.sub(r"^#+\s+[^\n]*\n?", "", para.strip()).strip()
+            para = re.sub(r"^>\s?", "", para, flags=re.MULTILINE).strip()
+            if para:
+                return para[:200]
+        return ""
 
     @staticmethod
     def substitute_variables(instructions: str, arguments: str) -> str:

--- a/app/data/playbooks/catalogue.json
+++ b/app/data/playbooks/catalogue.json
@@ -1,0 +1,3613 @@
+{
+  "version": 1,
+  "playbooks": [
+    {
+      "id": "marketing-kit",
+      "name": "Create a marketing kit",
+      "category": "Marketing",
+      "tags": [
+        "content",
+        "marketing"
+      ],
+      "emoji": "📣",
+      "description": "Turn a product brief into a launch kit. Get positioning angles, landing copy, 5 social posts, and a 1-page PDF leave-behind.",
+      "works_best_with": {
+        "agent_profile": "marketing-agent",
+        "skills": [
+          "pptx",
+          "docx",
+          "pdf",
+          "brave-search",
+          "vale-brand-voice"
+        ],
+        "mcp_servers": [
+          "canva-mcp",
+          "twitter-mcp",
+          "gmail-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Read the product brief",
+        "Draft 3 positioning angles and recommend one",
+        "Write landing-page hero + supporting sections",
+        "Produce 5 social posts (LinkedIn, X, Threads, Instagram)",
+        "Compile a 1-page PDF leave-behind"
+      ],
+      "prompt": "I want to create a launch marketing kit for my product.\n\nProduct brief:\n- Name: [product name]\n- One-liner: [10-15 word summary]\n- Target customer: [role + company shape]\n- Top 3 problems it solves: [problems]\n- Primary value props: [3-5 props]\n- Pricing model: [model + price points]\n- Competitors I differentiate against: [names]\n- Launch date: [date]\n- Tone / brand voice notes: [punchy / authoritative / playful / etc.]\n\nDeliverables, in this order:\n\n1) Positioning angles (3 options). For each: angle name, headline (<=12 words), the audience segment it lands hardest with, why it works, and the biggest risk. End with your pick and one paragraph of reasoning. Wait for my approval before moving on.\n\n2) Landing page copy, based on the picked angle:\n   - Hero: headline (<=10 words), subhead (<=25 words), primary CTA copy\n   - \"What it is\" section (~80 words, no jargon)\n   - 3 feature/benefit blocks (label + 1-sentence benefit + concrete proof point each)\n   - Social proof / objection-handling section\n   - Final CTA section\n   Keep total copy under 600 words. Ban: \"revolutionary\", \"seamless\", \"unlock\", \"leverage\", \"in today's landscape\".\n\n3) 5 social posts, tailored per platform — not the same copy reflowed:\n   - 1x LinkedIn (150-250 words, narrative or contrarian hook, 3 niche hashtags at the end only)\n   - 2x X / Twitter (one <=280 char standalone, one 4-tweet thread with a hook tweet)\n   - 1x Threads (conversational, <=500 chars, 1-2 emoji max)\n   - 1x Instagram caption (hook line + body + soft CTA + 5 niche hashtags)\n\n4) 1-page PDF leave-behind, written to my workspace as an actual .pdf file. Include: product one-liner, the 3 problems mapped to the 3 solutions, a screenshot placeholder block, 2 testimonial placeholders, pricing summary, and a contact line. Clean, high-contrast layout — no stock-photo clichés.\n\nQuality bar:\n- Cross-check the entire kit against the brand voice notes before handing it back\n- Every claim that names a number or fact must be either from my brief or flagged as \"placeholder — verify\"\n- At the bottom, list anything you had to invent so I can replace it"
+    },
+    {
+      "id": "weekly-content-calendar",
+      "name": "Plan a weekly content calendar",
+      "category": "Marketing",
+      "tags": [
+        "content",
+        "marketing",
+        "social"
+      ],
+      "emoji": "📅",
+      "description": "Plan 7 days of social content. Get a hook, post copy, CTA, and visual idea for every day.",
+      "works_best_with": {
+        "agent_profile": "marketing-agent",
+        "skills": [
+          "brainstorming",
+          "concise-planning",
+          "vale-brand-voice"
+        ],
+        "mcp_servers": [
+          "twitter-mcp",
+          "insta-business-mcp",
+          "facebook-mcp-server"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Confirm brand voice, audience, and active campaigns",
+        "Brainstorm weekly themes",
+        "Draft each day's hook, body, and CTA",
+        "Suggest a concrete visual per post",
+        "Output the week as one shareable plan"
+      ],
+      "prompt": "Plan a 7-day social content calendar.\n\nInputs:\n- Brand: [name + 1-line description]\n- Audience: [who, in 1-2 sentences, including their job and pain]\n- Platforms (rank by priority): [LinkedIn / X / Instagram / Threads / TikTok / ...]\n- This week's theme or active campaign (optional): [theme]\n- 2-3 recent posts that worked well (for voice reference): [paste or links]\n- Tone: [e.g. dry-witty, authoritative-but-warm, founder-voice]\n\nFor each of the 7 days (Mon -> Sun), produce:\n1. Date label and primary platform for the day (vary platforms across the week so the mix matches my priority list)\n2. Theme / angle for the day\n3. Hook (one line — the scroll-stopper)\n4. Full post copy, formatted for that platform's norms (LinkedIn long-form, X tight, IG caption with line breaks, etc.)\n5. CTA (specific — not \"let me know what you think\")\n6. Visual concept (1-2 sentences describing what's actually in the image/video — not a stock-photo brief)\n7. 3-5 hashtags, niche over broad\n\nConstraints:\n- No two days share the same hook structure (don't open every day with a stat or a question)\n- At least 2 posts must be narrative or personal-story shaped\n- At least 1 post must be a contrarian or pattern-break take\n- Voice must be consistent across the week — every post should sound like the same author\n\nOutput as a single shareable plan I can paste into a doc. Flag any day where you couldn't fill a field without inventing facts."
+    },
+    {
+      "id": "competitive-research",
+      "name": "Run competitive research",
+      "category": "Research",
+      "tags": [
+        "research"
+      ],
+      "emoji": "🔍",
+      "description": "Profile 3-5 competitors. Get a positioning map and concrete differentiation angles to act on.",
+      "works_best_with": {
+        "agent_profile": "competitive-intelligence",
+        "skills": [
+          "brave-search",
+          "firecrawl",
+          "playwright-mcp",
+          "ai-news-collectors"
+        ],
+        "mcp_servers": [
+          "firecrawl-mcp",
+          "brightdata-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Confirm product + segment",
+        "Shortlist 3-5 competitors and get approval",
+        "Profile each (positioning, pricing, strengths, gaps, recent moves)",
+        "Build a positioning map with justified axes",
+        "Recommend 3 concrete differentiation angles"
+      ],
+      "prompt": "Run a competitive research pass for my product.\n\nMy product:\n- Name + 1-liner: [paste]\n- Segment / category: [segment]\n- Primary buyer + their job-to-be-done: [who buys this and what outcome they want]\n- Pricing model: [model]\n- What I think my edge is (so you can pressure-test it): [edge]\n\nProcess:\n\n1) Identify competitors. Find the 3-5 most relevant for this segment. Give me your shortlist with one sentence per name on why it's in (and which obvious-but-wrong picks you ruled out and why). Wait for my approval before profiling.\n\n2) For each competitor, produce a profile with:\n   - Name + 1-line positioning in their own words (quote their homepage)\n   - Target customer: be specific — company size, role, industry\n   - Core product description: what it actually does, not what they claim\n   - Pricing: every plan and price; note enterprise tier if hidden\n   - Distribution: how they acquire customers (SEO, paid, partnerships, PLG, sales-led) — with evidence\n   - Top 3 strengths, each with a piece of evidence (URL, review quote, public metric)\n   - Top 3 weaknesses, each with evidence (negative reviews, missing features, public complaints, slow updates)\n   - Recent moves in the last 6 months (funding, launches, hires, pricing changes, GTM shifts)\n\n3) Positioning map. Pick two meaningful axes — NOT \"price vs features\". Pick axes that actually segment this market (depth-vs-breadth, self-serve-vs-sales-led, technical-vs-business-user, vertical-vs-horizontal, etc.). Plot every competitor and me. Justify the axis choice in 2-3 sentences.\n\n4) Differentiation recommendations. Give me 3 concrete angles I should consider. For each:\n   - The angle (one sentence)\n   - The segment it lands hardest with\n   - The proof points I'd need to credibly own it\n   - The biggest risk if I commit to it\n   - Which competitor it most directly threatens\n\nQuality bar:\n- Cite a real URL for every non-obvious claim\n- Pull from at least 3 source types per competitor (homepage, review site like G2/Capterra, recent news or blog)\n- If you can't verify something, say \"unverified\" — never invent ARR, customer counts, funding amounts, or headcount\n- If a competitor's docs/site are paywalled or behind login, say so and work from what's public"
+    },
+    {
+      "id": "deep-research-report",
+      "name": "Write a deep research report",
+      "category": "Research",
+      "tags": [
+        "content",
+        "report",
+        "research"
+      ],
+      "emoji": "📚",
+      "description": "Research a topic end-to-end. Get a long-form report with inline citations as Word and PDF.",
+      "works_best_with": {
+        "agent_profile": "knowledge-base-manager",
+        "skills": [
+          "brave-search",
+          "firecrawl",
+          "concise-planning",
+          "docx",
+          "pdf"
+        ],
+        "mcp_servers": [
+          "firecrawl-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Clarify topic, audience, depth, and constraints",
+        "Propose outline + source plan; wait for approval",
+        "Draft every section with inline citations",
+        "Build the references list",
+        "Compile final Word and PDF"
+      ],
+      "prompt": "I want a deep research report.\n\nBrief:\n- Topic: [topic]\n- Audience: [who reads this — their seniority, role, existing knowledge level]\n- Why they care: [the decision or question this informs]\n- Desired depth: [e.g. ~3000 words, 8-10 sections, exec-readable]\n- Hard constraints: [paywalled sources OK? recency requirement (e.g. nothing older than 2 years)? specific perspectives to cover or avoid?]\n- Style references (optional): [links or names of reports whose tone I like]\n\nPhase 1 — Outline. Wait for my approval before drafting prose.\nPropose:\n1. Working title + a 2-sentence framing of the report's argument or central finding\n2. Section list. For each section: title, 1-sentence purpose, the 3-5 sub-points it will cover, and an estimated word count\n3. The 2-3 questions the report MUST answer for the reader (this is the success bar)\n4. A source plan: 8-15 sources you intend to use, grouped by category (primary research, peer-reviewed, industry analyst, journalism, expert blog/practitioner), with a 1-line note on why each one is in the list and what perspective it brings\n5. What you're choosing NOT to cover, and why\n\nI'll reply with edits or \"approved\". Do not draft prose until I approve.\n\nPhase 2 — Draft.\n- Write every section in full to the estimated word count (±15%)\n- Inline-cite using [Author, Year] or [Source name] — every non-obvious claim needs a citation\n- Lead each section with the conclusion / takeaway, then support it (BLUF, not buildup)\n- Where sources disagree, surface both sides in 2-3 sentences and tell me which is better-supported and why\n- If a section's evidence is thin, say so plainly — don't pad with adjacent material\n- Include at least one concrete example, case, or data point per section\n\nPhase 3 — References + deliverables.\n- Build a numbered references list at the end with full URLs, author, publication, date\n- Produce two output files in my workspace:\n  1. Word document (.docx) with consistent heading styles\n  2. PDF version of the same content\n\nQuality bar:\n- Zero invented statistics, dates, quotes, or studies. If a claim has no source, drop it.\n- No filler intros (\"In today's fast-paced world...\", \"It is widely known that...\")\n- No AI-slop tells: ban \"delve\", \"tapestry\", \"leverage\", \"in the realm of\", \"navigate the complexities\", \"unlock the potential\"\n- A reader skimming only the section openers should still get the report's argument\n- At the very end, list any open questions or weak spots in the evidence so I know where to push back"
+    },
+    {
+      "id": "weekly-finance-report",
+      "name": "Generate a weekly finance report",
+      "category": "Finance",
+      "tags": [
+        "finance",
+        "report"
+      ],
+      "emoji": "📈",
+      "description": "Summarize the week's revenue, spend, and runway. Get a one-page digest with WoW deltas and decisions needed.",
+      "works_best_with": {
+        "agent_profile": "finance-agent",
+        "skills": [
+          "docx",
+          "pdf",
+          "concise-planning"
+        ],
+        "mcp_servers": [
+          "postgresql-mcp",
+          "gmail-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Read the configured data sources",
+        "Compare against last week",
+        "Flag movers (>10% WoW or >5% of total spend)",
+        "Surface items needing a decision",
+        "Output a one-page PDF"
+      ],
+      "prompt": "Generate this week's finance report.\n\nInputs:\n- Data sources to read: [list dashboards, sheets, warehouse tables, accounting export — with paths or URLs]\n- Last week's report (for delta comparison): [link / paste]\n- Period: this week = [start date] -> [end date]\n- Currency: [USD / EUR / etc.]\n\nProduce a one-page report with these sections, in this order:\n\n1) Headline (2 lines max). The single most important takeaway about the week's financials.\n\n2) Numbers table:\n   | Metric | This week | Last week | Delta | % change |\n   At minimum include: gross revenue, net revenue, total spend (broken into COGS, payroll, marketing, infra, other), gross margin %, cash balance, runway (months).\n\n3) Movers. Every line item that moved >10% week-over-week OR >5% of total spend. For each: what moved, by how much, and the most likely cause based on the data (cite the source).\n\n4) Trends (3 sentences max). What the 4-week direction looks like for revenue, spend, and runway.\n\n5) Needs your decision. Numbered list of items requiring my call this week. Each: the item, the deadline, the dollar amount at stake, and your recommendation in one line.\n\nConstraints:\n- Round to thousands (or appropriate magnitude); no false precision\n- If a number is unavailable, write \"n/a\" — never guess or silently extrapolate\n- Don't editorialize beyond the data — if you say \"likely caused by X\", point at the row/dashboard that backs it\n- Output as a single one-pager PDF in my workspace, suitable to forward to investors or co-founders without further editing"
+    },
+    {
+      "id": "personal-assistant-day-plan",
+      "name": "Plan my day",
+      "category": "Personal",
+      "tags": [
+        "marketing",
+        "personal",
+        "productivity"
+      ],
+      "emoji": "☀️",
+      "description": "Build a focused day plan from your calendar and todos. Get a time-blocked schedule and the single top priority.",
+      "works_best_with": {
+        "agent_profile": "personal-assistant",
+        "skills": [
+          "concise-planning",
+          "ask-questions-if-underspecified"
+        ],
+        "mcp_servers": [
+          "gmail-mcp",
+          "notion-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Read calendar and todos",
+        "Pick the single most important outcome",
+        "Time-block around fixed meetings",
+        "Batch shallow work into one block",
+        "Output a tight day plan"
+      ],
+      "prompt": "Plan my day.\n\nInputs:\n- Today's calendar: [paste or link]\n- Open todos / priorities: [paste or link]\n- Energy notes (optional): [e.g. focus best in the morning, fade after 3pm]\n\nGive me, in this exact order:\n1. One sentence — the single most important outcome for today.\n2. A time-blocked schedule. Keep my fixed meetings in place, then fill gaps with: at least one deep-work block (>=90 min, protected, named with the task) for the top priority, and one batched block for shallow work (email, replies, admin).\n3. End-of-day checkpoint — what I should review at 5pm to call today a win.\n\nKeep the whole plan under 200 words. Skip motivational language."
+    },
+    {
+      "id": "blog-post-draft",
+      "name": "Draft a blog post",
+      "category": "Content",
+      "tags": [
+        "content",
+        "seo"
+      ],
+      "emoji": "✍️",
+      "description": "Outline and draft a blog post. Get a publish-ready post with a strong hook and SEO basics covered.",
+      "works_best_with": {
+        "agent_profile": "content-creator",
+        "skills": [
+          "brave-search",
+          "vale-brand-voice",
+          "concise-planning"
+        ],
+        "mcp_servers": [
+          "notion-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Clarify topic, audience, angle, target length",
+        "Propose outline + opening hook; wait for approval",
+        "Draft the full post",
+        "Polish: AI-slop strip, fact-check, SEO meta",
+        "Output as a markdown block"
+      ],
+      "prompt": "Draft a blog post.\n\nBrief:\n- Topic: [topic]\n- Audience: [who reads this + what they already know]\n- Angle / POV: [the take, the contrarian framing, or the specific lens — be sharp]\n- Target length: [e.g. 1200 words]\n- Primary keyword (optional, for SEO): [keyword]\n- 2-3 posts whose voice I like (for reference): [links]\n\nPhase 1 — Outline. Wait for my approval before drafting.\nGive me:\n- 2 working title options\n- A one-sentence thesis (the single claim the post makes)\n- Section list (H2/H3 structure) with a 1-line purpose per section\n- The opening hook, written out in full — this is what'll make me say yes or no\n\nPhase 2 — Full draft, once I approve.\n- Hit the target length within ±10%\n- Use the H2/H3 structure from the outline; keep paragraphs <=4 sentences\n- End every section with a one-line takeaway\n- Include a concrete example, anecdote, or data point in at least 3 sections\n- Close with a sharp final line — not a generic CTA, not a summary\n\nPhase 3 — Polish pass.\n- Strip AI-slop phrasing: \"delve\", \"in today's landscape\", \"navigate the complexities\", \"unlock\", \"leverage\", \"tapestry\", \"in the realm of\"\n- Verify every fact, stat, or quote you used; cite or remove\n- Produce: title tag (<=60 chars), meta description (<=155 chars), suggested slug, and 2 alt-text strings for hero image options\n\nOutput the final post as a single markdown block I can paste into my CMS, with the SEO meta in a small block at the top."
+    },
+    {
+      "id": "support-triage",
+      "name": "Triage customer support inbox",
+      "category": "Customer Success",
+      "tags": [
+        "customer-success"
+      ],
+      "emoji": "📨",
+      "description": "Triage your support inbox. Get a table with urgency, theme, draft replies, and human-needed flags.",
+      "works_best_with": {
+        "agent_profile": "customer-support-agent",
+        "skills": [
+          "concise-planning"
+        ],
+        "mcp_servers": [
+          "gmail-mcp",
+          "notion-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Read recent unresolved tickets",
+        "Classify by urgency (P0-P3) and theme",
+        "Draft a first-pass reply per ticket",
+        "Flag tickets needing a human or product call",
+        "Surface theme patterns"
+      ],
+      "prompt": "Triage my customer support inbox.\n\nInputs:\n- Source to read: [Gmail label / Zendesk view / Front / Intercom — be specific]\n- Time window: [e.g. last 48 hours, unresolved only]\n- Tone guide / brand voice notes (optional): [paste or link]\n- Common-issue runbook (optional, so you reuse approved answers): [paste or link]\n\nFor every ticket, produce a row:\n| Customer | Subject | Urgency (P0-P3) | Theme | Sentiment | First-pass reply | Needs human? | Why |\n\nUrgency rubric:\n- P0: production-down, data loss, security incident, churn-risk customer threatening to leave, billing failure on enterprise account\n- P1: blocked workflow, billing errors on paid tier, paid-tier customer waiting >24h, broken integration\n- P2: feature request from active user, small UX bugs, free-tier issues, how-to questions\n- P3: vague feedback, spam, marketing-list reply-alls, opt-outs\n\nFirst-pass reply rules:\n- Open by restating the customer's specific issue in one sentence — NOT \"Thanks for reaching out!\"\n- Either resolve the issue or explain the next step with a concrete timeline\n- One action per reply — don't bundle\n- Sign-off matching the tone guide (if no guide, default to warm + direct)\n- Keep replies under 120 words\n\nAt the end of the table, add two sections:\n- Patterns: any theme that appeared in 3+ tickets — flag as a possible product or doc issue, with the affected ticket count and a 1-line hypothesis\n- Needs your call: tickets where Needs human = yes, listed with one-line context each, ranked by urgency\n\nDon't send anything. Drafts only, for me to review."
+    },
+    {
+      "id": "video-to-content-pack",
+      "name": "Repurpose a video into a content pack",
+      "category": "Content",
+      "tags": [
+        "content",
+        "social",
+        "video"
+      ],
+      "emoji": "📹",
+      "description": "Turn a long video into multi-platform content. Get a thread, LinkedIn post, 3 shorts scripts, a newsletter draft, and a blog post.",
+      "works_best_with": {
+        "agent_profile": "content-creator",
+        "skills": [
+          "brave-search",
+          "concise-planning",
+          "vale-brand-voice"
+        ],
+        "mcp_servers": [
+          "notion-mcp",
+          "twitter-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Pull transcript and chapter markers",
+        "Identify the 5-8 highest-engagement moments",
+        "Draft thread, LinkedIn post, and 3 shorts scripts",
+        "Write a newsletter draft and an SEO blog post",
+        "Compile as a single shareable doc"
+      ],
+      "prompt": "Turn this video into a multi-platform content pack.\n\nInputs:\n- Video URL (YouTube / Vimeo / Loom): [paste URL]\n- Creator / brand voice: [1-2 sentence description; link a recent post if I have one]\n- Target audience: [who this content is for]\n- Primary CTA across platforms (optional): [e.g. subscribe to newsletter, book a call]\n\nStep 1 — Source the material.\nPull the transcript and chapter markers. Read end-to-end — don't skim. Then identify the 5-8 highest-engagement moments: places where the speaker says something quotable, contrarian, or unexpectedly concrete. List them with timestamps before drafting anything.\n\nStep 2 — Produce these deliverables, in this order:\n\n1) Twitter / X thread (5-9 tweets, <=280 chars each)\n   - Hook tweet must work as a standalone — no \"thread below\" filler\n   - One concrete claim per tweet, no rhetorical questions\n   - Final tweet: a sharp summary or soft CTA, NOT \"follow me for more\"\n\n2) LinkedIn post (200-350 words)\n   - Narrative or contrarian hook — no \"here are 5 things I learned\" listicles\n   - One personal angle, one concrete payoff\n   - Optional 3 niche hashtags at the very bottom only\n\n3) Three short-form video scripts (1x 30s, 1x 60s, 1x 90s)\n   - Each: a 3-second hook, the payoff, one CTA line\n   - Tag scripts as TikTok / Reels / Shorts friendly — vertical, fast pace, no slow burns\n\n4) Newsletter draft (400-600 words)\n   - Standalone — must make sense to a reader who never saw the video\n   - Structure: opening anecdote -> the insight -> why it matters -> one takeaway\n   - End with a link back to the original video\n\n5) SEO blog post (1000-1400 words)\n   - H2/H3 structure derived from the chapters\n   - Embed the most quotable moments as pull-quotes with timestamps\n   - Title tag (<=60 chars), meta description (<=155 chars), suggested slug\n\nQuality bar:\n- Every deliverable must sound like the same author — no register drift across formats\n- Strip AI-slop: \"delve\", \"unlock\", \"navigate the complexities\", \"in today's landscape\"\n- At the bottom, mark which lines are verbatim quotes vs paraphrased so I can fact-check\n- Flag any claim where you extrapolated beyond what was said in the video"
+    },
+    {
+      "id": "cold-outreach-sequence",
+      "name": "Personalize cold outreach to a lead list",
+      "category": "Sales",
+      "tags": [
+        "lead-gen",
+        "sales"
+      ],
+      "emoji": "✉️",
+      "description": "Research a lead list and write 3-touch sequences. Get a per-lead hook, intro email, follow-up, and breakup email.",
+      "works_best_with": {
+        "agent_profile": "bd-partnerships",
+        "skills": [
+          "brave-search",
+          "firecrawl",
+          "playwright-mcp",
+          "concise-planning"
+        ],
+        "mcp_servers": [
+          "gmail-mcp",
+          "notion-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Clean the lead list",
+        "Research each lead for a specific hook",
+        "Draft a 3-touch sequence per lead",
+        "Compile as a sendable table",
+        "Flag leads you couldn't personalize"
+      ],
+      "prompt": "Personalize cold outreach for my lead list.\n\nInputs:\n- Lead list (CSV with at least name, company, role, email; LinkedIn URL is a big plus): [paste or path]\n- My company + 1-liner: [name + what we do]\n- Who we serve and the outcome we deliver: [ICP + outcome]\n- The single most-credible proof point I have (case study, logo, metric, certification): [paste]\n- Tone: [warm + direct / playful / technical-peer]\n- Sending account + signature block: [paste]\n\nStep 1 — Clean the list.\nRead every row. Drop generic mailboxes (info@, contact@, support@). Drop rows missing role or company. Tell me how many leads you started with and how many remain.\n\nStep 2 — Research per lead.\nFor each remaining lead, find ONE specific recent hook. In order of preference:\n1. A recent post they wrote (LinkedIn, blog, podcast)\n2. A recent move at their company (funding, launch, hiring spike, layoff, acquisition)\n3. A concrete job-to-be-done for their role at their company size\nNever use lazy \"I saw you work at [company]\" personalization. If you cannot find a real hook, mark the lead \"skip\" — don't fake it.\n\nStep 3 — Write a 3-touch sequence per lead.\n\nEmail 1 (initial, <=80 words):\n- Open with the specific hook in one sentence — NOT \"I hope this finds you well\"\n- One credible proof point that maps to the hook\n- One low-friction CTA (15-min call OR a single-question reply)\n\nEmail 2 (follow-up, +3 days, <=60 words):\n- A different angle or proof point — never \"just bumping this up\"\n\nEmail 3 (breakup, +7 days, <=40 words):\n- Honest, slightly self-deprecating, leaves the door open\n- No guilt trips, no \"this is my last email\" pressure\n\nOutput format:\n- One markdown table: Name | Company | Hook | Subject Line | Email 1 | Email 2 | Email 3 | Notes\n- Subject lines: <=6 words, lowercase, no salesy words (\"opportunity\", \"connect\", \"quick question\")\n- Plain text only — no HTML, no images, no tracking pixels\n- At the end, list any leads marked \"skip\" with a 1-line reason\n\nQuality bar:\n- Every email passes the \"would a busy person bother replying?\" test\n- No template scent — each sequence must read like a 1:1 message\n- Banned: \"I hope this email finds you well\", \"just wanted to reach out\", \"synergy\", \"thought leader\""
+    },
+    {
+      "id": "codebase-tech-debt-audit",
+      "name": "Audit my codebase for tech debt",
+      "category": "Engineering",
+      "tags": [
+        "audit",
+        "engineering"
+      ],
+      "emoji": "🔧",
+      "description": "Walk a codebase and write a refactor report. Get a file-cited list of dead code, hot-spot files, and ranked refactor opportunities.",
+      "works_best_with": {
+        "agent_profile": "backend-engineer",
+        "skills": [
+          "concise-planning",
+          "audit-context-building",
+          "git-commit"
+        ],
+        "mcp_servers": [
+          "filesystem"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Map the repo structure and tech stack",
+        "Identify dead code, hot files, dependency issues",
+        "Detect duplication, coupling, and test gaps",
+        "Rank findings by effort and risk",
+        "Output a markdown report with file:line citations"
+      ],
+      "prompt": "Audit this codebase for technical debt and produce a written report.\n\nScope:\n- Repo root: [path or URL]\n- Focus areas (defaults to whole repo): [paths or modules]\n- What I'm optimizing for: [readability / perf / shipping speed / onboarding / safety]\n- Leave alone: [generated code, vendored deps, soon-to-be-deleted modules]\n\nPhase 1 — Map the territory.\nWalk the repo and identify:\n- Tech stack (language, framework, build, test runner)\n- Top-level architecture (modules + responsibilities)\n- Where complexity concentrates (file LOC, cyclomatic complexity, churn from git log)\n- Test coverage shape (which dirs are tested, which aren't)\n\nOutput this map FIRST, before any recommendations. I'll sanity-check it before you continue.\n\nPhase 2 — Find the debt.\nCategorize findings into these buckets. Every finding MUST cite file:line.\n\n1. Dead code — unused exports, unreachable branches, orphaned files. Verify with grep before claiming.\n2. Hot-spot files — high churn + high complexity + low test coverage. These are the riskiest to change today.\n3. Duplication — copy-pasted logic that should be extracted. Show the 2-3 most painful examples with file:line for each copy.\n4. Dependency issues — outdated, unused, duplicate, deprecated, or improperly pinned.\n5. Coupling problems — circular imports, layers reaching across boundaries, leaky abstractions.\n6. Test gaps — modules where critical paths have no tests, flaky tests, tests that don't actually assert behavior.\n\nPhase 3 — Rank by ROI.\nScore each finding on:\n- Effort (S / M / L / XL)\n- Risk if untouched (Low / Med / High)\n- Confidence we can fix it safely (Low / Med / High)\n\nThen recommend a top-10 list to action this quarter. For each: what to do, what to leave alone, the smallest possible PR shape, and what could break.\n\nQuality bar:\n- Every claim cites file:line — \"this file is messy\" without evidence is not allowed\n- No suggestions that would require rewriting the whole repo\n- If you can't be sure (e.g. you can't run the tests), say so — never assume green is green\n- Don't propose adopting a trendy framework or rewriting in a new language unless I asked\n- Output the final report as REFACTOR_AUDIT.md in the repo root"
+    },
+    {
+      "id": "resume-tailor",
+      "name": "Tailor my resume to a job posting",
+      "category": "Career",
+      "tags": [
+        "career"
+      ],
+      "emoji": "📄",
+      "description": "Tailor a resume to a specific job. Get an ATS-friendly resume, a custom cover letter, and a follow-up email.",
+      "works_best_with": {
+        "agent_profile": "personal-assistant",
+        "skills": [
+          "docx",
+          "pdf",
+          "brave-search",
+          "vale-brand-voice"
+        ],
+        "mcp_servers": [
+          "gmail-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Read the JD and extract keywords",
+        "Re-rank my experience by relevance",
+        "Rewrite bullets with metrics",
+        "Draft a custom cover letter",
+        "Draft a follow-up email"
+      ],
+      "prompt": "Tailor my resume and cover letter for a specific job posting.\n\nInputs:\n- Job posting URL or pasted text: [paste]\n- My master resume: [paste or path]\n- 2-3 achievements I'm proud of that aren't on the resume yet (optional): [paste]\n- Constraints: [visa status, remote-only, target compensation if I want it referenced]\n\nPhase 1 — Read the JD.\nExtract:\n- The 5-8 must-have skills / keywords (rank by how often they appear)\n- 2-3 nice-to-haves\n- The signal that says what the team actually cares about (e.g. \"reduce on-call load\", \"ship to enterprise customers\", \"work cross-functionally with PM\")\n- Likely ATS / keyword-filter style based on the company (big-tech / startup / agency)\n\nShow me this analysis before rewriting anything. I'll confirm or correct.\n\nPhase 2 — Rewrite the resume.\n- Keep my real experience — never invent roles, titles, dates, or metrics\n- Reorder bullets so the most relevant ones for THIS job rise to the top of each role\n- Rewrite each bullet as: action verb -> what I did -> measurable result. If I don't have a real metric, ASK me before inventing — placeholder \"X%\" is OK if marked TODO\n- Match resume wording to the JD's vocabulary (e.g. if they say \"observability\", don't write \"monitoring\")\n- Keep it to 1 page unless I'm senior (15+ years)\n- Output as .docx — clean, ATS-friendly, no tables, no columns, no images\n\nPhase 3 — Cover letter (250-350 words).\n- Open with a specific reason I want THIS role — not \"I'm excited to apply\"\n- One concrete story that proves I can do the job\n- One paragraph on why I'm a fit for THEIR signal (from Phase 1)\n- Close with a clear ask (a conversation) — no \"thank you for your consideration\" filler\n- Output as .docx and as plain text I can paste\n\nPhase 4 — Follow-up email (for +7 days if no response).\n- <=80 words\n- Add a new piece of value: link to a project, a thought on the role, a relevant data point\n- Never \"just bumping this up\"\n\nQuality bar:\n- Strip AI-slop: \"passionate\", \"results-driven\", \"team player\", \"hit the ground running\"\n- Never invent a metric, employer, or skill I don't have\n- Flag every TODO at the bottom so I know what to fill in"
+    },
+    {
+      "id": "xiaohongshu-viral-note",
+      "name": "Write a Xiaohongshu (小红书) viral note",
+      "category": "Content",
+      "tags": [
+        "chinese-market",
+        "content",
+        "social"
+      ],
+      "emoji": "📕",
+      "description": "Write a 小红书 note in viral platform style. Get a clickable title, cover concept, body in 姐妹们 voice, and a hashtag stack.",
+      "works_best_with": {
+        "agent_profile": "content-creator",
+        "skills": [
+          "brainstorming",
+          "vale-brand-voice"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Confirm 痛点 / 产品 / 目标人群",
+        "Generate 5 title options in 小红书 标题党 style",
+        "Draft 封面 concept + body in 小红书 voice",
+        "Suggest a 5-10 hashtag stack",
+        "Run a 平台合规 review pass"
+      ],
+      "prompt": "Write a Xiaohongshu (小红书) note that has a real shot at going viral.\n\nInputs:\n- Product / topic / experience I'm posting about: [paste]\n- Target reader (be specific — 大学生 / 宝妈 / 职场女性 / 健身党 / etc.): [audience]\n- My voice / 人设: [e.g. 都市白领分享好物 / 大学生省钱党 / 健身教练]\n- The single transformation I want the reader to feel: [涨知识 / 长草 / 治愈 / 解决一个具体痛点]\n- Goal: [纯种草 / 引流私域 / 涨粉 / 推广自家产品]\n- Past high-performing note from this account (optional): [link]\n\nStep 1 — Title options (5).\nDraft 5 titles in 小红书 爆款 style. Each must:\n- Be <=20 Chinese characters\n- Use 1-3 fitting emoji (NOT generic ✨🌟)\n- Use at least one 标题党 pattern: 数字 (\"3款...\" / \"99%人不知道...\"), 反差/感叹 (\"姐妹们冲！\" / \"我宣布\"), 痛点提问 (\"为什么我...\"), 经验沉淀 (\"30天我...\"), or 干货承诺 (\"一篇讲清...\")\n- Pick one as your recommendation and explain in one sentence why it lands hardest with this reader.\n\nWait for me to pick before drafting the body.\n\nStep 2 — Cover page (封面).\nSuggest a 封面 design with:\n- 大字报 title text (a 5-8 character punchline — usually a sharper version of the title)\n- 1-line supporting subtitle\n- Concrete background description (real-life shot / 桌面平铺 / 对比图 / 步骤拼图 — NOT \"a beautiful image\")\n\nStep 3 — Body copy.\n- First-person voice\n- Reader address: 姐妹们 / 宝子们 / 大家 (pick what fits the 人设)\n- Hard structure: 痛点钩子 (2-3 lines) -> 解决方案 / 产品 / 方法 -> 真实使用感 OR 对比 -> 总结 + 软性 CTA\n- Line breaks every 1-2 sentences — never long paragraphs\n- 1-2 emoji per section to break the wall of text — don't over-emoji\n- 200-400 字 total, depending on the topic\n- Mark 2-3 places where I should insert an image (e.g. \"📸 这里放对比图\")\n\nStep 4 — Hashtag stack.\n5-10 hashtags at the end, mixed:\n- 2-3 broad volume tags (#好物分享 #生活记录)\n- 3-5 niche tags specific to the topic (#xx 测评 #平价 xx)\n- 1-2 community tags if relevant (#姐妹们种草 #打工人日常)\n\nStep 5 — Compliance check.\nFlag anything that risks 限流: 极限词 (\"最\" / \"第一\" / \"100%\"), unverified medical or efficacy claims, brand-name comparison with negatives, hard sells. Rewrite the flagged lines.\n\nQuality bar:\n- Must NOT read like translated Instagram copy\n- Must NOT use 朋友们 (it reads 抖音, not 小红书)\n- If the goal is 引流, the CTA stays soft — never \"私信我加微信\""
+    },
+    {
+      "id": "inbox-zero-triage",
+      "name": "Triage and reply to my inbox",
+      "category": "Productivity",
+      "tags": [
+        "productivity",
+        "sales"
+      ],
+      "emoji": "📥",
+      "description": "Triage unread email into Reply / Review / Noise. Get drafted replies in your voice, summaries, and a decisions list.",
+      "works_best_with": {
+        "agent_profile": "personal-assistant",
+        "skills": [
+          "concise-planning"
+        ],
+        "mcp_servers": [
+          "gmail-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Pull unread email in the window",
+        "Classify each as Reply / Review / Noise",
+        "Draft replies for the Reply bucket",
+        "Summarize the Review bucket in one line each",
+        "Output a single triage report"
+      ],
+      "prompt": "Triage my inbox and draft replies for everything I should touch today.\n\nInputs:\n- Source: [Gmail label / Outlook folder / etc.]\n- Time window: [e.g. last 24 hours, unread only]\n- My top 1-2 priorities this week (so you can judge what's urgent for ME): [paste]\n- Voice samples — 2-3 emails I sent recently that sound like me: [paste]\n- Out-of-scope senders to never touch (boss / spouse / a specific client): [list]\n\nStep 1 — Classify every email into one bucket:\n- REPLY — needs an actual response from me\n- REVIEW — I should see it but no reply needed (FYI, status update, calendar invite to accept/decline)\n- NOISE — newsletters, automated alerts, marketing\n\nFor each email, output: Sender | Subject | Bucket | One-line reason.\n\nStep 2 — For every REPLY email, draft a response.\nRules:\n- Match my voice samples — same register, same opener style, same sign-off\n- Address the actual question / ask in the first sentence\n- One concrete action or timeline per reply\n- <=120 words unless the email genuinely needs more\n- If I'd need to make a decision before replying, write \"NEEDS YOUR CALL: [the decision]\" at the top of the draft and leave a stub\n\nStep 3 — For REVIEW emails:\n- Summarize each in one line (\"FYI: Q3 board meeting moved to Thursday\")\n- If there's a calendar invite I should accept/decline, suggest which\n- Don't draft replies for these\n\nStep 4 — For NOISE:\n- Suggest a filter / label rule for repeat senders so I don't see them again\n- Do NOT auto-archive without my approval the first time\n\nStep 5 — Output a single triage report:\n1. Counts: how many REPLY / REVIEW / NOISE\n2. REPLY section with drafts ready to send\n3. REVIEW section with 1-line summaries\n4. NEEDS YOUR CALL section bubbling up anything that requires a decision\n5. Suggested filter rules at the bottom\n\nQuality bar:\n- Never send anything — drafts only, saved to my Drafts folder\n- Never fabricate context (e.g. \"As I mentioned in our last meeting...\") unless it's true\n- If the voice sample doesn't include enough signal, ask before guessing"
+    },
+    {
+      "id": "stock-thesis",
+      "name": "Build an investment thesis on a stock",
+      "category": "Investing",
+      "tags": [
+        "investing",
+        "research"
+      ],
+      "emoji": "📊",
+      "description": "Research a ticker and write a 1-page thesis. Get a bull case, bear case, valuation, catalysts, and a recommended action.",
+      "works_best_with": {
+        "agent_profile": "finance-agent",
+        "skills": [
+          "brave-search",
+          "firecrawl",
+          "concise-planning",
+          "pdf"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Read the latest filings and recent news",
+        "Read 2-4 earnings call transcripts for tone shifts",
+        "Build the bull and bear cases with cited evidence",
+        "Sketch valuation vs history and peers",
+        "Output a 1-page PDF memo"
+      ],
+      "prompt": "Build a 1-page investment thesis on this stock.\n\nInputs:\n- Ticker + company: [e.g. NVDA / Nvidia]\n- My time horizon: [3-6mo / 1-3yr / 5yr+]\n- My current view going in: [bull / bear / curious / no view]\n- Position context (optional): [thinking of opening / sizing up / averaging down / trimming]\n- Sources to prioritize: [10-K, last 4 earnings call transcripts, recent analyst notes, my past notes — paste or link]\n\nStep 1 — Read primary sources.\nIn this order:\n1. Latest 10-K / 10-Q\n2. Last 2-4 earnings call transcripts (management tone shifts ARE signal)\n3. Recent (last 90 days) news and analyst notes\n4. The 2-3 closest competitor 10-Ks for context\n\nTell me what's MISSING before drafting (e.g. \"next earnings call isn't out yet\", \"private competitor X has no public filings\"). Don't fabricate around gaps.\n\nStep 2 — Build the thesis.\n\nA. The business in 2 sentences. What it does, how it makes money. No jargon.\n\nB. Bull case (3-5 numbered points). Each point: the claim, the supporting evidence (cite filing / transcript / report with page or timestamp), the implied upside.\n\nC. Bear case (3-5 numbered points). Same structure. Steelman it — don't soft-pedal the risks.\n\nD. Valuation sketch. Current P/E, EV/EBITDA, P/S where relevant. Compare to: (a) the company's own 5-year average, (b) 2-3 closest peers. State whether it screens cheap, fair, or expensive AT TODAY'S PRICE.\n\nE. Catalysts to watch. 3-5 dated events in the next 6-12 months (earnings, product launches, regulatory rulings, debt rolls) and what each would prove or disprove.\n\nF. What would make me change my mind? 2-3 specific signals that would flip the thesis.\n\nG. Recommended next action. Open / size up / hold / trim / pass, with one sentence on why. ALWAYS express position size as % of portfolio, never $.\n\nStep 3 — Output.\n- 1-page memo as .pdf to my workspace\n- References list at the end with every citation (URL, page or timestamp)\n- A \"questions I couldn't answer\" section flagging what I should check before acting\n\nQuality bar:\n- Zero invented numbers. If you can't find revenue/margin/guidance, say so — don't estimate silently.\n- This is analysis, not financial advice — frame it as such\n- No \"to the moon\", no \"clear winner\", no \"trust me\""
+    },
+    {
+      "id": "etsy-digital-product",
+      "name": "Launch a digital product on Etsy / Gumroad",
+      "category": "Side Hustle",
+      "tags": [
+        "ecommerce",
+        "side-hustle"
+      ],
+      "emoji": "🛍️",
+      "description": "Pick a niche and launch a digital product. Get a niche brief, SEO listing, cover-image briefs, and storefront copy.",
+      "works_best_with": {
+        "agent_profile": "marketing-agent",
+        "skills": [
+          "brave-search",
+          "brainstorming",
+          "pdf",
+          "file-organizer"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Scope a viable niche from my interests + skills",
+        "Research existing listings for demand",
+        "Define the smallest v1 product",
+        "Write the SEO listing (title, tags, description)",
+        "Brief cover images + draft storefront copy"
+      ],
+      "prompt": "Help me launch a digital product on Etsy / Gumroad / Payhip.\n\nInputs:\n- My interests + skills + spare time per week (be honest): [paste]\n- Target platform: [Etsy / Gumroad / Payhip / Shopify]\n- Product type I'm leaning toward (optional): [printables / planners / Notion templates / wedding suite / etc.]\n- Brand voice + visual style: [e.g. minimal beige / playful kid-friendly / spicy spreadsheet-bro]\n- Budget for design tools / ads ($0 is fine): [budget]\n\nPhase 1 — Niche brief. Wait for my approval before writing the listing.\n\nPropose 3 niche options. For each:\n- The niche in one specific sentence (\"perpetual budget tracker for couples splitting bills proportionally\" — NOT \"budget tracker\")\n- Why it has demand: cite 3-5 real Etsy/Gumroad listings already selling something nearby, with seller name, price, and estimated monthly sales (or \"established shop, can't tell volume\")\n- Why I can credibly own it given my skills + voice\n- The smallest possible v1 product (1 file, deliverable in a weekend)\n- A realistic price (don't underprice)\n\nRecommend one and explain why. Wait for me to confirm.\n\nPhase 2 — Listing.\n\nOnce I confirm the niche:\n\n1. Title (140 chars max for Etsy). Front-load with the highest-intent keyword. Pattern: [Product type] + [Specific use case] + [Variant], e.g. \"Wedding Budget Spreadsheet | Excel + Google Sheets | Couples Cost Split + Vendor Tracker\".\n\n2. Tags (13 for Etsy, all <=20 chars, lowercase). Mix: 3 broad volume, 7 mid-volume long-tail, 3 hyper-niche. Note search volume tier where you can estimate.\n\n3. Description (400-600 words, scannable):\n   - Hook line (one sentence — the transformation)\n   - What's included (bulleted, exact file names + formats)\n   - How it works (3-5 steps)\n   - Who it's for / not for (sets expectations, reduces refund rate)\n   - FAQ (4-6 real questions buyers ask)\n   - Delivery note (instant download, file types, license terms)\n\n4. Cover image briefs (5 images for the carousel). For each: composition, text overlay, color palette suggestion.\n   - Image 1: hero mockup with the value-prop overlay text\n   - Image 2: feature breakdown\n   - Image 3: in-use / lifestyle shot\n   - Image 4: \"what you get\" file manifest\n   - Image 5: social proof or testimonial placeholder\n\n5. Storefront copy:\n   - Shop announcement banner (<=140 chars)\n   - About section (200-300 words in my voice)\n   - Welcome message + post-purchase email\n\nQuality bar:\n- Don't fake \"100+ sold\" social proof — leave placeholders for real numbers\n- No \"limited time offer\" pressure tactics\n- Banned: \"high-quality\", \"perfect for\", \"must-have\" — say something specific instead\n- At the bottom, list every assumption you made about my niche, voice, or buyers so I can correct them"
+    },
+    {
+      "id": "real-estate-listing",
+      "name": "Write a real estate listing",
+      "category": "Real Estate",
+      "tags": [
+        "ecommerce",
+        "real-estate",
+        "sales"
+      ],
+      "emoji": "🏠",
+      "description": "Turn property details into a polished listing. Get an MLS-ready description plus social variants for IG, TikTok, and email.",
+      "works_best_with": {
+        "agent_profile": "marketing-agent",
+        "skills": [
+          "brainstorming",
+          "vale-brand-voice"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Read property data and photos",
+        "Identify the 3 strongest selling points",
+        "Draft the MLS description",
+        "Spin into IG, TikTok, and email variants",
+        "Flag fair-housing risk language"
+      ],
+      "prompt": "Write a complete listing pack for this property.\n\nInputs:\n- Property data (address, beds, baths, sqft, lot, year, key features): [paste]\n- 5-15 photos with brief captions of what each shows: [paste or path]\n- Asking price + days-on-market context: [paste]\n- Neighborhood notes (school district, walkability, recent comps, vibe): [paste]\n- Target buyer (be specific — first-timers / families / downsizers / investors): [audience]\n- Agent voice / brokerage style: [warm-and-personal / luxury-minimalist / data-driven / etc.]\n\nStep 1 — Identify the 3 strongest selling points.\nDon't list everything good about the house. Pick the 3 things that make THIS property different from the comps. Each: the feature, why it matters to the target buyer, the evidence (which photo or data point backs it).\n\nTell me your three before drafting. I'll confirm or swap.\n\nStep 2 — MLS description (150-220 words).\n- Open with a specific hook tied to selling point #1 — NOT \"Welcome home\" or \"Step into\"\n- Walk the buyer through the property in a logical order (front -> public spaces -> private spaces -> outdoor)\n- Mention all three selling points, with the strongest as the anchor\n- End with a single concrete CTA tied to the brokerage style (book a tour / open house date / agent direct line)\n\nStep 3 — Social variants.\n1. Instagram caption (120-180 words): one strong hook, the story of the home, 5-8 niche hashtags\n2. TikTok hook (script for a 30-45s walk-through, 3-second hook + 3 highlight beats + close)\n3. Email blast subject + body (subject <=7 words, body <=200 words, one image suggestion per section)\n\nStep 4 — Compliance scan.\nFlag anything that touches fair-housing risk language:\n- Descriptors about who the home is \"for\" (kids, families, professionals — risky)\n- Neighborhood characterizations that signal race, religion, national origin\n- Steering language\nRewrite the flagged lines with safer alternatives.\n\nQuality bar:\n- Never invent a feature (\"newly renovated\" if the data doesn't say so)\n- Never reference schools by name unless I confirm zoning\n- Banned: \"must see\", \"hidden gem\", \"won't last long\", \"motivated seller\"\n- If a selling point would require an inspection / appraisal claim, mark it \"verify\""
+    },
+    {
+      "id": "bug-repro-fix",
+      "name": "Reproduce a bug and ship the fix",
+      "category": "Engineering",
+      "tags": [
+        "engineering"
+      ],
+      "emoji": "🐛",
+      "description": "Take a stack trace and ship a real fix. Get a failing test, a patch, and a PR that goes red-to-green with a postmortem stub.",
+      "works_best_with": {
+        "agent_profile": "backend-engineer",
+        "skills": [
+          "git-commit",
+          "github"
+        ],
+        "mcp_servers": [
+          "filesystem"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Locate the failing code from the trace",
+        "Write a minimal failing test (RED)",
+        "Diagnose and patch (GREEN)",
+        "Run the broader suite for regressions",
+        "Open a PR with a postmortem stub"
+      ],
+      "prompt": "Reproduce this bug and ship the fix.\n\nInputs:\n- Stack trace or production log line (paste the whole thing): [paste]\n- Failing test command (optional): [e.g. pytest tests/foo_test.py::test_x]\n- Recent suspect commit(s) (optional): [shas or PR links]\n- Branch to work on: [branch name — create new from main if blank]\n- Test scope: [whole suite / affected module only]\n\nPhase 1 — Locate.\n- Walk the stack trace from outermost frame to innermost. For each frame, open the file and read the function.\n- State your current understanding: which file, which function, what the trace is telling us.\n- Do NOT patch anything yet. If you can't pinpoint the failing line, say so and ask for more context (env, inputs, version).\n\nPhase 2 — Write a failing test (RED).\n- Write the smallest possible test that reproduces this bug. Place it in the matching test file (or create one).\n- Run the test. It must fail with an error that maps cleanly to the original stack trace.\n- If your test passes on the first run, the repro is wrong — iterate until it fails for the right reason.\n- Commit the failing test on its own commit: `test: reproduce <bug-id>`. Do NOT amend later — keep red-then-green visible in git history.\n\nPhase 3 — Patch (GREEN).\n- Write the minimum patch that makes the failing test pass.\n- Re-run the new test — it must go green.\n- Re-run the broader test suite for the affected module (and integration tests if the bug touches I/O).\n- If anything else breaks, surface the regression and ask before pressing on.\n- Commit the fix on its own commit with a Conventional Commit message: `fix(<area>): <one-line summary>`.\n\nPhase 4 — Open the PR.\nTitle: `fix(<area>): <summary>`\nBody sections:\n- What broke\n- Why it broke\n- The fix\n- How I tested it (mention the new test by name)\nKeep the repro-test commit and the fix commit visible separately — don't squash before review. Link the issue / incident if I gave you one.\n\nPhase 5 — Postmortem stub (at the bottom of the PR body).\n- Was this caught by tests before prod? Why not?\n- What test or guardrail would catch a CLASS of bugs like this one?\n- One-sentence recommendation (a new test, a type, a lint rule, a runbook entry).\n\nQuality bar:\n- Never \"fix\" by changing the test to match the bug — the test encodes correct behavior, the fix changes the code\n- Never silently catch the exception to make things green\n- If the root cause is in a dependency or env config, say so plainly — don't patch around it"
+    },
+    {
+      "id": "issue-to-pr-pipeline",
+      "name": "Ship a GitHub issue end-to-end as a merged PR",
+      "category": "Engineering",
+      "tags": [
+        "engineering",
+        "loop",
+        "pipeline"
+      ],
+      "emoji": "🤖",
+      "description": "Take an issue and ship a merged PR. Loop: read repo, code, test, open PR, address review, merge.",
+      "works_best_with": {
+        "agent_profile": "backend-engineer",
+        "skills": [
+          "git-commit",
+          "github",
+          "concise-planning"
+        ],
+        "mcp_servers": [
+          "filesystem",
+          "github-api"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Read the issue + repo context",
+        "Plan the change and test surface",
+        "Make edits + run tests until green",
+        "Open the PR and respond to review",
+        "Merge and watch the deploy"
+      ],
+      "prompt": "Take this GitHub issue and ship it end-to-end as a merged PR — read the repo, plan, code, test, open the PR, respond to review, merge.\n\nInputs:\n- Issue URL or pasted text: [paste]\n- Repo path: [path or URL]\n- Branch base (default main): [base]\n- Test commands: [paste]\n- Lint commands: [paste]\n- Reviewer to request: [GH handle]\n- Hard stop after N failed CI runs: [default 2]\n\nPhase 1 — Understand.\n- Read the issue plus linked context (PRD, screenshots, related issues, prior PRs)\n- Walk the repo to identify in-scope files and the test surface covering them\n- Restate the change: user-visible behavior, surface area, tests that should exist after\n- If ambiguous, post a clarifying comment on the issue and STOP. Don't guess.\n\nPhase 2 — Branch and plan.\n- `git checkout -b fix/<issue-id>-<slug>` from {base}\n- Write a 5-10 line plan as the PR description draft. Stick to it.\n\nPhase 3 — Code in passes.\n- Smallest possible change that fixes the issue\n- Add or extend tests FIRST when the change has behavioral impact\n- Commit small: each commit is a \"thought\" the reviewer can follow\n\nPhase 4 — Local green.\n- Run lint; fix what it complains about\n- Run tests for the affected module first, then full suite\n- If tests fail, root-cause from the trace — never silence them. Max 2 CI retries before escalating.\n\nPhase 5 — Open the PR.\n- Title: `<area>: <one-line summary>`\n- Body: What broke / Why / The fix / How I tested / Risks\n- Link the issue, request the named reviewer\n- Push via `gh pr create`\n\nPhase 6 — Review loop.\n- Watch via `gh pr view --comments`\n- For each comment: read, decide, ask if you disagree — never silently disagree\n- Apply as NEW commits (don't force-push during review)\n- On approval: `gh pr merge --squash --delete-branch`\n\nFeedback signal (log for the next loop):\n- Did the reviewer accept on first pass? Log pushback themes.\n- Did CI go green on first try? Track flaky-test patterns.\n- Append every \"thing I should have caught earlier\" to CLAUDE.md.\n\nQuality bar:\n- NEVER skip CI to ship faster. NEVER force-push during review.\n- NEVER claim tests pass unless you watched them go green THIS session.\n- If the change touches auth, payments, or migrations: stop and ask before merging — even if CI is green.\n- After merge, watch the deploy for 15 min for regressions before declaring done."
+    },
+    {
+      "id": "on-call-sre-loop",
+      "name": "Run an on-call alert loop with runbook update",
+      "category": "Engineering",
+      "tags": [
+        "engineering",
+        "loop"
+      ],
+      "emoji": "🚨",
+      "description": "Run an alert end-to-end. Get a diagnosis, fix or escalation, postmortem, and runbook updates that compound.",
+      "works_best_with": {
+        "agent_profile": "backend-engineer",
+        "skills": [
+          "concise-planning",
+          "audit-context-building"
+        ],
+        "mcp_servers": [
+          "filesystem"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Acknowledge and frame the alert",
+        "Run the diagnostic playbook",
+        "Propose fix or escalate by authority",
+        "Resolve only when metrics stabilize",
+        "Write postmortem + update runbook"
+      ],
+      "prompt": "You're on rotation. An alert just fired. Run the loop: diagnose, fix or page, postmortem, update runbook.\n\nInputs:\n- Alert payload (PagerDuty / Opsgenie / Slack — paste the full thing): [paste]\n- Service that's degraded: [name + repo + dashboard URL]\n- Existing runbook (if any): [path or URL]\n- My authority level: [read-only / can-run-safe-commands / can-deploy-fix — default read-only]\n- Escalation contact: [name + how to reach]\n\nPhase 1 — Acknowledge and frame.\n- Acknowledge in channel: \"investigating <alert>, working hypothesis in 5 min\"\n- Restate what's broken in one sentence — user-visible symptom, not the metric name\n- Pull dashboards (latency, error rate, throughput, recent deploys) into context\n\nPhase 2 — Diagnose.\n- Check recent changes first: deploys, config flips, feature-flag changes last 24h\n- Compare current values to same time last week — normal blip or real shift?\n- Run the runbook's diagnostic steps if one exists\n- Form a hypothesis with confidence (high/med/low) and the evidence\n- DO NOT GUESS. If you can't get to medium confidence, escalate.\n\nPhase 3 — Act by authority level.\n- Read-only: post hypothesis + proposed remediation, page the human\n- Can-run-safe-commands: only commands listed as safe in the runbook; observe; loop\n- Can-deploy-fix: open PR, get approver, deploy, watch 30 min before declaring resolved\n- NEVER deploy a hotfix to auth, payments, or migration code without a human\n\nPhase 4 — Resolve and postmortem.\n- Resolve ONLY after the metric has been stable for 15 min\n- Postmortem sections:\n  - Headline (user-visible impact, duration, scope)\n  - Timeline (alerted → first action → mitigation → resolution, with timestamps)\n  - Root cause (technical cause, NOT \"the engineer who deployed it\")\n  - What worked / what didn't (which diagnostic steps helped, which wasted time)\n  - Action items (each: owner, deadline, ticket link)\n\nPhase 5 — Update the runbook (the loop closes here).\n- If the diagnosis steps you used aren't in the runbook, add them\n- If the runbook had bad info, fix it (and explain why in the commit)\n- Open a PR against the runbook with your edits — even small ones\n\nFeedback signal (compounds across incidents):\n- Diagnostic steps that were the fast path → promote to the top of the runbook\n- Dead-end steps → demote or delete\n- Alert false-positive rate: if 3+ in a week, propose tuning the threshold\n\nQuality bar:\n- Never \"resolve\" without verifying the metric is actually stable\n- Never declare root cause without evidence (log line, query, graph)\n- Blameless postmortem — focus on system + process, not the person"
+    },
+    {
+      "id": "google-maps-leadgen-pipeline",
+      "name": "Scrape Google Maps and ship personalized cold outreach",
+      "category": "Lead Gen",
+      "tags": [
+        "lead-gen",
+        "pipeline",
+        "sales"
+      ],
+      "emoji": "🗺️",
+      "description": "Scrape Google Maps for a niche+city, enrich, and ship outreach. Get a vetted list and a 3-touch sequence per lead.",
+      "works_best_with": {
+        "agent_profile": "marketing-agent",
+        "skills": [
+          "brave-search",
+          "firecrawl",
+          "playwright-mcp",
+          "concise-planning"
+        ],
+        "mcp_servers": [
+          "gmail-mcp",
+          "notion-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Define niche + cities",
+        "Scrape Google Maps listings",
+        "Enrich missing emails + verify deliverability",
+        "Personalize a 3-touch sequence per lead",
+        "Export a sendable CSV"
+      ],
+      "prompt": "Build a local-business lead-gen pipeline end-to-end: scrape Google Maps for a niche+city, enrich emails, verify, and write personalized outreach.\n\nInputs:\n- Niche / category (be specific): [e.g. \"independent dental practices\", \"yoga studios with <10 staff\"]\n- Target cities / areas: [list]\n- My offer + one-liner: [paste]\n- My credibility / proof point: [paste]\n- Scraper tool: [Apify Google Maps / Outscraper / SerpAPI / scrap.io]\n- Enrichment stack: [Hunter / Apollo / Snov / Clay]\n- Verifier: [EmailListVerify / NeverBounce / ZeroBounce]\n- Sending stack: [Instantly / Smartlead / Lemlist]\n- Daily volume per inbox: [default 30]\n- Tone: [warm-and-direct / playful / industry-peer]\n\nPhase 1 — Scope and scrape.\n- Confirm niche + cities. Estimate list size before scraping.\n- Wait for my approval.\n- Run the Google Maps scraper for {category} + {city}. Capture: name, address, phone, website, hours, rating, review count, photo URLs.\n- Filter obvious chains (>3 locations indexed) unless I asked for chains.\n\nPhase 2 — Enrich.\n- For businesses with a website but no email, crawl contact / about / footer for visible emails\n- For still-missing, try Hunter/Apollo lookup\n- Drop rows missing both email AND phone — not actionable\n\nPhase 3 — Verify.\n- Run every email through deliverability\n- Tag: green (safe) / yellow (catch-all or risky) / red (bounce)\n- Drop reds; queue yellows for manual review\n\nPhase 4 — Personalize per lead.\n- Find ONE specific hook from their Google Maps presence:\n  - A recent review (positive or negative) you can reference\n  - A specific service or specialty they advertise\n  - A photo subject that says something about the business\n- If you cannot find a real hook, mark \"skip\" — don't fake personalization\n\nPhase 5 — Write the sequence.\n- Email 1 (<=80 words): subject <=6 words lowercase, open with hook, one credible proof, one low-friction CTA\n- Email 2 (+3 days, <=60 words): new angle or proof, not \"just bumping\"\n- Email 3 (+7 days, <=40 words): honest breakup, leaves door open\n\nPhase 6 — Export.\n- CSV ready to import: email, first_name, business_name, hook, subject1, body1, subject2, body2, subject3, body3\n- Summary row at top: scraped / enriched / verified green / personalized / skipped\n\nFeedback signal (after campaign sends):\n- Reply rate per niche × city — feed back into next list's targeting\n- Which hook types landed (review / specialty / photo) — bias future personalization\n- Which inboxes flagged for spam — rotate them out\n\nQuality bar:\n- NEVER send anything from this prompt — outputs only\n- NEVER scrape behind a login (no LinkedIn cookies, no Apollo session)\n- Respect robots.txt for any site crawl\n- US: CAN-SPAM physical address + unsubscribe in every email\n- EU/UK: drop the row unless there's a clear B2B legitimate-interest basis\n- Flag cities where local laws ban unsolicited B2B email (e.g. Canada CASL)"
+    },
+    {
+      "id": "review-mining-pitch",
+      "name": "Mine competitor reviews and pitch a fix",
+      "category": "Lead Gen",
+      "tags": [
+        "audit",
+        "lead-gen",
+        "sales"
+      ],
+      "emoji": "⭐",
+      "description": "Mine reviews for pain points. Get an audit PDF per prospect and a tailored email pitching the fix as a service.",
+      "works_best_with": {
+        "agent_profile": "marketing-agent",
+        "skills": [
+          "brave-search",
+          "firecrawl",
+          "pdf",
+          "concise-planning"
+        ],
+        "mcp_servers": [
+          "gmail-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Pick sector + prospect list",
+        "Scrape reviews across sources",
+        "Cluster complaints by theme",
+        "Produce per-prospect audit PDF",
+        "Write the pitch email"
+      ],
+      "prompt": "For each prospect, mine their reviews for pain points and produce an audit PDF + a tailored cold email pitching the fix as a service.\n\nInputs:\n- Sector: [e.g. local dental practices, boutique gyms, plumbers]\n- Target prospects (5-20 names + Google/Yelp URLs): [list]\n- Review sources to scan: [Google / Yelp / Trustpilot / Facebook / industry sites]\n- My offer / what I'd fix: [paste — \"missed-call recovery\", \"review reply automation\", \"appointment-booking bot\"]\n- Tone: [data-driven consultant / friendly local agency / etc.]\n\nPhase 1 — Scrape.\n- For each prospect, pull last 100 reviews per source (or all, whichever is fewer)\n- Capture: rating, date, snippet, owner response if any\n- Drop reviews with no text (rating-only)\n- Show me the volume table before going further\n\nPhase 2 — Cluster per prospect.\n- Tag each review with one theme:\n  - Wait time / scheduling\n  - Communication (calls not returned, no follow-up)\n  - Pricing surprises\n  - Quality of service\n  - Staff attitude\n  - Physical space / cleanliness\n  - Booking experience\n- Count by theme. Average rating per theme.\n\nPhase 3 — Produce the audit PDF per prospect (3-4 pages).\n- Page 1: 1-sentence verdict + stats (avg rating, review count, response rate, top 3 themes)\n- Page 2: top 3 themes with 2-3 verbatim quotes each\n- Page 3: cost-of-ignore estimate using sector benchmarks if available\n- Page 4: the fix and the cost of ignore vs address\n\nSave as `audit-<prospect-slug>.pdf`.\n\nPhase 4 — Pitch email per prospect.\n- Subject (<=6 words, lowercase): tease the specific theme — \"missed calls hurting reviews?\"\n- Body (<=120 words): one verbatim review, the pattern across their reviews, what the fix would do, attach the audit PDF, soft CTA (15-min walkthrough)\n- Sign-off matching tone\n- NEVER use shame language (\"your reviews are terrible\") — neutral observation\n\nPhase 5 — Output.\n- PDFs in workspace\n- CSV: prospect | email | subject | body | top theme | rating\n- \"Fastest reply path\" ranking: prospects whose complaints map cleanest to my fix\n\nFeedback signal:\n- Reply rate by complaint theme — which themes resonate for outreach\n- Audit-PDF view tracking — who opened it\n- Closed-won themes — bias next round to the highest-converting complaint pattern\n\nQuality bar:\n- Every quote is verbatim from a real review (cite source + date)\n- NEVER invent reviews. If a prospect has too few, skip them.\n- Don't pitch on theme A if their actual complaints are about theme B\n- Respect review-site ToS: cite, link back, don't republish in bulk"
+    },
+    {
+      "id": "podcast-to-content-pack",
+      "name": "Turn a podcast episode into a multi-platform content pack",
+      "category": "Content",
+      "tags": [
+        "content"
+      ],
+      "emoji": "🎙️",
+      "description": "Turn a podcast episode into a content pack. Get show notes, audiograms, a LinkedIn post, a thread, and a newsletter.",
+      "works_best_with": {
+        "agent_profile": "content-creator",
+        "skills": [
+          "concise-planning",
+          "vale-brand-voice"
+        ],
+        "mcp_servers": [
+          "notion-mcp",
+          "twitter-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Transcribe and chapter the episode",
+        "Identify the 5-8 strongest moments",
+        "Brief 5 audiograms",
+        "Draft LinkedIn, thread, and newsletter",
+        "Compile show notes"
+      ],
+      "prompt": "Turn this podcast episode into a multi-platform content pack.\n\nInputs:\n- Episode audio URL or path: [paste]\n- Episode title + show context: [paste]\n- Host + guest names: [paste]\n- Target audience: [who listens + what they want]\n- Brand voice / tone: [paste or link]\n- Primary CTA across platforms (optional): [subscribe / book guest / join community]\n\nPhase 1 — Transcribe + chapter.\n- Generate or pull the full transcript with speaker labels and timestamps\n- Identify natural chapter breaks (topic shifts >=2 min)\n- Tag the 5-8 strongest moments — quotable insight, contrarian take, story beat, surprising stat\n- List timestamps before drafting anything\n\nPhase 2 — Produce deliverables in this order:\n\n1) Show notes (the host's MVP deliverable)\n- 1-paragraph episode summary\n- Bulleted chapter list with timestamps + 1-line per chapter\n- Guest links (site, social, anything they plugged)\n- 3-5 \"quotes worth pulling\" with timestamps\n\n2) Audiogram briefs (5 clips, 30-90 sec each)\n- For each: timestamp range, headline caption, recommended visual (waveform color, background image vibe)\n- Tag platform-fit: YouTube Shorts / Reels / TikTok / LinkedIn / X\n\n3) LinkedIn long-form post (200-350 words)\n- Narrative open referencing one specific moment + timestamp\n- One sharp takeaway\n- Link to full episode at the bottom\n\n4) X / Twitter thread (5-7 tweets)\n- Hook tweet works standalone — no \"listen to the pod\" filler\n- Each tweet: one concrete claim or quote\n- Final tweet: episode link\n\n5) Newsletter draft (400-600 words)\n- Standalone — makes sense to someone who never listened\n- Structure: anecdote -> the conversation's central tension -> the resolution -> one takeaway\n- End with the episode link\n\nFeedback signal (after publishing):\n- Per platform: which audiogram drove the most plays back to the full episode — bias next batch's clip selection\n- Which guest type drives the most newsletter signups — feeds future booking choices\n- Show notes traffic week over week — surface the chapter format that lands\n\nQuality bar:\n- Every quote is verbatim — copy the speaker's words, not your paraphrase\n- Attribute every quote to the speaker by name + timestamp\n- Strip cross-talk and filler (\"like\", \"you know\") in pull quotes; keep in show notes\n- Flag any contentious moment — let the host decide whether to amplify\n- Never invent a moment that wasn't in the transcript"
+    },
+    {
+      "id": "seo-decay-refresh-loop",
+      "name": "Run an SEO content-decay refresh loop",
+      "category": "Content",
+      "tags": [
+        "content",
+        "loop",
+        "report",
+        "seo"
+      ],
+      "emoji": "🔄",
+      "description": "Find decaying posts and ship refreshes. Get a ranked list, refresh briefs, and refreshed copy with a 30-day re-measurement.",
+      "works_best_with": {
+        "agent_profile": "content-creator",
+        "skills": [
+          "brave-search",
+          "firecrawl",
+          "vale-brand-voice"
+        ],
+        "mcp_servers": [
+          "notion-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Pull rankings, traffic, engagement",
+        "Detect posts decaying past threshold",
+        "Read top SERP competitors per post",
+        "Write a refresh brief + new copy",
+        "Schedule a 30-day re-measurement"
+      ],
+      "prompt": "Run a content-decay refresh round on my site.\n\nInputs:\n- Site: [URL]\n- Analytics source: [GSC + GA4 / Ahrefs / Semrush / Plausible]\n- Time window: [last 90 days vs prior 90]\n- Decay threshold: [default >20% MoM traffic drop OR rank drop >5 positions]\n- Top N to action this round: [default 10]\n- Brand voice notes: [paste or link]\n\nPhase 1 — Pull decay signals.\nFor every URL, compute:\n- Organic traffic delta (% MoM)\n- Average position delta\n- CTR delta\n- Engagement delta (avg time or scroll depth)\nSurface URLs breaching the threshold. Sort by lost traffic in absolute terms.\n\nPhase 2 — Diagnose per post.\nFor the top {N}:\n- Why decaying:\n  - Outdated info (stat from 2 years ago, defunct product, broken external link)\n  - SERP shifted (competitor wrote deeper version; AI Overview eats the answer)\n  - Intent shifted (people now want X, post is about Y)\n  - Technical (slow page load, broken layout, robots/canonical issue)\n- Pull current top-5 SERP results — read them. Note what they have that ours doesn't.\n\nPhase 3 — Brief the refresh per post.\n- Verdict: refresh / consolidate / sunset (with 301)\n- For refresh: specific changes\n  - Update which stats/sources\n  - Add which sections (with H2/H3)\n  - Remove which dated language\n  - New angle or contrarian take if SERP demands it\n- Effort (S / M / L)\n\nPhase 4 — Write the refresh.\n- Rewrite with the brief's changes\n- Keep the URL (preserves backlinks)\n- Update the post date + add a \"last updated\" line at top\n- Verify every fact / stat / quote — cite or remove\n- Output as a markdown block ready to paste into the CMS\n\nPhase 5 — Schedule re-measurement (closes the loop).\n- For each refreshed post, schedule a 30-day check: did traffic recover? rank improve?\n- Output a calendar block for my project tracker\n\nFeedback signal (after 30 days):\n- Which decay drivers recovered (\"updating stats lifted traffic 40%\") — bias next round's diagnosis\n- Which didn't recover — those might need sunset, not refresh\n- Average lift per refresh — calibrates ROI vs net-new content\n\nQuality bar:\n- Never rewrite for the sake of \"fresh date\" — only with a real reason\n- Never delete a post with backlinks without a thoughtful 301 plan\n- Strip AI-slop: \"delve\", \"unlock\", \"navigate the complexities\"\n- If a post has <100 monthly visits, flag for sunset"
+    },
+    {
+      "id": "newsletter-monetization-audit",
+      "name": "Audit a newsletter and build the sponsorship rate card",
+      "category": "Content",
+      "tags": [
+        "content",
+        "founder"
+      ],
+      "emoji": "💰",
+      "description": "Audit a newsletter and build the sponsorship rate card. Get a media kit, rate card, and 3 sponsor pitches ready to send.",
+      "works_best_with": {
+        "agent_profile": "marketing-agent",
+        "skills": [
+          "concise-planning",
+          "pdf",
+          "brave-search"
+        ],
+        "mcp_servers": [
+          "gmail-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Audit subscribers + engagement vs benchmark",
+        "Segment audience by interest + engagement",
+        "Build a tiered sponsorship rate card",
+        "Draft 3 pitch emails to target sponsors",
+        "Output a media kit"
+      ],
+      "prompt": "Audit my newsletter and build the sponsorship rate card + pitch path.\n\nInputs:\n- Newsletter platform: [beehiiv / Substack / ConvertKit / Ghost — and how to pull stats]\n- Total subscribers + 90-day growth: [paste]\n- Avg open rate, click rate, unsubscribe rate (last 90 days): [paste]\n- Top 10 posts by engagement (titles + open % + click %): [paste]\n- My audience description (1-2 sentences — role, industry, intent): [paste]\n- Closest 2-3 competitor newsletters running sponsorships: [list]\n- Target sponsor types (SaaS / service / book / event / etc.): [paste]\n\nPhase 1 — Audit the surface.\n- Subscriber tier (under 1k / 1-10k / 10-100k / 100k+) and typical CPM at that tier\n- Engagement quality (open % vs Substack/beehiiv benchmark by tier)\n- Topic concentration — which themes consistently overperform\n- Subscriber segments you can credibly slice (job title, industry, geography) given platform data\n- Verdict: is the list MONETIZABLE today, or do you need 3-6 more months of growth first?\n\nPhase 2 — Build the rate card.\n- Per-placement pricing: dedicated send / classified slot / primary slot / \"presented by\" full sponsor\n- Rate logic: blend CPM + flat minimums + scarcity (one sponsor per issue)\n- Bundle options (4-pack, 12-pack with discount)\n- Add-ons (social cross-post, podcast read, custom landing page)\n- Realistic per-issue revenue range at current size\n\nPhase 3 — Draft 3 pitch emails to target sponsor types.\n- Each <=120 words\n- Open with a specific reason THIS sponsor fits this audience (not \"great deal\")\n- One credible proof (engagement stat, segment they care about, comparable case)\n- Clear rates + next step (book a 15-min slot or send the media kit)\n- Sign-off matching my voice\n\nPhase 4 — Output.\n- Rate card as a 1-page PDF\n- Media kit (2 pages) with audience profile, engagement stats, sample issue\n- The 3 pitch emails as drafts\n- A \"do this before pitching\" checklist (sponsor page on site, logo wall, etc.)\n\nFeedback signal (after 30 days of pitching):\n- Reply rate per sponsor type — which segments are warmest\n- Pricing pushback patterns — recalibrate rate card if a tier consistently gets discounted\n- Sponsor performance once placed (clicks, signups) — feed into the next pitch's case-study line\n\nQuality bar:\n- Never inflate subscriber count or open rates — sponsors verify; one bust kills the reputation\n- Never promise audience overlap you can't measure (no \"mostly CTOs\" without survey data)\n- Be honest if the list isn't monetizable yet — recommend a growth plan instead\n- Don't use \"we\" if it's a solo newsletter — sponsors hate fake teams"
+    },
+    {
+      "id": "win-loss-icp-loop",
+      "name": "Mine closed deals to refine your ICP",
+      "category": "Sales",
+      "tags": [
+        "loop",
+        "sales"
+      ],
+      "emoji": "🏆",
+      "description": "Mine last quarter's closed deals to refine your ICP. Get patterns by segment and updated scoring rules for next quarter.",
+      "works_best_with": {
+        "agent_profile": "bd-partnerships",
+        "skills": [
+          "concise-planning",
+          "audit-context-building",
+          "pdf"
+        ],
+        "mcp_servers": [
+          "notion-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Pull last quarter's closed deals",
+        "Analyze each touchpoint + outcome",
+        "Cluster patterns by segment",
+        "Update the ICP + scoring rules",
+        "Output revised lead-scoring criteria"
+      ],
+      "prompt": "Mine my last quarter's closed deals to tighten my ICP for the next quarter.\n\nInputs:\n- CRM source: [Salesforce / HubSpot / Pipedrive / Close — how to access]\n- Quarter to analyze: [Q3 2026 / etc.]\n- Current ICP: [paste — title + company size + industry + use case]\n- Closed-won, closed-lost, in-progress counts: [paste totals]\n- Sales / CSM notes (call summaries, deal notes): [paste or link]\n\nPhase 1 — Pull and classify.\n- For every closed deal: firmographics (size, industry, region), behavioral (lead source, touches), buying committee (titles), velocity (days to close), ACV, expansion potential\n- Classify each: closed-won-good-fit / closed-won-bad-fit (will churn) / closed-lost-good-fit (should have won) / closed-lost-bad-fit (correctly disqualified)\n\nPhase 2 — Pattern analysis.\nFor each bucket:\n- Firmographic / behavioral signals that predict it\n- Velocity profile (fast wins vs slow grinds)\n- ACV profile\n- Top objections\n\nFindings as: \"X% of closed-won-good-fit had {signal}; only Y% of closed-lost-bad-fit did\" — concrete and measurable.\n\nPhase 3 — Update the ICP.\n- What's IN that wasn't (new sub-segment performing well)\n- What's OUT (segment losing or winning bad-fit deals)\n- New must-have qualifiers\n- New disqualifiers\n\nShow me the updated ICP as a diff. Wait for approval.\n\nPhase 4 — Translate to scoring rules.\n- Lead-scoring per signal: +X or -X points\n- Stage gates: \"do not advance to demo without {signal verified}\"\n- BDR talk-track changes: which discovery questions to ask first\n\nPhase 5 — Output.\n- ICP update memo (1-2 pages) as `icp-q<X>-update.pdf`\n- CSV of scoring-rule changes ready to load into CRM\n- A \"kill list\" of in-progress deals that no longer match — recommend tactful disqualification\n\nFeedback signal (after next quarter):\n- Did closed-won rate go up for new-ICP leads?\n- Did time-to-close shorten?\n- Did churn drop in the closed-won cohort?\n- Loop the result back into the ICP for the following quarter\n\nQuality bar:\n- Every claim cites specific deals (IDs or anonymized names)\n- NEVER fabricate a pattern from one deal — minimum 3 examples\n- If sample sizes are too small for a segment, say so — don't force a conclusion\n- This is sales analysis, NOT a layoff list — frame for targeting, not blame"
+    },
+    {
+      "id": "investor-monthly-update",
+      "name": "Write this month's investor update",
+      "category": "Sales",
+      "tags": [
+        "founder",
+        "report",
+        "sales"
+      ],
+      "emoji": "📋",
+      "description": "Write this month's investor update from raw KPIs. Get a polished memo + email + an ask list with specific intros.",
+      "works_best_with": {
+        "agent_profile": "finance-agent",
+        "skills": [
+          "concise-planning",
+          "pdf"
+        ],
+        "mcp_servers": [
+          "gmail-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Pull KPIs + deltas vs plan",
+        "Surface wins, misses, asks",
+        "Draft the TL;DR + numbers table",
+        "Polish into memo + email",
+        "Stage specific asks"
+      ],
+      "prompt": "Write this month's investor update.\n\nInputs:\n- Last month's update (for delta + tone reference): [paste or link]\n- This month's KPIs: [paste — revenue, MRR/ARR, growth, churn, runway, headcount, key launches]\n- Wins this month (3-5 bullets): [paste]\n- Misses this month (be honest — 2-3): [paste]\n- Asks I have for investors (intros, hires, advice): [paste]\n- Tone: [transparent-founder / sharp-operator / chatty]\n\nStep 1 — Structure the memo.\nSections, in order:\n1. TL;DR (3 sentences max — the single most important thing)\n2. Numbers table (this month vs last vs plan, with deltas)\n3. Wins (3-5, each with a concrete outcome — not \"we launched X\" but \"X drove $Y in revenue\")\n4. Misses (2-3, with what you're doing about each — never just \"we'll do better\")\n5. What I'm focused on next month (3 priorities, in outcome language)\n6. Asks (specific intros by company or role; not \"intros welcome\")\n\nStep 2 — Write it.\n- TL;DR first. Investors skim — front-load.\n- Numbers table: metric, this-month, last-month, % delta, plan target. Flag anything off plan with a 1-line explanation.\n- Wins: one paragraph each, with a metric you can defend\n- Misses: name it, cause as you understand it today, the experiment to fix it. Owners + timelines.\n- Asks: list each ask with the WHY (\"we need a head of growth because conversion is stuck at X\")\n\nStep 3 — Output.\n- Polished memo (.pdf and .md) to my workspace\n- Same content as an email body with subject: \"<Company> — <Month> update: <one-line theme>\"\n- A \"what to leave out next time\" note for me (anything that felt too in-the-weeds)\n\nFeedback signal (closes loop month over month):\n- Reply rate from investors — if it drops, you're being too long or too generic\n- Asks that get answered — which framing of asks gets actual intros? Bias next month's wording.\n- Which sections investors quote back in 1:1s — those are the parts that landed\n\nQuality bar:\n- NEVER hide a miss to \"manage perception\" — investors find out and lose trust\n- Never invent metrics or growth rates — round only to plausible precision\n- No \"we're seeing momentum\" filler — quote a number or cut it\n- Keep total length under 800 words — every line should earn its place"
+    },
+    {
+      "id": "customer-interview-loop",
+      "name": "Cluster customer interviews and feed shipped fixes back",
+      "category": "Customer Success",
+      "tags": [
+        "customer-success",
+        "loop",
+        "research"
+      ],
+      "emoji": "🗣️",
+      "description": "Cluster customer interviews and feed shipped fixes back. Get a discovery report and a ranked product backlog.",
+      "works_best_with": {
+        "agent_profile": "personal-assistant",
+        "skills": [
+          "concise-planning",
+          "pdf",
+          "audit-context-building"
+        ],
+        "mcp_servers": [
+          "notion-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Read every transcript end-to-end",
+        "Extract per-interview themes",
+        "Cluster across the cohort",
+        "Prioritize by frequency × revenue",
+        "Loop back last cohort's shipped items"
+      ],
+      "prompt": "Cluster this cohort of customer interviews, surface the highest-leverage themes, and prepare next sprint's backlog.\n\nInputs:\n- Interview transcripts (5-20): [paste files or paths]\n- Customer attributes per interviewee (segment, ACV, tenure): [CSV]\n- Last cohort's shipped items (so we can measure adoption): [list]\n- My product / company in 1 line: [paste]\n\nPhase 1 — Read every transcript end-to-end.\nDo not skim. Note your reading order so the analysis isn't biased by the loudest customer first.\n\nPhase 2 — Per-interview extraction.\nFor each transcript, extract:\n- 1-line \"what they're trying to do\"\n- 3-5 jobs-to-be-done mentioned (in their words)\n- Frictions encountered with current solution (theirs OR ours)\n- A wish: what would they want to be magically possible?\n- Would-they-pay-for-it answer if tested\n- Direct verbatim quotes with timestamps for the most quotable lines\n\nPhase 3 — Cluster across cohort.\n- Theme each friction / wish across interviewees\n- Frequency (how many mentioned)\n- Revenue impact (sum of ACV)\n- Score = frequency × revenue + sentiment intensity tag (mild / strong / blocker)\n\nPhase 4 — Prioritize.\n- Top 5 themes: name, 3 verbatim quotes, customers affected, revenue at stake, recommendation (ship / investigate / decline + why)\n- Bottom themes: what to explicitly NOT work on, with reasoning\n\nPhase 5 — Loop back last cohort's shipped items (closes the loop).\n- For each item shipped last round: did interviewees mention it? Did they use it? Did it close the friction?\n- Verdict per shipped item: hit / partial / miss\n\nPhase 6 — Output.\n- Discovery report (3-5 pages) as `discovery-<date>.pdf`\n- Prioritized backlog CSV: theme | priority | suggested experiment | owner | rough effort\n- A \"what to ask next cohort\" list to test hypotheses we couldn't validate this round\n\nFeedback signal:\n- Adoption rate of shipped items per theme — if low, the fix missed the real friction\n- Which interview style / question elicited the strongest signal — refine the discovery script\n- Drop-off in friction mentions over cohorts — measures whether you're closing problems for good\n\nQuality bar:\n- Every theme cites at least 3 customer quotes (not just one loud one)\n- Never speak FOR customers — use their words verbatim\n- If a customer asked for X but the JTBD is Y, surface BOTH\n- If a theme is huge but only 1 customer mentioned it, flag \"outlier — investigate\" not \"P0\""
+    },
+    {
+      "id": "nps-detractor-save-loop",
+      "name": "Run an NPS detractor save loop",
+      "category": "Customer Success",
+      "tags": [
+        "customer-success",
+        "loop"
+      ],
+      "emoji": "🆘",
+      "description": "Triage detractors, diagnose, and run a save play. Get a save script per detractor and a 30-day re-survey schedule.",
+      "works_best_with": {
+        "agent_profile": "personal-assistant",
+        "skills": [
+          "concise-planning",
+          "audit-context-building"
+        ],
+        "mcp_servers": [
+          "gmail-mcp",
+          "notion-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Pull recent detractor responses",
+        "Diagnose root cause per detractor",
+        "Cluster themes across cohort",
+        "Draft save plays per high-value detractor",
+        "Schedule a 30-day re-survey"
+      ],
+      "prompt": "Run a detractor save round end-to-end: triage, diagnose root cause, draft tailored save plays, and schedule re-surveys.\n\nInputs:\n- NPS data export (last 30 days, score + free-text + customer_id + ACV): [paste]\n- CRM source for context (interactions, tickets, usage): [how to access]\n- CSM team + workload: [paste]\n- Known save plays (discount / exec sponsorship / new feature preview / training): [list]\n\nPhase 1 — Triage detractors.\n- Every score 0-6 from the last 30 days\n- Drop responses with no free-text (can't act on no signal)\n- For each: pull account context (ACV, tenure, recent tickets, last login)\n- Flag high-ACV as P0; mid-ACV as P1; low-ACV as P2\n\nPhase 2 — Diagnose per detractor.\nFor each:\n- Extract the single most actionable phrase from their free-text\n- Tag root cause: product-gap / pricing / support / onboarding / sales-promise-mismatch / champion-left / out-of-our-control\n- Identify history pattern (recent ticket, billing event, executive change at their company)\n\nPhase 3 — Cluster across all detractors.\n- Theme frequency\n- Revenue at stake per theme\n- Top 3 themes → product / sales / CS leadership need to see these\n\nPhase 4 — Draft save plays per detractor (P0 + P1).\nFor each:\n- Suggested CSM (load-balanced by workload)\n- Save play to lead with (most likely to resonate given the root cause)\n- 100-word script: validate feedback, name the specific issue, propose action, ask for 15 min next week\n- Backup play if the first is declined\n- Realistic P(save): high / med / low — be honest\n\nPhase 5 — Schedule re-survey (closes the loop).\n- 30-day re-survey task for each save attempt\n- 60-day check for \"did the underlying issue actually get fixed?\"\n\nPhase 6 — Output.\n- Save-play CSV: customer | score | theme | CSM | play | script | re-survey date\n- Weekly digest for product / sales / CS leadership: themes + revenue at stake + recommended ownership\n- \"Do not contact\" list for detractors who asked for no follow-up\n\nFeedback signal (after 30 days):\n- Save rate per theme — which are saveable, which aren't\n- Save rate per CSM — promote what's working\n- Themes that recur quarter over quarter — surface to product as systemic\n\nQuality bar:\n- Never frame a save call as \"we want to keep your business\" — lead with their problem\n- Never over-promise — if you can't fix the root cause, say so and earn trust\n- Respect \"do not contact\" responses immediately\n- If a detractor's issue is genuinely out of our control, accept gracefully — don't drag it out"
+    },
+    {
+      "id": "weekly-review-loop",
+      "name": "Run a weekly review on calendar, journal, and todos",
+      "category": "Personal",
+      "tags": [
+        "loop",
+        "personal",
+        "productivity"
+      ],
+      "emoji": "🪞",
+      "description": "Run a weekly review with calendar, journal, and todos. Get patterns, 3 priorities for next week, and a slipped log.",
+      "works_best_with": {
+        "agent_profile": "personal-assistant",
+        "skills": [
+          "concise-planning"
+        ],
+        "mcp_servers": [
+          "gmail-mcp",
+          "notion-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Pull calendar, journal, todos",
+        "Score last week's priorities",
+        "Surface energy + drift patterns",
+        "Set next week's 3 priorities",
+        "Log what slipped for next loop"
+      ],
+      "prompt": "Run my weekly review. Read what actually happened, identify patterns, and set up next week.\n\nInputs:\n- Calendar for the past 7 days: [link or paste]\n- Journal entries / daily notes for the past 7 days: [paste or path]\n- Todo list (open + completed): [paste or link]\n- Last week's planned 3 priorities (so we can score): [paste]\n- Energy notes (when I focus best): [paste]\n\nPhase 1 — Read what happened.\n- Per day: calendar blocks, journal sentiment / energy / wins / friction, todos closed vs slipped\n- Simple stats: meeting hours, deep-work hours, todos completed / opened ratio\n\nPhase 2 — Score last week's 3 priorities.\nFor each: hit / partial / miss. One sentence why.\n- If miss: bad planning, bad execution, or wrong priority?\n\nPhase 3 — Patterns.\n- Energy peaks and valleys\n- Calendar shape: did the structure match the priorities? Or did meetings eat focus blocks?\n- One recurring friction (a task that kept slipping, a person blocking, a tool that wasted time)\n- One surprise win (something that worked you didn't plan for)\n\nPhase 4 — Next week's plan.\n- 3 priorities in outcome language (\"ship X\", not \"work on X\")\n- A time-blocked skeleton: protect deep-work blocks around fixed meetings\n- One thing to STOP doing this week\n- One thing to START doing this week\n\nPhase 5 — Log what slipped (closes the loop).\n- Append to `slipped.md` the tasks that didn't close\n- Pattern check: are the same tasks slipping 3+ weeks running? Kill them or break them down.\n\nFeedback signal:\n- Priority hit rate over 4 weeks — if <50%, over-planning or under-protecting time\n- Recurring friction themes — surface to a \"kill list\" for the month\n- Energy patterns refined each week — schedule deep work in your peak window\n\nQuality bar:\n- Total output <300 words — tight plan, not a journal\n- Be honest about misses — don't sugarcoat\n- Don't add new ideas as priorities if last week's didn't ship\n- If I missed all 3 priorities, ASK before just rolling them over — something's wrong upstream"
+    },
+    {
+      "id": "annual-review-loop",
+      "name": "Run an annual review from a year of journals",
+      "category": "Personal",
+      "tags": [
+        "loop",
+        "personal"
+      ],
+      "emoji": "🎯",
+      "description": "Read 12 months of journals and run an annual review. Get patterns, 3 themes for next year, and a quarterly check-in schedule.",
+      "works_best_with": {
+        "agent_profile": "personal-assistant",
+        "skills": [
+          "concise-planning",
+          "pdf",
+          "audit-context-building"
+        ],
+        "mcp_servers": [
+          "notion-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Read 12 months of journals + calendar",
+        "Surface wins, losses, recurring patterns",
+        "Compare to last year's themes",
+        "Set next year's 3 themes",
+        "Calendar block + schedule quarterly check-ins"
+      ],
+      "prompt": "Run my annual review using a year of journals, calendar, and notes.\n\nInputs:\n- 12 months of journal entries / daily notes: [path or paste]\n- Calendar for the year (or summary): [link or paste]\n- Last year's themes / goals (if any): [paste]\n- Closest people in my life this year: [list]\n- Areas of life to score (work / health / relationships / craft / money / etc.): [paste]\n\nPhase 1 — Read the year.\n- Read every journal entry in chronological order. Note your reading order so you don't anchor on recent months.\n- For each month, jot a one-line summary: dominant theme + energy + turning point if any\n- Pull the 10-20 longest entries — usually the ones that matter most\n\nPhase 2 — Surface patterns.\n- 3-5 biggest wins, with concrete outcomes (not \"I grew\" but \"I shipped X\")\n- 3-5 biggest losses or misses — what they cost, what you learned (honest, not punishing)\n- Recurring frictions that NEVER got resolved — systemic issues to attack next year\n- Surprises: anything that mattered more than expected; anything you expected to matter that didn't\n- Per area of life: hit / partial / miss for the year\n\nPhase 3 — Compare to last year's themes.\n- For each theme last year: did it land? Evidence?\n- Which themes you kept showing up for vs which faded\n- Which themes were ill-defined and need a sharper next-year version\n\nPhase 4 — Set next year's themes (3, not 10).\n- Each theme: name, why this year, what success looks like in concrete terms (a metric, an artifact, a relationship change), what you'll say NO to\n- One thing to STOP\n- One thing to START\n\nPhase 5 — Calendar block the year.\n- Block major projects, retreats, family/relationship time\n- Schedule a quarterly check-in: re-read this review + your weekly slipped log\n\nPhase 6 — Output.\n- Polished annual review PDF (5-8 pages) as `annual-review-<year>.pdf`\n- 1-page summary for sharing with a coach / partner / close friend if I want\n- Calendar import file (.ics) for blocked time\n\nFeedback signal (next year, closes the multi-year loop):\n- Did the 3 themes still feel right at the quarterly check-in?\n- Patterns that recur 2+ years — those are identity-level, not goal-level\n- Misses that recur 2+ years — kill them or radically restructure\n\nQuality bar:\n- Don't sugarcoat — but don't punish either. Diagnostic, not punitive.\n- Use my actual words from the journal wherever possible — your paraphrase loses the texture\n- If a theme feels forced (\"I should care about networking\"), say so — fake themes are worse than no themes\n- Keep digestible — if I won't re-read it in 3 months, it's too long"
+    },
+    {
+      "id": "personal-crm-keepalive",
+      "name": "Keep your close relationships warm",
+      "category": "Personal",
+      "tags": [
+        "loop",
+        "personal",
+        "sales"
+      ],
+      "emoji": "🤝",
+      "description": "Spot relationships decaying and re-engage tastefully. Get a scored list, drafted messages, and follow-up dates.",
+      "works_best_with": {
+        "agent_profile": "personal-assistant",
+        "skills": [
+          "concise-planning"
+        ],
+        "mcp_servers": [
+          "gmail-mcp",
+          "notion-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Tier and score contacts",
+        "Surface context per decaying relationship",
+        "Draft tasteful re-engagement messages",
+        "Schedule outreach across the week",
+        "Track follow-up dates"
+      ],
+      "prompt": "Audit my close relationships and keep the important ones warm.\n\nInputs:\n- Contact list with last-interaction date (CSV from phone / email / Notion / personal CRM): [paste or path]\n- Tier rubric (define your own — examples below): [paste or use defaults]\n   - Tier 1: closest family + 5 closest friends — touch at least monthly\n   - Tier 2: close friends + key professional ties — touch at least quarterly\n   - Tier 3: extended network — touch at least twice a year\n- Recent journal entries mentioning any of these people (last 3 months): [paste or path]\n- My current bandwidth: [how much time / week can I actually give this?]\n\nPhase 1 — Tier and score.\n- Tag every contact with a tier\n- Flag anyone past their tier's threshold\n- Sort by decay risk — how long past the threshold AND how important\n\nPhase 2 — Surface context per decaying relationship.\nFor each flagged contact:\n- Last interaction: when, what about\n- Anything in my journal that mentioned them recently\n- Any life event you can find (birthday this month, recent move, milestone — only if I gave you data)\n- The most natural reason to reach out\n\nPhase 3 — Draft a tasteful re-engagement per contact.\n- Tone: how I'd actually text or email them — not LinkedIn \"let's reconnect\"\n- Reference something specific (last conversation, shared memory, life event)\n- A low-friction next step (a coffee, a call, a \"no need to reply just thinking of you\")\n- Length matches the relationship — Tier 1 short and warm, Tier 3 longer \"here's what I've been up to\"\n\nPhase 4 — Schedule.\n- Spread the outreach over the week so I'm not blasting 30 in a day\n- Tag any contacts I should call rather than text/email\n- Add a follow-up date on my calendar so I don't drop the thread\n\nPhase 5 — Output.\n- Markdown table: contact | tier | days since last touch | context | drafted message | suggested channel | scheduled date\n- A \"do not reach out this week\" list (people in conflict, recent loss, asked for space)\n\nFeedback signal (closes loop month over month):\n- Reply rate by tier — are you actually reconnecting with Tier 1?\n- Patterns in which messages got the longest replies — those are the warmth-builders\n- Relationships that stayed dormant despite multiple touches — accept it, drop from active list\n\nQuality bar:\n- NEVER batch-send identical messages — every one is 1:1\n- NEVER reference something they shared in confidence\n- Tier 1 outreach is never asking for something — it's just showing up\n- If a relationship is genuinely over (mutual fade, life apart), respect it\n- Don't add new contacts to active tiers without explicit input — relationships are earned in"
+    },
+    {
+      "id": "family-meal-plan",
+      "name": "Plan a family meal week from pantry + budget",
+      "category": "Home",
+      "tags": [
+        "home"
+      ],
+      "emoji": "🛒",
+      "description": "Plan 7 days of meals from your pantry + budget. Get a grocery list and a kid-friendly schedule.",
+      "works_best_with": {
+        "agent_profile": "personal-assistant",
+        "skills": [
+          "concise-planning",
+          "pdf"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Scan pantry + freezer + fridge",
+        "Read dietary + budget constraints",
+        "Plan 7 days pantry-first",
+        "Generate grocery list grouped by section",
+        "Suggest leftover-friendly combos"
+      ],
+      "prompt": "Plan a family meal week from the pantry + budget + dietary constraints.\n\nInputs:\n- Household: who's eating (ages, preferences, allergies): [paste]\n- Pantry inventory (snap a photo or list staples + perishables): [paste]\n- Dietary constraints (allergies, religious, preference): [paste]\n- Weekly grocery budget: [amount]\n- Nights with hard time constraints (kids' activity, late work): [paste]\n- Cuisines we love + would like more of: [paste]\n- Leftover tolerance: [love 'em / once is enough]\n\nPhase 1 — Inventory + plan shape.\n- Group pantry: USE THIS WEEK (perishables) vs anything else\n- Decide cuisine mix for the 7 days (don't make the same culture 3 nights in a row)\n- Identify 1-2 nights for fast / one-pot meals based on time constraints\n- Identify 1 night for a \"stretch\" recipe — a fun project\n\nPhase 2 — Draft the 7-day plan.\nFor each night:\n- Recipe name + cuisine\n- 5-min summary of how to make it\n- Pantry items it uses (mark which)\n- New ingredients needed (drives the grocery list)\n- Active cook time\n- Kid-friendly flag\n\nPhase 3 — Build the grocery list.\n- Group by store section (produce, dairy, dry, frozen, meat/fish)\n- Specific quantities (not \"onions\" but \"3 yellow onions\")\n- Estimate cost per item using rough current prices\n- Total estimate vs budget — if over, suggest swaps\n\nPhase 4 — Output.\n- 1-page meal plan as PDF for the fridge\n- Grocery list as a markdown checklist\n- A \"what to prep on Sunday\" list (wash-and-chop that makes weeknights faster)\n\nFeedback signal (next week):\n- Which recipes got eaten happily vs pushed around the plate — promote winners\n- Which pantry items got used vs piled up — stop buying the unused ones\n- Did actual grocery cost match estimate? Tune the price list.\n\nQuality bar:\n- Never propose a recipe nobody will actually eat\n- Respect allergies absolutely — even trace contamination warnings\n- Default to whole-food, scratch-cook unless I said otherwise\n- If budget is tight, lead with cheaper proteins (eggs, beans, ground meat); skip steak-night\n- Keep total active cook time under 45 min for any weeknight unless I asked for the project meal"
+    },
+    {
+      "id": "airbnb-hosting-optimization",
+      "name": "Optimize an Airbnb listing and set re-measurement",
+      "category": "Home",
+      "tags": [
+        "audit",
+        "home",
+        "loop"
+      ],
+      "emoji": "🏡",
+      "description": "Optimize an Airbnb listing end-to-end. Get title + photos + price + message templates with a 30-day re-measurement.",
+      "works_best_with": {
+        "agent_profile": "marketing-agent",
+        "skills": [
+          "concise-planning",
+          "pdf",
+          "vale-brand-voice"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Diagnose 90-day performance vs comps",
+        "Optimize title + photos + description",
+        "Recommend dynamic pricing curve",
+        "Rewrite message templates",
+        "Schedule 30-day re-measurement"
+      ],
+      "prompt": "Optimize an Airbnb listing end-to-end and set up the re-measurement loop.\n\nInputs:\n- Listing URL or property name: [paste]\n- 90 days of booking + revenue + occupancy data: [paste or CSV]\n- 90 days of reviews (titles + full text): [paste or path]\n- Competitor listings in the area (3-5 comparable): [URLs]\n- Current pricing strategy (flat / dynamic / seasonal): [paste]\n- Current message templates (inquiry / pre-arrival / check-out / review): [paste]\n- Constraints (min stay, gap day, owner-blocked dates): [paste]\n\nPhase 1 — Diagnose performance.\n- Occupancy vs comps (above / at / below market)\n- Average daily rate vs comps\n- Total revenue vs comps (occupancy × ADR)\n- Review score + 2-3 themes from reviews — both wins and gripes\n- Conversion rate (views to bookings) if available\n\nPhase 2 — Optimize the listing.\n- Title: rewrite for the strongest single hook (proximity to X, the unique feature, the trip type)\n- Photos: list 5-10 photo upgrades (cover photo, missing room, lighting, staging)\n- Description: rewrite using wins from reviews — let guests' words sell the place\n- House rules: surface anything causing review hits (cleanliness fee surprise, parking confusion)\n- Amenities: any I'm under-tagging that comps are tagging\n\nPhase 3 — Pricing.\n- Recommended dynamic curve for next 90 days, calibrated to weekday / weekend / seasonal events\n- Minimum stay rules to optimize occupancy without leaving money on the table\n- Gap-day discount logic for awkward one-night gaps\n\nPhase 4 — Rewrite the message templates.\n- Inquiry response: <=120 words, warm + concrete (proximity / parking / wifi / check-in)\n- Pre-arrival: 48h before — practical (entry, parking, neighborhood)\n- Check-out: simple list, no guilt-trippy \"please leave a 5-star review\"\n- Post-stay review request: 24h after — a specific compliment to the guest, soft review ask\n\nPhase 5 — Schedule re-measurement (closes the loop).\n- 30 days from now: re-check occupancy, ADR, review score, conversion\n- 60 days: full re-audit on the same axes\n\nPhase 6 — Output.\n- An action list ranked by ROI (changes that take an hour and lift bookings 10%+ first)\n- Rewritten title + description + house rules + amenity list\n- 4 message templates ready to paste into Airbnb\n- A 1-page summary PDF for my co-host or cleaner\n\nFeedback signal:\n- After 30 days: which changes moved the metric you targeted?\n- Patterns in new reviews — did the gripes go away?\n- Did pricing changes lift revenue, or just shift bookings around?\n\nQuality bar:\n- NEVER fabricate amenities (no \"ocean view\" if you can see a parking lot)\n- NEVER write fake-friendly templates — guests can smell scripts\n- Respect platform rules (no off-platform contact ask in templates)\n- If reviews are dropping for a structural reason (the bed, wall thinness), name it — cosmetic fixes won't save it"
+    },
+    {
+      "id": "novel-chapter-draft",
+      "name": "Draft a novel chapter with continuity",
+      "category": "Creative",
+      "tags": [
+        "content",
+        "creative"
+      ],
+      "emoji": "📖",
+      "description": "Draft a novel chapter without breaking continuity. Get beats, prose at your voice, and a continuity diff vs the bible.",
+      "works_best_with": {
+        "agent_profile": "content-creator",
+        "skills": [
+          "concise-planning",
+          "vale-brand-voice",
+          "docx"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Read the bible + last chapter end-to-end",
+        "Beat the chapter",
+        "Draft prose at your voice",
+        "Continuity check vs bible",
+        "Diff new facts back into the bible"
+      ],
+      "prompt": "Draft the next chapter of my novel without breaking continuity.\n\nInputs:\n- Continuity bible (characters, world rules, established facts, timeline): [path]\n- Prior chapter(s) — at minimum the last full chapter: [paste or path]\n- My outline for THIS chapter (a paragraph is fine): [paste]\n- The book's POV (1st / 3rd limited / 3rd omniscient) + tense: [paste]\n- 2-3 prose samples that capture my voice: [paste]\n- Target word count: [e.g. 3000-4000 words]\n- Off-limits (a scene I'm not writing, a reveal not yet earned): [paste]\n\nPhase 1 — Read the bible + last chapter end-to-end.\n- Note every character on stage at the end of the previous chapter — they need to either be moved off or accounted for\n- Note any time-of-day / location continuity needed for the opening line\n- Note any open emotional or plot thread this chapter should close, advance, or deliberately leave hanging\n\nPhase 2 — Beat the chapter.\n- Open beat: where + when + who (continue from prior chapter, not jump cold)\n- 3-6 middle beats: what changes scene to scene? What's the protagonist trying / failing / learning?\n- Close beat: ends on a turn — a reveal, a decision, a cliffhanger, or a still moment that sets up the next chapter\n- Show me the beats. Wait for approval before drafting prose.\n\nPhase 3 — Draft the prose.\n- POV + tense locked from the bible\n- Voice matches the prose samples — sentence rhythm, vocabulary, comma habit\n- Dialogue carries weight — no chit-chat that doesn't reveal character or move plot\n- Scene description in service of mood, not inventory\n- Hit the target word count within ±15%\n\nPhase 4 — Continuity check.\n- For every fact you used about the world, character, or timeline: verify against the bible\n- Surface any place you had to invent — name the new fact and ask whether to add to the bible\n- Flag any phrase that drifted from the voice samples\n\nPhase 5 — Output.\n- Drafted chapter (.docx + .md) to my workspace\n- A diff against the bible: new facts the chapter introduces\n- A note on what threads this chapter advanced and what's still open for the next one\n\nFeedback signal:\n- After I edit: which lines I cut tell you what's drifting from the voice\n- Continuity issues caught at edit — bake into the bible so they don't recur\n- Pacing: too long / short relative to beat count? Tune ratios for next time.\n\nQuality bar:\n- NEVER invent a character, place, or rule that contradicts the bible\n- NEVER advance a thread the outline said to leave alone\n- Show, don't tell — replace \"she was angry\" with the action that proves it\n- Strip first-draft tics: weak verbs (\"was/were\"), filter verbs (\"she felt\", \"she heard\")\n- Don't ship a chapter that ends on a wet noodle — every chapter end is a small hook"
+    },
+    {
+      "id": "course-builder",
+      "name": "Build a course / cohort program end-to-end",
+      "category": "Creative",
+      "tags": [
+        "content",
+        "creative"
+      ],
+      "emoji": "🎓",
+      "description": "Build a course / cohort program end-to-end. Get modules, quizzes, drip schedule, sales page, and a fully-drafted Module 1.",
+      "works_best_with": {
+        "agent_profile": "content-creator",
+        "skills": [
+          "concise-planning",
+          "pdf",
+          "vale-brand-voice"
+        ],
+        "mcp_servers": [
+          "notion-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Lock the transformation",
+        "Outline 6-10 modules",
+        "Draft lessons + quizzes + homework",
+        "Plan drip + community rhythm",
+        "Write the sales page + launch sequence"
+      ],
+      "prompt": "Build a course / cohort program end-to-end.\n\nInputs:\n- Topic + the single transformation it delivers (\"learn to ship a SaaS landing page\" not \"marketing\"): [paste]\n- Target student (level + goal + pain): [paste]\n- Format: [self-paced async / live cohort / hybrid] + length [4 weeks / 6 weeks / etc.]\n- My credibility (why I can teach this): [paste]\n- Tools I'll use (Maven / Skool / Teachable / Kajabi / Discord + email): [paste]\n- Existing material I have (blog posts, talks, notes): [path or list]\n- Price target: [amount]\n\nPhase 1 — Lock the transformation.\n- Restate the transformation in one sentence (student goes from X to Y in Z weeks)\n- The single artifact the student will produce by the end (a deployed thing, a finished work, a portfolio piece)\n- The 3-5 specific outcomes a graduate will demonstrate\n\nWait for me to confirm. The transformation drives every module.\n\nPhase 2 — Module outline.\n- 6-10 modules, each with: title, 1-line learning objective, the homework artifact the student ships\n- Sequence so each module's homework feeds the next\n- Identify the 1-2 modules where students typically drop off and make those extra concrete\n\nPhase 3 — Per-module content.\nFor each module:\n- 3-5 lessons (each 5-15 min if video, or 800-1200 words if written)\n- A quiz or self-check at the end (5 questions max, calibrated to \"did you understand the load-bearing concept\")\n- A homework brief with: goal, steps, a real example, a rubric for \"good enough to move on\"\n- Optional stretch challenge for advanced students\n\nPhase 4 — Drip + community.\n- Drip schedule (when each module unlocks for self-paced / what's covered in each live session for cohort)\n- Community rhythm: weekly office hour question, peer-review channel, accountability buddies\n- Mid-course check-in to catch drop-off risk\n\nPhase 5 — Launch + pricing.\n- Sales page outline (hero + problem + solution + curriculum + outcomes + price + FAQ)\n- Email sequence for waitlist → launch (5 emails)\n- Pricing logic + cohort cap reasoning\n\nPhase 6 — Output.\n- Full course outline as a single PDF\n- Module 1 fully written as a proof-of-concept (lessons + homework + quiz)\n- Sales page draft\n- The waitlist email sequence\n\nFeedback signal (after cohort 1, closes the loop):\n- Drop-off curve — which module loses students. Restructure THAT module.\n- Homework completion rate per module — low completion needs easier wins or clearer rubric\n- NPS at the end + \"what would you tell a friend\" quotes — those become next cohort's sales page\n\nQuality bar:\n- Never promise outcomes you can't deliver — under-promise, over-deliver\n- Every module has one clear takeaway — if you can't name it, the module isn't ready\n- Avoid filler (\"welcome video\", \"what we'll cover\") — students paid for transformation, not throat-clearing\n- If the course works async, don't fake live urgency — different students buy different formats"
+    },
+    {
+      "id": "skill-bank-builder",
+      "name": "Distill reusable skills from your recent agent runs",
+      "category": "Productivity",
+      "tags": [
+        "loop",
+        "productivity"
+      ],
+      "emoji": "🧠",
+      "description": "Mine recent agent runs and distill reusable Skills. Get new skill files with verification steps and pitfalls.",
+      "works_best_with": {
+        "agent_profile": "personal-assistant",
+        "skills": [
+          "concise-planning",
+          "audit-context-building"
+        ],
+        "mcp_servers": [
+          "filesystem"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Read recent task history",
+        "Extract patterns from wins and failures",
+        "Score skill candidates",
+        "Write skill files with pitfalls + verification",
+        "Update the skill index"
+      ],
+      "prompt": "Look at my recent agent runs and distill reusable skills from them so I don't have to re-explain every time.\n\nInputs:\n- Recent task history (last 7-30 days of agent runs / chats / completed work): [paste path or summary]\n- Current skill directory: [path]\n- Skill format I use: [Anthropic Skills SKILL.md / .claude/skills / custom]\n- Max new skills to propose this round: [default 5]\n\nPhase 1 — Read the history.\n- Skim every completed task\n- Tag each: one-off / pattern (might recur) / system change (worth a skill)\n- Drop the one-offs\n\nPhase 2 — Pattern extraction.\nFor \"pattern\" tasks:\n- Goal in one sentence\n- Inputs\n- Steps that actually worked (what shipped value, not what was planned)\n- What went wrong? What had to be re-asked or re-done?\n- The canonical \"good run\" of this task\n\nCluster patterns. If 3+ tasks share the same shape, that's a skill candidate.\n\nPhase 3 — Score candidates.\nFor each:\n- Frequency: how often will this recur?\n- Stakes: cost of getting it wrong?\n- Drift: how often does the right approach change? (high-drift skills age fast)\n- ROI: time saved per future invocation\n\nShow me the top {N} candidates ranked. Wait for confirmation.\n\nPhase 4 — Write the skill files.\nFor each approved candidate:\n- Title + 1-line purpose\n- When to use (and when NOT to)\n- Required inputs (named, with types)\n- Step-by-step procedure\n- Verification steps (how to know the run succeeded)\n- Pitfalls (specific failure modes from history + workaround)\n- Example invocation\n- Update history at bottom (date + what changed)\n\nSave each as a separate file in the skill directory.\n\nPhase 5 — Update the index (closes the loop — the agent becomes smarter for next time).\n- Add new skills to the registry\n- Re-sort the index by frequency-of-use if available\n\nFeedback signal:\n- After a month: which new skills got invoked, which gathered dust?\n- Skills that got invoked but produced bad runs — root-cause and patch the skill\n- Patterns the agent keeps re-asking about despite a skill existing — the skill is hidden or routing is broken\n\nQuality bar:\n- Never create a skill from a single example — minimum 3 instances to call it a pattern\n- Each skill has explicit verification steps — no \"trust me\"\n- Pitfalls section is mandatory — no skill ships without documented failure modes\n- If two skills overlap, merge them or call out the difference clearly\n- Skills drift — every skill has a \"last reviewed\" date; flag anything >90 days for re-review"
+    },
+    {
+      "id": "travel-itinerary-deep",
+      "name": "Plan a trip with the expensive research done first",
+      "category": "Personal",
+      "tags": [
+        "marketing",
+        "personal",
+        "research"
+      ],
+      "emoji": "✈️",
+      "description": "Plan a trip end-to-end with visa + vaccine + advisory research done first. Get a day-by-day itinerary, packing list, and budget.",
+      "works_best_with": {
+        "agent_profile": "personal-assistant",
+        "skills": [
+          "brave-search",
+          "concise-planning",
+          "pdf"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Do the visa / vaccine / advisory research first",
+        "Build a day-by-day itinerary",
+        "Shortlist lodging + transport",
+        "Generate packing + prep checklist",
+        "Output printable PDF + offline maps"
+      ],
+      "prompt": "Plan this trip end-to-end with the \"being wrong is expensive\" research done.\n\nInputs:\n- Destination(s) + dates: [paste]\n- Travelers (count, ages, mobility / dietary / medical considerations): [paste]\n- Trip style (lazy / adventure / cultural / business+leisure / etc.): [paste]\n- Budget (total, or per-person per-day): [paste]\n- Passports / citizenships in the group: [paste]\n- Non-negotiables (must-see, must-eat, must-do): [paste]\n- Pace preference (1 thing/day / packed / mix): [paste]\n\nPhase 1 — The \"expensive to get wrong\" research.\n- Visa requirements per traveler for each destination (entry stamp, e-visa, visa-on-arrival, pre-application)\n- Vaccine + health requirements (yellow fever cert, required vaccines, recommended)\n- Travel advisories for the dates (gov advisory level, recent unrest, weather hazards, monsoon / hurricane / wildfire season)\n- Travel insurance recommendation tier + 2-3 specific policies fitting the trip\n- Currency + payment landscape (cash heavy? cards widely accepted? specific apps locally dominant?)\n- SIM / eSIM options + cost\n- Power adapter type\n\nIf anything is a blocker (visa not obtainable in time, vaccine needs weeks to take effect), flag it loudly NOW.\n\nPhase 2 — Day-by-day itinerary.\nFor each day:\n- City + neighborhood you'll be in\n- Morning / afternoon / evening blocks\n- 1-2 anchor activities per block (don't over-pack)\n- Travel time between activities (realistic — include the 20 min to find an Uber, not just the drive)\n- Food: 1 specific recommendation per meal, with cuisine + price tier + walking time\n- A buffer block (90 min minimum) for downtime / weather contingency\n- Logistical notes (book the museum slot 48h ahead, the restaurant requires a reservation, this market is closed Mondays)\n\nPhase 3 — Logistics + budget.\n- Lodging: shortlist 3 per city with neighborhood logic, price, why-this-pick\n- Inter-city transport: flights / trains / ferries with realistic timings\n- Estimated budget per day per category (lodging / food / activities / transport / shopping buffer)\n- Total trip cost vs budget — if over, suggest cuts\n\nPhase 4 — Packing + prep checklist.\n- Documents (printed copies, photos in cloud)\n- Clothing for the climate at the dates + 1-2 things the climate isn't obvious about\n- Health kit specific to destinations (mosquito repellent, altitude meds, etc.)\n- Cash strategy\n\nPhase 5 — Output.\n- Polished itinerary PDF (printable + shareable)\n- 1-page \"essentials at a glance\" (addresses, confirmation numbers, emergency contacts in destination)\n- Pre-departure checklist with dates by which each item should be done (visa, insurance, etc.)\n- Offline-accessible Google Maps list of every venue mentioned\n\nFeedback signal (mid-trip, closes loop for next trip):\n- Which blocks ran long vs short — recalibrate the rest of the trip\n- Which restaurants / activities exceeded expectations — bias next city's picks toward the same source\n- Anything the research missed — capture for the next trip's planning prompt\n\nQuality bar:\n- NEVER assume visa rules from prior trips — they change. Verify against the destination's current government site.\n- NEVER recommend an activity without checking it's actually operating in the season I'm visiting\n- Cite real, current sources for the health / safety advisories — link them\n- If anything in the trip is high-risk for one of the travelers (mobility, allergy, condition), name it and recommend a swap\n- Flag every place you had to guess (lodging price during a specific event, restaurant availability) so I can verify before booking"
+    },
+    {
+      "id": "linkedin-viral-mining",
+      "name": "Mine likers of a viral LinkedIn post for outreach",
+      "category": "Lead Gen",
+      "tags": [
+        "lead-gen",
+        "sales",
+        "social"
+      ],
+      "emoji": "🪝",
+      "description": "Mine likers/commenters of a viral post. Get a scored list and DMs tied to the original post's hook.",
+      "works_best_with": {
+        "agent_profile": "marketing-agent",
+        "skills": [
+          "brave-search",
+          "playwright-mcp",
+          "concise-planning"
+        ],
+        "mcp_servers": [
+          "gmail-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Pull likers/commenters",
+        "Score by ICP fit",
+        "Find a hook tied to the post",
+        "Draft DMs and emails",
+        "Output reply-triage cheatsheet"
+      ],
+      "prompt": "Mine the people who engaged with a viral LinkedIn post and run a tight outreach round.\n\nInputs:\n- LinkedIn post URL: [paste]\n- My ICP filter (job title + company size + industry): [paste]\n- My offer + 1-line value prop: [paste]\n- Tooling: [Leadspicker / PhantomBuster / Apify LinkedIn engagement scraper]\n- Max leads this round: [default 50]\n- Send channel: [LinkedIn DM / email / both]\n\nPhase 1 — Pull engagement.\n- Use the scraper to pull every liker + commenter on the post (cap 500)\n- For each: name, role, company, location, headline, engagement type (like / comment text)\n- Show me the count before going further\n\nPhase 2 — Score for ICP fit (0-3).\n- 3 = perfect match; 2 = close; 1 = adjacent (expanded buyer / influencer); 0 = noise\n- Drop 0s. Show me the distribution and let me reject any 1s I want to skip.\n\nPhase 3 — Write the outreach.\nFor each remaining lead:\n- Open by referencing the SPECIFIC viral post (NOT \"I saw you engage with content recently\")\n- For commenters: reference what they said in 1 sentence\n- For likers: reference the post's main argument and a related question they probably care about\n- Connect their context to my offer in one sentence\n- Low-friction CTA: a question or a 15-min ask\n- <=400 chars for LinkedIn DM; <=80 words for email\n\nPhase 4 — If email is on:\n- Find a verified email via Hunter/Apollo\n- Write a parallel email with the same hook, email-appropriate length\n\nPhase 5 — Output.\n- Table: Name | Company | ICP Score | Engagement | Hook | DM | Email | Notes\n- A send order grouped by score (3s first)\n- A reply-triage cheatsheet: if reply says X, tag Y, next action Z\n\nFeedback signal:\n- Reply rate by ICP score — calibrates next threshold\n- Reply rate by engagement type (commenter vs liker) — which to prioritize\n- Which hooks landed — hook-template bank gets a winner update each round\n\nQuality bar:\n- NEVER scrape using a logged-in LinkedIn session you'd risk getting banned for\n- NEVER mass-send identical DMs — each references something specific\n- Respect LinkedIn's daily DM limits — flag if my volume would trip them\n- If the post is about a sensitive topic (layoffs, personal loss), default to declining and tell me why"
+    },
+    {
+      "id": "aaa-chatbot-demo-close",
+      "name": "Build personalized chatbot demos per prospect",
+      "category": "Lead Gen",
+      "tags": [
+        "lead-gen"
+      ],
+      "emoji": "💬",
+      "description": "Build a tailored chatbot demo per prospect. Get a live demo URL, the cold email, and a follow-up plan.",
+      "works_best_with": {
+        "agent_profile": "marketing-agent",
+        "skills": [
+          "firecrawl",
+          "playwright-mcp",
+          "concise-planning"
+        ],
+        "mcp_servers": [
+          "gmail-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Research each prospect's site + offerings",
+        "Build a tailored demo bot",
+        "Host at a personalized URL",
+        "Write the cold email with the demo link",
+        "Plan the follow-up cadence"
+      ],
+      "prompt": "Build a tailored chatbot demo for each prospect and pitch them with the live demo URL. The demo should look like it was built FOR them.\n\nInputs:\n- Prospect list (name + website URL + sector): [paste 5-20 rows]\n- My chatbot platform: [Voiceflow / Botpress / Chatbase / Stack AI / custom]\n- Hosting domain: [e.g. demo.myagency.com/<slug>]\n- Pricing: [setup fee + retainer]\n- Tone: [warm + competent local agency / sharp consultant / etc.]\n\nPhase 1 — Scope per prospect.\n- Crawl each prospect's website: services, hours, FAQ, contact form, common questions\n- Identify the SINGLE highest-value bot use case:\n  - Dentist → appointment booking + insurance question deflection\n  - Plumber → emergency dispatch routing + quote intake\n  - Restaurant → reservation + dietary FAQ\n- Show me your picks before building. Wait for confirmation.\n\nPhase 2 — Build the demo.\n- Take brand colors and logo from their site (if visible)\n- Configure with 5-10 of their actual FAQ questions and answers\n- Wire the high-value intent (booking) to a fake-but-realistic flow\n- Embed at a personalized URL: demo.myagency.com/<prospect-slug>\n- Test every intent end-to-end before declaring it ready\n\nPhase 3 — Cold email per prospect.\n- Subject (<=6 words): \"<prospect-name>, built you a demo\"\n- Body (<=120 words):\n  - \"I built a demo of an AI assistant for your <type of business>\"\n  - One specific thing it handles (\"books appointments without calling the front desk\")\n  - Live link: <demo URL>\n  - \"If it's useful, 15 min to talk through what it'd take to deploy?\"\n- Sign-off + signature\n\nPhase 4 — Follow-up plan.\n- T+3 days: \"did you get a chance to try the demo? happy to walk you through it\"\n- T+7 days: case study from a similar business + a specific metric\n- T+14 days: honest breakup, leave the demo URL live for 30 more days\n\nPhase 5 — Output.\n- Each demo deployed and tested\n- CSV: prospect | sector | demo URL | email subject | email body | follow-up 1 | follow-up 2 | breakup\n- Demo retention check: alert me which demos got >0 sessions in the first 72h — those are hot leads\n\nFeedback signal:\n- Demo open rate (subject A/B), session rate, demo-to-call conversion\n- Which sectors close at what price point — feed back into next prospect list\n\nQuality bar:\n- NEVER fabricate hours, prices, or services — only what's on the public site\n- NEVER claim \"AI knows everything about your business\" — set realistic expectations\n- Mark the demo with a small \"demo built by <my agency>\" footer\n- If a site blocks iframes, deliver as a hosted page link"
+    },
+    {
+      "id": "local-seo-smb",
+      "name": "Run local SEO domination for a small business",
+      "category": "Lead Gen",
+      "tags": [
+        "lead-gen",
+        "seo"
+      ],
+      "emoji": "📍",
+      "description": "Audit local SEO and ship the wins. Get a GMB plan, citation gaps, schema, and a review-response system.",
+      "works_best_with": {
+        "agent_profile": "marketing-agent",
+        "skills": [
+          "brave-search",
+          "firecrawl",
+          "concise-planning",
+          "pdf"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Audit GMB + NAP consistency + schema",
+        "Plan GMB posts + photos + Q&A",
+        "Find citation gaps vs competitors",
+        "Build a review-response system",
+        "Ship schema markup for the site"
+      ],
+      "prompt": "Run a local-SEO domination round for an SMB.\n\nInputs:\n- Business name + address + phone + website: [paste]\n- Service area or primary location: [paste]\n- 3-5 top local competitors: [paste with URLs]\n- Industry: [paste]\n- Current local rank for top 3 queries: [paste or \"unknown\"]\n- Existing GMB profile URL: [paste]\n\nPhase 1 — Audit.\n- GMB completeness: categories, services, attributes, hours, photos, posts, Q&A\n- NAP (Name/Address/Phone) consistency across top 10 citation sources (Yelp, BBB, Yellow Pages, industry-specific)\n- Review profile: count, recent volume, response rate, sentiment\n- Google Maps rank for top 5 queries from 3-5 grid points around the service area\n- Schema markup on the website (LocalBusiness, Service, Review, FAQ)\n- Mobile page speed (Google's #1 local ranking factor)\n\nPhase 2 — GMB optimization plan.\n- Primary category + 4 secondary\n- Services matched to what competitors are ranking for\n- 10 GMB Posts for the next 30 days (offers, events, products) with image briefs\n- 20 Q&As to seed (with answers — ranking signal)\n- Photo upload schedule (2-3/week with what to shoot)\n\nPhase 3 — Citation gaps.\n- Sources where competitors are listed and you aren't\n- Industry-specific citations (e.g., dentists → Healthgrades, plumbers → Angi)\n- A NAP standardization sheet so the next 50 citations match\n\nPhase 4 — Review-response system.\n- Templates for 5-star (thank, name a specific thing, soft CTA to return)\n- Templates for negative (acknowledge, offer to make it right offline, never argue publicly)\n- Outreach to get 10 new reviews this month (specific past customers + the ask script)\n\nPhase 5 — Output.\n- Audit PDF\n- 30-day GMB plan\n- Citation submission checklist (sorted by traffic)\n- Review templates + outreach scripts\n- Schema markup code ready to drop into the site\n\nFeedback signal:\n- Local rank delta on target queries (grid view monthly)\n- GMB call / direction clicks delta\n- Review count + average rating trajectory\n\nQuality bar:\n- NEVER buy reviews — Google detects and de-ranks\n- NEVER use a virtual office address — GMB requires real service-area or staffed location\n- Schema must validate (Google Rich Results Test)\n- Don't keyword-stuff GMB business name — that's a violation"
+    },
+    {
+      "id": "cold-call-disposition-loop",
+      "name": "Re-score the cold-call list on yesterday's dispositions",
+      "category": "Sales",
+      "tags": [
+        "loop",
+        "marketing",
+        "sales"
+      ],
+      "emoji": "☎️",
+      "description": "Re-score the call list using yesterday's dispositions. Get a connect-tuned dial order and a talk-track A/B.",
+      "works_best_with": {
+        "agent_profile": "bd-partnerships",
+        "skills": [
+          "concise-planning"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Pull yesterday's call log",
+        "Tag dispositions + patterns",
+        "Re-score leads (connect prob × ICP)",
+        "Reorder today's call queue",
+        "Suggest a talk-track A/B"
+      ],
+      "prompt": "Use yesterday's cold-call dispositions to reorder today's call list for the highest connect rate.\n\nInputs:\n- Yesterday's call log (CSV: lead_id, name, company, time_called, disposition): [paste]\n- Today's available list (CSV: lead_id, name, company, phone, time_zone, ICP score): [paste]\n- Dial windows today: [e.g. 9-11am, 1-3pm local time]\n- Disposition codes I use: [CONNECT_INTERESTED / CONNECT_NOT_NOW / VOICEMAIL / NO_ANSWER / WRONG_NUMBER / DNC]\n- Talk-track variants tested yesterday: [paste]\n\nPhase 1 — Yesterday's analysis.\n- Connect rate by hour of day in their time zone\n- Connect rate by ICP score\n- Top 3 patterns from CONNECT_INTERESTED calls (what did they say first? top objection?)\n- Patterns from CONNECT_NOT_NOW — real \"not nows\" or polite blowoffs?\n\nPhase 2 — Re-score today's list.\n- Predicted connect probability from yesterday's hour-of-day data + their time zone\n- ICP score (re-use if available)\n- Dial priority = connect_prob × ICP_fit\n- Reorder by dial priority within each dial window\n\nPhase 3 — Talk-track A/B.\n- Variant A: yesterday's best-performing opener (carry forward)\n- Variant B: a hypothesis based on what objection killed deals yesterday\n- Split 50/50\n\nPhase 4 — Output.\n- CSV: time_window | lead | phone | dial_priority | talk_track_variant\n- 3-bullet summary for the team\n- A \"do not dial today\" list (DNCs, dead numbers from yesterday, leads on snooze)\n\nFeedback signal (end of today):\n- Did dial priority correlate with connect rate? (validates the model)\n- Which talk-track variant won? Promote to default.\n- Which window had highest connect per ICP segment? Pin for tomorrow.\n\nQuality bar:\n- Never queue a DNC lead — re-check the scrub\n- Never auto-dial outside permitted hours by jurisdiction\n- If yesterday's sample is <20 calls, don't pretend to find a pattern — say so\n- Tag any lead with 3 consecutive NO_ANSWER as \"rest\" for 2 weeks"
+    },
+    {
+      "id": "sales-call-to-crm",
+      "name": "Turn a sales call recording into a CRM update",
+      "category": "Sales",
+      "tags": [
+        "sales"
+      ],
+      "emoji": "🎧",
+      "description": "Turn a sales call into a CRM update + next-step tasks + follow-up email. Get a clean stage move and ready-to-paste notes.",
+      "works_best_with": {
+        "agent_profile": "bd-partnerships",
+        "skills": [
+          "concise-planning",
+          "vale-brand-voice"
+        ],
+        "mcp_servers": [
+          "gmail-mcp",
+          "notion-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Read transcript and structure",
+        "Update the CRM record",
+        "Build the next-step task list",
+        "Draft the follow-up email",
+        "Output an internal manager note"
+      ],
+      "prompt": "Turn a sales call recording into a CRM update + a next-step task list + a follow-up email.\n\nInputs:\n- Call recording or Gong/Fathom/Otter transcript: [paste]\n- Deal/account ID + opportunity: [paste]\n- Buying committee from CRM (titles + names): [paste]\n- Our methodology (MEDDIC / SPICED / CHAMP): [paste]\n- Tone for follow-up email: [paste]\n\nPhase 1 — Read and structure.\n- Identify speakers; reconcile against the buying committee\n- Extract: pains discussed, objections raised, decisions made, commitments by either side, timing signals\n- Surface explicit and implicit blockers (champion missing, exec sponsor undisclosed)\n\nPhase 2 — Update the CRM record.\n- Suggested stage move (advance/hold/regress with one-sentence reason)\n- Updates per MEDDIC field (or your methodology): metrics, economic buyer, decision criteria, decision process, identify pain, champion\n- Risks: flag anything that lowers close probability\n- Suggested next stage gate\n\nPhase 3 — Next-step list.\n- Tasks for me (action, owner, deadline, why)\n- Tasks for the prospect (we send the proposal by X, you send IT review by Y)\n- Internal asks (need legal review, need SE for demo)\n\nPhase 4 — Follow-up email.\n- Subject (<=8 words): reference the specific commitment from the call\n- Body (<=200 words): recap, action items with owners + dates, one open question that earns a reply\n- Attach anything they asked for\n- Send-or-schedule recommendation\n\nPhase 5 — Output.\n- CRM diff (markdown) ready to paste into the deal\n- Task list (CSV) ready to import\n- Email draft (markdown)\n- A 1-paragraph internal note for sales manager / RevOps\n\nFeedback signal:\n- Did the stage move match what actually happened?\n- Which methodology slots were consistently empty after first call — refine the discovery script\n- Email reply rate per follow-up template — promote the winning structure\n\nQuality bar:\n- Never invent commitments or pains that weren't said\n- Cite timestamps for any direct quote\n- Mark anything \"low confidence — verify\" if the call was muddy\n- Never auto-send the follow-up — drafts only"
+    },
+    {
+      "id": "amazon-listing-optimizer",
+      "name": "Optimize an Amazon listing end-to-end",
+      "category": "E-commerce",
+      "tags": [
+        "ecommerce",
+        "real-estate",
+        "seo"
+      ],
+      "emoji": "📦",
+      "description": "Optimize an Amazon listing with keyword research + review mining. Get title, bullets, A+ brief, and backend keywords.",
+      "works_best_with": {
+        "agent_profile": "marketing-agent",
+        "skills": [
+          "brave-search",
+          "firecrawl",
+          "concise-planning"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Pull keyword research + competitor SERP",
+        "Mine reviews for voice + objections",
+        "Write title, bullets, A+ brief",
+        "Tune backend search terms",
+        "Output a before/after diff"
+      ],
+      "prompt": "Optimize my Amazon listing end-to-end with keyword research and review mining.\n\nInputs:\n- My ASIN + 3-5 competitor ASINs in the same niche: [paste]\n- Target marketplace: [US / UK / DE / JP / etc.]\n- Brand voice notes: [paste]\n- Current listing performance (sessions / conversion / revenue if available): [paste]\n- Constraints: [trademarked terms to use, brand registry status, A+ access yes/no]\n\nPhase 1 — Keyword research.\n- Pull top search terms from Helium 10 / Jungle Scout / Brand Analytics for the niche\n- Intent tiers: head (high volume, hard rank), torso (mid), long-tail (specific buyers)\n- Cross-reference with competitor titles — what keywords are they ranking on?\n- Output a ranked keyword list with monthly search volume and competition score\n\nPhase 2 — Review mining for voice + objections.\n- Pull last 500 reviews across my ASIN + competitors\n- Cluster positive reviews by what buyers loved (use their exact phrases)\n- Cluster negative reviews by what disappointed buyers\n- Identify the top 3 \"objections to overcome\" my listing must address\n\nPhase 3 — Write the listing.\n- Title: front-load with the highest-volume relevant keyword. Pattern: [Brand] + [Product] + [Key Feature] + [Use Case] + [Variant] within Amazon's character limit\n- 5 bullets: lead each with a benefit IN ALL CAPS THEN a sentence. First bullet handles the #1 objection. Last bullet handles brand/warranty trust.\n- A+ content brief: 5-7 modules (hero with overlay, 3-feature comparison, FAQ, brand story, social proof, related products)\n- Backend search terms: 250-byte limit, no duplicates, no competitor brand names\n\nPhase 4 — Output.\n- Title (counted)\n- 5 bullets ready to paste\n- A+ content module brief (text + image directions per module)\n- Backend keywords (formatted to byte count)\n- A before/after diff showing the key changes\n\nFeedback signal (after 30 days):\n- Session-to-purchase conversion delta\n- Search-term performance: which keywords now have impressions / clicks\n- Review themes — did the new bullets address the objections?\n\nQuality bar:\n- NEVER use prohibited terms (Amazon's flagged words: performance claims, medical claims, etc.)\n- NEVER copy competitor brand names into title or backend\n- Every claim has a supporting feature in the listing — no marketing-only fluff\n- A+ content must work for buyers on mobile — short text, big images"
+    },
+    {
+      "id": "shopify-bulk-descriptions",
+      "name": "Generate Shopify product descriptions in bulk",
+      "category": "E-commerce",
+      "tags": [
+        "ecommerce",
+        "sales",
+        "seo"
+      ],
+      "emoji": "🏷️",
+      "description": "Generate SEO product descriptions for a Shopify catalog. Get titles, descriptions, meta, tags, and alt text per SKU.",
+      "works_best_with": {
+        "agent_profile": "content-creator",
+        "skills": [
+          "concise-planning",
+          "vale-brand-voice"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Audit the SKU batch",
+        "Generate listings per template",
+        "Voice-consistency pass",
+        "Export ready-to-import CSV",
+        "Flag SKUs needing human input"
+      ],
+      "prompt": "Generate product descriptions for a batch of Shopify SKUs.\n\nInputs:\n- Shopify catalog export (CSV with SKU, current title, current description, category, key attributes): [paste]\n- Brand voice + tone notes: [paste or link]\n- Target audience: [paste]\n- SEO keyword strategy (head terms per category): [paste]\n- Batch size this run: [default 50 SKUs]\n\nPhase 1 — Audit the batch.\n- For each SKU: identify what's missing (no description, generic copy, no meta, no alt text)\n- Categorize by template (apparel / home / electronics / etc.)\n- Flag any SKU with insufficient data — needs human input first\n\nPhase 2 — Per-SKU generate.\nFor each:\n- Title (<=70 chars): brand + product + key attribute + variant\n- Product description (200-350 words):\n  - Lead with the transformation (what the buyer gets, not what the product is)\n  - 3 feature/benefit blocks (concrete)\n  - Specs section (bullet list, scannable)\n  - Closing line that earns the add-to-cart click\n- SEO meta description (<=155 chars)\n- 5 image alt-text strings tied to specific product shots\n- 5-7 relevant tags\n\nPhase 3 — Voice consistency check.\n- Sample 5 random outputs back-to-back — do they sound like the same brand?\n- Strip AI-slop: \"elevate\", \"discover\", \"introducing\", \"unleash\", \"transform your\"\n\nPhase 4 — Output.\n- Updated CSV ready to import to Shopify\n- A \"needs human input\" CSV for the flagged SKUs\n- Sample preview (3 randomly chosen SKUs) for spot-checking\n\nFeedback signal:\n- Which categories saw the highest conversion lift post-update\n- Which AI phrasings buyers complained about in reviews — bake into the ban list\n- Top-converting product pages — which structure did they share?\n\nQuality bar:\n- NEVER invent specs or materials — only what's in the input data\n- Match Shopify SEO best practices (length, structure)\n- One unique angle per product — don't pattern-match identical openers across the catalog\n- If the input data is too sparse for a product, flag it — don't fill with fluff"
+    },
+    {
+      "id": "print-on-demand-launch",
+      "name": "Launch a print-on-demand niche",
+      "category": "Side Hustle",
+      "tags": [
+        "ecommerce",
+        "side-hustle"
+      ],
+      "emoji": "👕",
+      "description": "Pick a POD niche and launch 10 designs. Get a niche brief, design briefs, listings, and a 30-day publishing plan.",
+      "works_best_with": {
+        "agent_profile": "marketing-agent",
+        "skills": [
+          "brave-search",
+          "brainstorming",
+          "concise-planning"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Propose 3 niche options + recommend one",
+        "Brief 10 designs in the chosen niche",
+        "Write listings for each design",
+        "Plan a steady-cadence publishing schedule",
+        "Define winners/killers in feedback"
+      ],
+      "prompt": "Launch a print-on-demand niche end-to-end.\n\nInputs:\n- POD platform: [Printify / Printful / Redbubble / TeePublic / Merch by Amazon]\n- Storefront: [Shopify / Etsy / Amazon / direct on POD platform]\n- My skills + interests (be honest): [paste]\n- Budget for design tools + ads: [budget — $0 is OK]\n- Time per week: [hours]\n\nPhase 1 — Niche brief. Wait for approval before designing.\n\nPropose 3 niche options. For each:\n- Specific niche in one sentence (\"nursing-specialty humor for night-shift ER nurses\" NOT \"nurse t-shirts\")\n- Why it has demand: cite 3-5 existing TeePublic/Redbubble/Etsy listings with seller name + sales rank / review count\n- Why it's not over-saturated: estimated seller count + design freshness\n- Smallest viable v1: 10 designs in one product format\n- Realistic price + commission per sale\n\nRecommend one. Explain why. Wait for confirmation.\n\nPhase 2 — Design briefs (10 designs).\nFor each:\n- Concept in one sentence (the joke / sentiment / visual hook)\n- Layout (text-only / text+illustration / visual-only)\n- Color palette (specific hex codes)\n- Typography direction (sans / serif / handwritten — name the font family)\n- Reference style (\"Sarah Lawrence Press meets Smitten Kitchen\") — pick artists / brands the designer would know\n- Variant suggestions (mug / sticker / poster)\n\nPhase 3 — Listings.\nFor each design:\n- Title pattern (front-loaded keyword + niche tag + emotion + variant)\n- Tag list (Etsy: 13 tags max, mix head + long-tail)\n- Description (300 words): hook, who it's for, what's printed where, gift-giving angle, care instructions\n- Pinterest pin caption + 5 hashtags\n\nPhase 4 — Output.\n- Niche brief PDF\n- 10 design briefs (markdown)\n- 10 listings ready to paste\n- A 30-day publishing schedule (don't dump all 10 at once — Etsy/POD favors steady cadence)\n\nFeedback signal (after 30 days):\n- Per-design sales — which earned out the design time\n- Search terms that led to clicks — bias future title patterns\n- Refund rate or complaint themes — adjust quality / fulfillment partner\n\nQuality bar:\n- NEVER plagiarize existing designs — original concepts only\n- NEVER use trademarked phrases (sports team names, brand slogans, lyrics, character names)\n- Test each design as a low-cost variant (mug or sticker) before committing to expensive variants (hoodie)\n- Cite inspiration listings so I can verify they're not direct competitors"
+    },
+    {
+      "id": "faceless-youtube-pipeline",
+      "name": "Run a faceless YouTube content pipeline",
+      "category": "Side Hustle",
+      "tags": [
+        "content",
+        "side-hustle",
+        "video"
+      ],
+      "emoji": "📺",
+      "description": "Run a faceless YouTube pipeline. Get topic research, scripts, voiceover briefs, b-roll lists, and a 30-day schedule.",
+      "works_best_with": {
+        "agent_profile": "content-creator",
+        "skills": [
+          "brave-search",
+          "brainstorming",
+          "concise-planning"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Research topics with high views-per-day",
+        "Script the next 4 videos",
+        "Brief voiceover + music + b-roll",
+        "Plan titles, thumbnails, distribution",
+        "Schedule across 30 days"
+      ],
+      "prompt": "Produce a faceless YouTube content pipeline.\n\nInputs:\n- Niche + value prop: [paste]\n- Target audience: [age, interests, watch context]\n- Style: [calm-explainer / energetic-edutainment / mysterious-narrative / data-heavy]\n- Channel goal: [ad revenue / affiliate / lead-gen for a paid product]\n- Production stack: [ElevenLabs voice / Suno music / Midjourney/Runway visuals / editor style]\n- Posting cadence: [3/week / daily / 2 long + 5 shorts]\n- 5 top performers in your niche to learn from: [list]\n\nPhase 1 — Topic research.\n- Pull top 50 videos in the niche from the last 90 days, ranked by views-per-day-since-upload\n- Identify title patterns + thumbnail patterns + length sweet spots\n- Surface 10-15 highest-leverage topic angles for THIS channel\n\nPhase 2 — Script the next 4 videos.\nFor each:\n- Hook (first 15 seconds — the curiosity gap or stakes setup)\n- Outline (5-9 beats)\n- Full script in spoken voice (target ~150 words/min)\n- Length target (matches the niche's sweet spot)\n- B-roll list: scene-by-scene, what visual goes where (stock / AI-generated / motion graphic)\n- On-screen text callouts\n- Thumbnail brief: composition, big text overlay (max 4 words), emotion cue\n\nPhase 3 — Voiceover + music brief.\n- Voice character (ElevenLabs voice ID + speed + emotion)\n- BGM type + intensity curve (calm intro → build → punchline → outro)\n- SFX cues at key moments (whoosh on transitions, ding on big claims)\n\nPhase 4 — Distribution.\n- Title A/B options (2 per video)\n- Description (200-300 words, keyword-rich, links to affiliate or signup)\n- Tags (15-20)\n- Pinned-comment hook to drive engagement\n- Community-tab teaser for the upcoming video\n\nPhase 5 — 30-day schedule + output.\n- Publishing calendar across the cadence\n- Per-video brief packaged as PDF for the editor\n\nFeedback signal (closes the loop):\n- Per video: CTR, AVD, subscribers gained — feed back into next batch's title + hook + length\n- Topic clusters that overperform — double down\n- Topics where retention crashes after 30 sec — kill the pattern\n\nQuality bar:\n- Every claim in the script must be defensible — no invented stats\n- Original take per video — don't just rewrite the top-ranking video\n- Disclose AI voice / AI imagery in description per platform rules\n- Never plagiarize visuals — use licensed stock, your own, or AI-generated only"
+    },
+    {
+      "id": "pinterest-affiliate-pins",
+      "name": "Batch 30 Pinterest pins for an affiliate niche",
+      "category": "Side Hustle",
+      "tags": [
+        "side-hustle",
+        "social"
+      ],
+      "emoji": "📌",
+      "description": "Batch 30 Pinterest affiliate pins. Get titles, image briefs, alt text, and a daily posting schedule.",
+      "works_best_with": {
+        "agent_profile": "content-creator",
+        "skills": [
+          "brainstorming",
+          "concise-planning"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Keyword research for the niche",
+        "Write 30 pin titles + descriptions",
+        "Build 5-6 reusable image templates",
+        "Schedule across 30 days",
+        "Promote winners"
+      ],
+      "prompt": "Batch-generate Pinterest affiliate pins for a niche.\n\nInputs:\n- Affiliate niche + program (Amazon Associates / ShareASale / specific brand): [paste]\n- Target audience demographic (Pinterest skews female 25-45): [paste]\n- Brand voice for captions: [paste]\n- Image creation tool: [Canva / Midjourney / Recraft / etc.]\n- Posting tool: [Tailwind / Pinterest scheduler]\n\nPhase 1 — Keyword research.\n- Identify 30 search terms in your niche with Pinterest monthly searches >5000 (use Pinterest Trends + Predis)\n- Tier by intent: discovery (browsing) / consideration (comparing) / decision (buying)\n- Map each keyword to an existing affiliate product\n\nPhase 2 — Pin titles + captions.\nFor each of 30 pins:\n- Title (35-100 chars, front-loaded with the search keyword)\n- Description (200-500 chars): hook + value-prop + soft CTA + 5 hashtags\n- Image style brief: layout (text-heavy / split-image / before-after / list-style), color palette (Pinterest-friendly: cream, sage, terracotta, etc.), typography pair, exact text overlay\n- Alt text (real accessibility, not keyword stuffing)\n- Destination URL with affiliate tag\n\nPhase 3 — Image briefs grouped by template.\n- Group pins by visual template (5-6 templates) so Canva can reuse the design\n- Per template: dimensions (Pinterest favors 2:3), template name, color/typography spec, what's interchangeable per pin\n\nPhase 4 — Schedule.\n- 1-2 pins/day for 30 days (Pinterest favors steady cadence over bursts)\n- Mix board destinations (don't post 30 pins to one board)\n- Idea Pins vs static pins ratio (Pinterest now favors Idea Pins)\n\nPhase 5 — Output.\n- Pin CSV: title | description | board | image template | destination URL | alt text\n- 5-6 Canva-ready image briefs\n- 30-day Tailwind schedule (CSV)\n\nFeedback signal:\n- Per pin: impressions / saves / outbound clicks — promote winners\n- Template-level: which design template gets the most saves — bias next batch\n- Click-through to affiliate sale: which keyword tiers actually convert (discovery rarely does)\n\nQuality bar:\n- NEVER overlay text claims you can't substantiate (\"#1 in 2026\", \"doctor-recommended\")\n- Disclose affiliate status per FTC + Pinterest rules\n- NEVER use other creators' images without licensing\n- Every pin description offers value, not just a sale push"
+    },
+    {
+      "id": "affiliate-review-site",
+      "name": "Run an affiliate review-site content engine",
+      "category": "Side Hustle",
+      "tags": [
+        "content",
+        "seo",
+        "side-hustle"
+      ],
+      "emoji": "🌐",
+      "description": "Run a niche affiliate review-site engine. Get keyword clusters, post outlines, drafts, and an internal-link map.",
+      "works_best_with": {
+        "agent_profile": "content-creator",
+        "skills": [
+          "brave-search",
+          "firecrawl",
+          "concise-planning",
+          "vale-brand-voice"
+        ],
+        "mcp_servers": [
+          "notion-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Map keyword clusters into pillar + supporting",
+        "Outline 10 posts (money + traffic mix)",
+        "Draft each post with honest reviews",
+        "Audit internal links + orphans",
+        "Schedule the publishing cadence"
+      ],
+      "prompt": "Build a niche affiliate review-site content pipeline.\n\nInputs:\n- Niche + 3 high-commission affiliate programs: [paste]\n- Domain age + current monthly traffic: [paste]\n- Existing top posts (if any): [paste]\n- Posting cadence: [2/week / 4/week / 1/day]\n- Brand voice (genuine reviewer / authority / casual buddy): [paste]\n- Disclosure block to include: [paste — FTC compliant]\n\nPhase 1 — Keyword cluster mapping.\n- Pull 100-300 keywords for the niche (Ahrefs / Semrush / KWFinder)\n- Cluster into pillar pages + supporting pages (topical authority)\n- Per cluster: 1 pillar (comprehensive) + 5-10 supporting (specific buying / comparison / how-to)\n- Identify \"money pages\" (high commercial intent) vs \"traffic pages\" (informational that funnels to money pages)\n\nPhase 2 — Outline 10 posts this round (mix money + traffic).\nFor each:\n- Post type (best-of list / vs comparison / single product review / how-to / buyer guide)\n- Target word count + structure\n- Internal-link plan (which other posts link in/out)\n- Affiliate product mapping (which products / where in the post)\n- Featured-snippet opportunity (table / list / definition box)\n\nPhase 3 — Draft each post.\n- Open with the reader's question (no \"in today's fast-paced world\")\n- TL;DR / verdict at the top for impatient readers\n- Use the products you'd actually recommend — never push the highest commission\n- Include screenshots or original photos where possible (cite if you can't)\n- Strong final CTA tied to the affiliate link\n\nPhase 4 — Internal-link audit.\n- Map every published post → which new posts should link to it\n- Identify orphan posts (no incoming internal links) and fix\n- Update the pillar page to link out to the new supporting posts\n\nPhase 5 — Output.\n- 10 publish-ready posts (markdown)\n- Internal-link map (CSV: source post → target post)\n- A publishing schedule across the cadence\n\nFeedback signal:\n- Per post: organic traffic, time on page, clicks to affiliate, conversions\n- Cluster-level: which clusters earned out the content investment in 90 days\n- Search Console queries you didn't target but ranked for — add to next batch\n\nQuality bar:\n- NEVER promote a product you wouldn't recommend to a friend — readers smell it\n- Always include the cheapest \"good enough\" option, not just the highest-commission pick\n- Include real cons for every product, not \"the only drawback is...\"\n- Disclosure block on every post; per FTC + Amazon Associates rules\n- Don't fake \"tested\" claims — say \"based on reviewer consensus\" if you didn't test"
+    },
+    {
+      "id": "dtc-ugc-ad-producer",
+      "name": "Produce DTC UGC ad variants for paid social",
+      "category": "Marketing",
+      "tags": [
+        "marketing",
+        "social",
+        "video"
+      ],
+      "emoji": "🎬",
+      "description": "Produce UGC ad variants for DTC. Get 10 hooks, 5 full scripts, shot lists, and a 7-day testing plan.",
+      "works_best_with": {
+        "agent_profile": "marketing-agent",
+        "skills": [
+          "brainstorming",
+          "concise-planning",
+          "vale-brand-voice"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Generate 10 hooks across 10 patterns",
+        "Pick 5 to write full scripts for",
+        "Brief shot lists per script",
+        "Plan a 7-day budget split + kill rules",
+        "Promote winners into the next batch"
+      ],
+      "prompt": "Produce DTC UGC ad variants ready for paid social.\n\nInputs:\n- Brand + product (link to product page): [paste]\n- Target ad platforms: [Meta / TikTok / YouTube Shorts]\n- Audience persona (be specific): [paste]\n- Brand voice + visual guidelines: [paste]\n- Avatar/creator: [HeyGen avatar ID / real creator / Arcads]\n- Hook framework to lean into: [problem-agitate-solve / before-after / contrarian / testimonial / unboxing]\n- Daily ad spend (so I know how many creatives we need): [paste]\n\nPhase 1 — Hook library (10 hooks, 10 patterns).\n- Pattern interrupt (\"Stop scrolling if you...\")\n- Vulnerability (\"I was embarrassed to admit...\")\n- Contrarian (\"Everyone says X. They're wrong.\")\n- Stakes (\"This $X mistake cost me Y\")\n- Curiosity gap (\"The reason this works isn't what you think\")\n- Identity (\"If you're the type of person who...\")\n- Stat (\"X% of people don't realize...\")\n- POV demo (\"Watching me use this for the first time\")\n- Q&A (\"Why does this work so well?\")\n- Authority (\"After 3 years of trying everything\")\n\nFor each: the first 3 seconds verbatim + on-screen text.\n\nPhase 2 — Full scripts (pick 5 winning hooks).\nFor each:\n- 30-second + 60-second versions\n- Beat structure: hook → problem → solution intro → demo → proof → CTA\n- Visual cues per beat (what's on screen, gestures, camera angle)\n- On-screen text overlays at key moments\n- CTA: specific (X% off / use code Y) — never generic \"link in bio\"\n\nPhase 3 — Shot list per script.\n- Locations (kitchen / bedroom / street / etc.)\n- Props\n- Wardrobe direction\n- B-roll needed\n- Music vibe\n\nPhase 4 — 7-day testing plan.\n- Day 1-3: launch all 5 with equal small budget ($X/day each)\n- Day 4: kill bottom 2 by CPA\n- Day 5-7: scale top 2 by 20%/day, draft 3 fresh hooks based on what won\n- Track per platform: CTR, hold rate at 3s, hook rate at 15s, CPA\n\nPhase 5 — Output.\n- 10 hooks + 5 full scripts (markdown)\n- 5 shot lists ready for HeyGen / creator / Arcads\n- A 7-day testing schedule + reporting template\n\nFeedback signal (closes after 7 days):\n- Winning hook patterns this week — bake into the hook library\n- Hooks that consistently fail — drop from rotation\n- Platform-specific: which hook style works for Meta vs TikTok vs Shorts\n\nQuality bar:\n- NEVER make medical, financial, or income claims you can't substantiate\n- NEVER use copyrighted music in ads\n- Disclose paid partnership per platform rules\n- If using a real creator, get written consent for the script + usage terms"
+    },
+    {
+      "id": "ppc-ad-variant-factory",
+      "name": "Generate PPC ad copy variants for testing",
+      "category": "Marketing",
+      "tags": [
+        "loop",
+        "marketing"
+      ],
+      "emoji": "🧪",
+      "description": "Generate PPC ad copy variants across hypothesis dimensions. Get 15 variants tagged for clean attribution.",
+      "works_best_with": {
+        "agent_profile": "marketing-agent",
+        "skills": [
+          "brainstorming",
+          "concise-planning"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Read the current best ad",
+        "Generate 15 variants across 5 hypotheses",
+        "Spec the testing rig + kill rules",
+        "Output platform-ready CSV",
+        "Feedback into next round"
+      ],
+      "prompt": "Generate PPC ad copy variants for systematic testing.\n\nInputs:\n- Product + landing page: [paste URL]\n- Audience persona: [paste]\n- Platform: [Meta Ads / Google Ads / LinkedIn Ads / TikTok Ads]\n- Current best-performing ad (for benchmark): [paste copy + metrics]\n- Budget per variant: [paste]\n- Hypothesis dimensions to test: [hook / offer / proof / CTA / objection]\n\nPhase 1 — Performance read of current best.\n- Why this ad is winning (which hook is doing the work)\n- Risk: which dimension is most likely to plateau (audience saturation)\n- Surface 2-3 untested dimensions\n\nPhase 2 — 15 variants across 5 hypotheses.\n- 3 variants testing the HOOK (same offer, different opener)\n- 3 variants testing the OFFER (same hook, different incentive — % off, BOGO, free shipping, money-back)\n- 3 variants testing the PROOF (same offer, different social proof — review count, expert quote, before-after, press)\n- 3 variants testing the CTA (same body, different action — buy, learn, try free, save)\n- 3 variants testing the OBJECTION (same offer, different addressed objection — price, fit, quality, timing)\n\nFor each:\n- Headline (per platform's character limit)\n- Primary text (per platform's char limit)\n- Description (Google) or first-line hook (Meta)\n- Image/video direction (one sentence)\n- The hypothesis being tested\n\nPhase 3 — Testing rig.\n- Recommended budget split (typically equal for first 48h)\n- Statistical-significance threshold (don't kill ads early; minimum spend or impressions)\n- Kill rules (CPA above X, CTR below Y)\n\nPhase 4 — Output.\n- CSV ready to import (per platform format)\n- A \"why this variant\" note column for the marketing team\n- A pre-launch checklist (UTMs, pixel, landing-page match)\n\nFeedback signal (after 7 days):\n- Which hypothesis dimension moved CPA the most — focus next batch there\n- Which combinations interact (winning hook + winning CTA together)\n- Audience fatigue signal (impression frequency >2 with falling CTR)\n\nQuality bar:\n- NEVER make claims you can't substantiate (income, weight loss, medical)\n- One variable per variant for clean attribution\n- Match the landing-page copy to the ad's promise — message-match drives CR\n- Disclose any required information per platform (housing, employment, credit) policies"
+    },
+    {
+      "id": "sales-page-long-form",
+      "name": "Write a long-form sales page that converts",
+      "category": "Sales",
+      "tags": [
+        "sales",
+        "side-hustle"
+      ],
+      "emoji": "📜",
+      "description": "Write a long-form sales page for a course or info-product. Get hero, agitation, mechanism, offer, FAQ, and CTA stack.",
+      "works_best_with": {
+        "agent_profile": "marketing-agent",
+        "skills": [
+          "concise-planning",
+          "vale-brand-voice",
+          "pdf"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Structure the 12 page sections",
+        "Write each section with care",
+        "A/B alternates for hero + CTA",
+        "Trust-killer audit",
+        "Output as markdown + builder import"
+      ],
+      "prompt": "Write a long-form sales page that converts.\n\nInputs:\n- Product / offer + price: [paste]\n- Target buyer (specific): [paste]\n- Transformation (where they are now → where they'll be): [paste]\n- 3-5 buyer objections you hear most: [paste]\n- Social proof you have (testimonials, case studies, results): [paste]\n- Brand voice + tone (warm-advisor / sharp-coach / no-BS-operator): [paste]\n- Existing sales page (for context, if rewriting): [paste]\n\nPhase 1 — Structure the page (12 sections in order).\n1. Hero: pre-headline + headline + sub + CTA above the fold\n2. Problem: who you serve + the pain you fix (no vague \"struggling with...\")\n3. Agitation: what happens if they don't fix this\n4. Story / mechanism: why this product works (your unique angle)\n5. Offer: what's included, line by line\n6. Bonuses: 2-3 stackable bonuses, each with a perceived value\n7. Pricing: anchor + final price + payment options\n8. Guarantee: specific, time-bound, no-fine-print\n9. Social proof block: 5-10 testimonials with names + outcomes\n10. FAQ: handles every objection from the input\n11. Final CTA stack: 2-3 CTAs with different angles\n12. P.S.: the one thing they should remember\n\nPhase 2 — Write each section.\n- Hero headline: outcome + timeframe + how it works (\"X without Y in Z weeks\")\n- Problem: name the buyer's situation in their own words\n- Agitation: vivid scenes of what happens if they don't fix it\n- Mechanism: your unique angle on why this works (not just \"AI\" or \"proven\")\n- Offer: each line item gets a benefit, not just a feature\n- Guarantee: name the specific outcome and the refund mechanic\n- FAQ: answer the buyer's question, then handle the implicit objection underneath\n\nPhase 3 — Output.\n- Full sales page as a markdown block\n- 3 headline alternatives for A/B\n- 2 hero CTAs for A/B\n- A landing-page builder import (if I'm using ConvertKit / Carrd / etc.)\n- A \"trust-killers\" audit: anything in the page that would lose a skeptical reader\n\nFeedback signal:\n- Conversion rate vs baseline\n- Where readers drop off (scroll-depth + heatmap) — restructure\n- Refund rate post-launch — too high means over-promised; too low might mean under-priced\n\nQuality bar:\n- NEVER fake urgency (countdown timers that reset, \"only 3 left\" lies)\n- NEVER use stock photos for \"testimonials\" — real names + real photos or none\n- Every claim is supported (a case, a stat, a real number)\n- Pricing must be transparent — no hidden upsells or surprise charges\n- If you can't substantiate \"guarantee\", remove it rather than weaken it"
+    },
+    {
+      "id": "lead-magnet-pdf",
+      "name": "Generate a lead-magnet PDF for list-building",
+      "category": "Marketing",
+      "tags": [
+        "marketing",
+        "sales"
+      ],
+      "emoji": "🧲",
+      "description": "Generate a lead-magnet PDF + opt-in funnel. Get a 10-20 page guide, landing page, and a 4-email delivery sequence.",
+      "works_best_with": {
+        "agent_profile": "marketing-agent",
+        "skills": [
+          "concise-planning",
+          "vale-brand-voice",
+          "pdf"
+        ],
+        "mcp_servers": [
+          "gmail-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Brief title + format + promise",
+        "Outline 5-8 sections",
+        "Write the PDF content",
+        "Draft the opt-in funnel pages",
+        "Write the 4-email nurture sequence"
+      ],
+      "prompt": "Generate a lead-magnet PDF + opt-in funnel for list-building.\n\nInputs:\n- Niche + target audience: [paste]\n- The single problem the lead magnet solves: [paste]\n- My paid product (so the lead magnet seeds it): [paste]\n- Format preference: [checklist / template / cheatsheet / mini-guide / swipe file / calculator]\n- Brand voice + tone: [paste]\n\nPhase 1 — Lead-magnet brief.\n- Title (curiosity gap + outcome — \"The 5-Step X That Got Me Y in Z\")\n- Promise (one specific transformation in one specific timeframe)\n- Format choice with reasoning (which format matches the niche's appetite)\n- Estimated time-to-value for the reader (under 15 min reading or use)\n\nPhase 2 — Outline.\n- Cover page brief\n- TOC\n- 5-8 sections, each: section name, what the reader gets, how long they spend on it\n- Calls-to-action embedded (light): one mid-doc, one at the end\n- An \"About me\" or \"What's next\" page bridging to the paid offer\n\nPhase 3 — Write the content.\n- Each section: practical, no fluff, specific examples or fill-in-the-blank templates\n- Visual cues (a checklist, a 2-column table, a callout box, a worksheet)\n- Closing CTA: not generic \"follow me\" — specific next step (free call, paid mini-product, course waitlist)\n\nPhase 4 — Opt-in funnel.\n- Landing page hook (one sentence — the promise) + 3 bullets + CTA\n- Confirmation page (sets expectation: deliver immediately + what's next)\n- Delivery email: subject, copy, the download link, a P.S. that previews tomorrow's email\n- 3-email nurture sequence: each addresses one objection between the lead and the paid offer\n\nPhase 5 — Output.\n- The PDF (delivered as .pdf to my workspace)\n- Landing page + confirmation page copy\n- 4-email sequence ready to paste into ConvertKit / beehiiv\n\nFeedback signal:\n- Opt-in conversion rate (target: >25% from cold traffic; >40% from warm)\n- Open / click rate on the nurture sequence\n- Lead-to-customer conversion at the end of the sequence\n\nQuality bar:\n- NEVER promise outcomes the PDF can't deliver — that bleeds into refund rate on the paid product\n- NEVER pad with filler — 10 useful pages beat 30 mediocre ones\n- Disclose anything material (affiliate links, sponsored content)\n- The PDF should be useful even if they never buy the paid offer"
+    },
+    {
+      "id": "signal-backtest-loop",
+      "name": "Move a trading idea from hypothesis to paper",
+      "category": "Investing",
+      "tags": [
+        "investing",
+        "loop"
+      ],
+      "emoji": "🎲",
+      "description": "Move a trading idea from hypothesis to paper. Get a defensible backtest, paper-trade plan, and scale-or-kill verdict.",
+      "works_best_with": {
+        "agent_profile": "finance-agent",
+        "skills": [
+          "concise-planning",
+          "audit-context-building",
+          "pdf"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Translate idea to a testable signal",
+        "Backtest with realistic frictions",
+        "Defend against false-positives",
+        "Run paper-trade window",
+        "Decide: scale, iterate, or kill"
+      ],
+      "prompt": "Take this trading idea from hypothesis to a defensible paper-trade decision. Be brutally honest — most ideas should die at backtest.\n\nInputs:\n- The idea in plain English: [paste — what signal, what asset class, what's the edge thesis]\n- Asset universe: [e.g. S&P 500 stocks / liquid futures / top 50 crypto by mcap]\n- Data source: [polygon / yfinance / Tiingo / Alpaca / etc.]\n- Backtest period: [e.g. 2018-01-01 to 2025-12-31]\n- Initial capital + per-trade size: [paste]\n- Frictions to assume: [commission / spread / slippage / borrow cost for shorts]\n- Risk limits: [max drawdown / max single-position size / sector caps]\n\nPhase 1 — Translate to a testable signal.\n- Define the signal mathematically (don't accept fuzziness)\n- Define entry rule and exit rule\n- Define universe filter (liquidity, market cap, sector exclusions)\n- Define position-sizing (equal-weight / vol-targeted / Kelly fraction)\n- Show me the rules before running the backtest. Wait for confirmation.\n\nPhase 2 — Backtest with realistic frictions.\n- Walk-forward, no look-ahead\n- Include: commission, spread, slippage, borrow cost for shorts, dividend handling\n- Compute: total return, CAGR, Sharpe, Sortino, max drawdown, max DD duration, win rate, profit factor, turnover, average holding period\n- Per-year breakdown\n- Stress windows: 2018 Q4, 2020 March, 2022, any custom\n\nPhase 3 — Defend against false-positives.\n- Out-of-sample: hold out the last 20% of the period and test only there\n- Walk-forward optimization: if you tuned any parameter, show sensitivity\n- Look-ahead audit: prove every input was available at decision time historically\n- Survivorship bias: point-in-time universe membership vs current\n- Multiple-comparison check: how many variants did you try? Adjust for it.\n\nPhase 4 — Paper-trade plan.\nIf backtest survives Phase 3:\n- Paper-trade for a defined window (3 months minimum, or 30 trades, whichever is later)\n- Track real prices, real slippage estimates, real fills\n- Predefine kill conditions early (drawdown > X%, signal coverage < Y trades)\n\nPhase 5 — Verdict.\nAfter paper, compare to backtest:\n- Did Sharpe survive? (fell more than 30% = real warning)\n- Did slippage assumptions hold?\n- Did the signal fire as often as expected?\n- Verdict: scale to live small / continue paper / kill\n\nOutput:\n- Backtest report as `signal-<name>-backtest.pdf` with charts and per-year table\n- Signal-rules file (`signal-<name>.md`) with exact entry/exit/sizing logic\n- Paper-trade tracking sheet\n- Verdict in 3 sentences with the supporting metric\n\nFeedback signal:\n- Per signal: backtest Sharpe vs paper Sharpe gap — calibrates your backtest-to-live model\n- Patterns in killed signals — bake into future Phase 1 filters\n\nQuality bar:\n- This is research, NOT financial advice\n- If backtest looks too good (Sharpe >2.0 on equities), assume broken and audit harder\n- NEVER look at the test set during parameter tuning\n- Position sizing must be reproducible and bounded — no \"use your judgment\" rules\n- If realistic frictions kill the edge, kill the idea — do not weaken the frictions"
+    },
+    {
+      "id": "earnings-call-scanner",
+      "name": "Scan today's earnings calls for trade signals",
+      "category": "Investing",
+      "tags": [
+        "investing",
+        "research"
+      ],
+      "emoji": "🔔",
+      "description": "Scan today's earnings calls for trade-relevant signals. Get summaries, KPI deltas, tone shifts, and ranked alpha.",
+      "works_best_with": {
+        "agent_profile": "finance-agent",
+        "skills": [
+          "brave-search",
+          "firecrawl",
+          "concise-planning",
+          "pdf"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Pull transcripts + 10-Qs + analyst notes",
+        "Extract KPI deltas + tone shifts per ticker",
+        "Rank for trade relevance + confidence",
+        "Output a daily memo + watchlist",
+        "Track hit rate over quarters"
+      ],
+      "prompt": "Scan today's earnings calls and surface trade-relevant signals.\n\nInputs:\n- Watchlist of tickers reporting in the window: [paste]\n- Window: [today's after-market / tomorrow pre-market / this week]\n- Time horizon for trade decisions: [intra-day / swing / quarter]\n- Data sources I want you to pull from: [official transcripts + 10-Q + analyst notes]\n- Style: [pure-numbers / numbers+narrative / contrarian-spotter]\n\nPhase 1 — Per ticker, pull and read.\n- The earnings transcript (official, not summarized)\n- The 10-Q if filed\n- Top 3 analyst notes if available\n- The chart and after-hours move\n\nPhase 2 — Extract per ticker.\n- Headline (revenue + EPS + guidance vs consensus, 1 line)\n- KPI deltas (each major metric vs prior quarter, vs guidance, vs year-ago)\n- Segment performance: which segments outperformed / underperformed\n- Tone shifts in management commentary (caution increased? confidence about a specific market?)\n- Top 3 analyst Q&A exchanges that mattered (right question + management's answer)\n- Anything inconsistent (numbers say A, narrative says B) — often the alpha\n- After-hours price action interpretation\n\nPhase 3 — Rank for trade relevance.\n- Strong reaction warranted (positive or negative) vs market reaction priced it in vs market got it wrong\n- Confidence score per call (high/med/low based on signal clarity)\n- A \"pay attention\" list for the next earnings cycle (companies whose tone shifted enough to matter)\n\nPhase 4 — Output.\n- Daily summary memo (1 page per ticker, 1 sentence verdict per call)\n- A trade-watchlist with: ticker, signal, suggested direction, confidence, suggested time horizon, exit plan\n- A \"questions I couldn't answer\" section flagging what to check before acting\n\nFeedback signal (next earnings cycle):\n- Did your top-confidence calls play out? Track hit rate over 4 quarters\n- Which sectors did your model do best on? — focus there\n- Tone-shift signals: how often did they predict the next quarter's print?\n\nQuality bar:\n- This is analysis, NOT financial advice. Frame as such.\n- NEVER invent guidance, revenue, or quote. If you can't find it, say so.\n- Cite transcript timestamps for every quoted line\n- If the transcript isn't available yet, mark the ticker \"waiting\" — don't summarize from press releases alone\n- No \"to the moon\" framing — neutral analysis only"
+    },
+    {
+      "id": "real-estate-deal-analyzer",
+      "name": "Analyze a real estate deal under buy / flip / Airbnb",
+      "category": "Investing",
+      "tags": [
+        "investing",
+        "real-estate"
+      ],
+      "emoji": "🏘️",
+      "description": "Analyze a real estate deal end-to-end. Get cap rate, cash-on-cash, 5-yr ROI under buy-hold / flip / Airbnb scenarios.",
+      "works_best_with": {
+        "agent_profile": "finance-agent",
+        "skills": [
+          "brave-search",
+          "firecrawl",
+          "concise-planning",
+          "pdf"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Pull listing data + comps",
+        "Run buy-hold, flip, and Airbnb scenarios",
+        "Grade the deal A-F per scenario",
+        "Output a deal memo + negotiation script",
+        "Calibrate comp sources over time"
+      ],
+      "prompt": "Analyze a real estate deal from a Zillow / Redfin / MLS URL.\n\nInputs:\n- Listing URL: [paste]\n- My capital available: [paste]\n- Financing: [cash / conventional 25% down / DSCR / hard money]\n- Investment thesis: [buy-and-hold / fix-and-flip / Airbnb / wholesale]\n- My target metrics: [min cap rate, min cash-on-cash, max payback]\n- Local context: [rent comps source, ARV comps source, Airbnb data source]\n\nPhase 1 — Pull the listing data + comps.\n- Property: address, beds/baths, sqft, lot, year built, condition\n- Asking price + days on market\n- Rent comps (within 1 mile, similar bed/bath/sqft): 5 examples with rent\n- ARV comps (sold in last 6 months, similar shape): 5 examples\n- Airbnb comp data if relevant (occupancy, ADR for the area)\n\nPhase 2 — Run each scenario.\n\nBuy-and-hold:\n- Purchase price + closing + immediate repairs\n- Monthly: rent - (mortgage + tax + insurance + property mgmt + vacancy reserve + maintenance reserve + capex reserve)\n- Annual: NOI, cap rate, cash-on-cash, debt-coverage ratio\n- 5-year: appreciation (regional rate), principal paydown, total ROI\n\nFix-and-flip:\n- ARV - (purchase + rehab + holding costs + closing in + closing out + agent fees)\n- Holding time + risk\n- Net profit + ROI\n\nAirbnb:\n- Furnishing cost\n- Realistic occupancy + ADR (don't take AirDNA at face value — discount 15-20%)\n- Net revenue after platform fees + cleaning + utilities + linens + management\n- Compare to long-term rent — is the Airbnb premium worth the operating headache?\n\nPhase 3 — Grade the deal A-F per scenario.\n- A: hits all target metrics with margin\n- B: hits most, with some risk\n- C: borderline — needs price negotiation\n- D / F: pass\n\nPhase 4 — Output.\n- 1-page deal memo PDF\n- 3 scenarios with side-by-side metrics\n- A negotiation script: opening offer + walk-away price + the 2 things to push back on (inspection items, closing date)\n- A \"questions to ask the listing agent\" list\n\nFeedback signal:\n- Track which graded deals you bid on, won, and how they performed at 12 months\n- Calibrate your comp sources — were rent / ARV estimates accurate?\n- Which scenario assumptions were most often wrong (occupancy is usually the optimistic one)\n\nQuality bar:\n- NEVER use AirDNA / Zillow Zestimate without sanity-checking against 3+ comps\n- NEVER skip the maintenance / capex / vacancy reserves to make the math work\n- Cite every comp by address + sale date / rent + observed date\n- If the deal is a clear pass, say so in one paragraph — don't waste a memo"
+    },
+    {
+      "id": "freelance-proposal-generator",
+      "name": "Generate a tailored freelance proposal",
+      "category": "Career",
+      "tags": [
+        "career",
+        "side-hustle"
+      ],
+      "emoji": "💼",
+      "description": "Tailor a freelance proposal per job posting. Get a hook, scope, pricing tiers, and a follow-up plan.",
+      "works_best_with": {
+        "agent_profile": "marketing-agent",
+        "skills": [
+          "concise-planning",
+          "vale-brand-voice"
+        ],
+        "mcp_servers": [
+          "gmail-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Read the brief + decide bid/skip",
+        "Tailor the hook",
+        "Spec scope + tiered pricing",
+        "Reduce buyer risk with guarantees",
+        "Output proposal + follow-up plan"
+      ],
+      "prompt": "Generate a tailored freelance proposal for a job posting.\n\nInputs:\n- Job posting URL or pasted text: [paste]\n- My portfolio links: [paste]\n- My pricing model + minimum rate: [paste]\n- Relevant past projects (with outcome metrics): [paste]\n- Tone: [confident-expert / curious-collaborator / cost-conscious-pragmatist]\n- Platform: [Upwork / Contra / direct outreach / Fiverr Pro]\n\nPhase 1 — Read the brief.\n- What's the actual outcome they want (often hidden under the technical ask)?\n- Their constraints (timeline, budget hints, team size)\n- Red flags (vague scope, scope creep signals, low-ball budget, asking for free samples)\n- Green flags (specific outcome, clear deadline, willingness to discuss)\n\nDecide: bid or skip. Tell me why.\n\nPhase 2 — Tailor the hook.\n- Open with the specific outcome from the brief — NOT \"I'm Sarah, a freelance designer\"\n- Show you read the brief by referencing one specific detail\n- Stack 1-2 directly relevant past projects with outcome metrics (\"shipped X for Y client in Z weeks; revenue went up 18%\")\n\nPhase 3 — Scope and pricing.\n- Restate the scope as you understand it (catches misalignment early)\n- Propose 1-3 packages (basic / recommended / premium) — anchors against undercutting\n- Each package: deliverables, timeline, what's NOT included, price\n- Payment terms: 50% upfront standard, milestone for larger projects\n\nPhase 4 — Reduce the buyer's risk.\n- Specific guarantee (revisions limit, refund policy, money-back if you miss the deadline)\n- A \"what could go wrong\" section that names the risks + how you mitigate\n- A short kickoff call invite (15 min) — the cheap conversion path\n\nPhase 5 — Output.\n- Proposal as a markdown block ready to paste\n- A short cover note (<=60 words) for platforms that need it\n- A 2-step follow-up plan (+3 days, +7 days)\n- A red-flag list to share with me before I hit Send\n\nFeedback signal:\n- Win rate by platform + job type — focus your time\n- Win rate by package selection (basic / recommended / premium) — calibrate pricing tiers\n- Patterns in losses — was it pricing, fit, slow response, or no portfolio match?\n\nQuality bar:\n- NEVER inflate experience or claim work you didn't do\n- NEVER use the same boilerplate across postings — each proposal is 1:1\n- Respect platform ToS (no off-platform contact ask before win on platforms that forbid it)\n- If the budget is clearly too low for quality work, say so — propose a smaller scope at your rate"
+    },
+    {
+      "id": "childrens-picture-book",
+      "name": "Produce a children's picture book end-to-end",
+      "category": "Creative",
+      "tags": [
+        "creative",
+        "side-hustle"
+      ],
+      "emoji": "🧸",
+      "description": "Produce a children's picture book end-to-end. Get a story, page-by-page art briefs, and storefront copy.",
+      "works_best_with": {
+        "agent_profile": "content-creator",
+        "skills": [
+          "brainstorming",
+          "concise-planning",
+          "pdf"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Lock the story arc",
+        "Write the read-aloud text",
+        "Brief art page by page",
+        "Write cover + storefront copy",
+        "Plan a launch promotion"
+      ],
+      "prompt": "Produce a children's picture book end-to-end.\n\nInputs:\n- Age range: [3-5 / 6-8]\n- Theme or moral: [e.g. sharing, resilience, bedtime, identity]\n- Tone: [calm-bedtime / silly-energetic / quietly-magical]\n- Length: [8 / 12 / 16 / 24 pages]\n- Visual style: [watercolor / flat-vector / paper-cut / pencil-sketch / 3D]\n- Storefront: [Amazon KDP / Etsy / 小红书 PDF / Gumroad / Shopify]\n- Language: [English / 中文 / bilingual]\n- Cultural specificity wanted: [paste]\n\nPhase 1 — Story arc.\n- Protagonist (name, age, defining trait — must be relatable to the age range)\n- Setting (concrete, sensory)\n- Inciting moment (small but real to a child)\n- 3-act structure: setup → challenge → resolution\n- Page-by-page beat list (text per page + emotional arc)\n- A repeated phrase / rhythm a child can predict (huge for re-readability)\n\nShow me the arc. Wait for me to approve before writing prose.\n\nPhase 2 — Write the text.\n- Age-appropriate vocabulary (no condescending baby talk; age 6-8 can handle real words)\n- Read-aloud rhythm — every page should pass the \"say it out loud\" test\n- Max word count per page (younger ages: 30-50 words; older: 60-100)\n- Show emotion through action, not labels (\"Maya stomped\" not \"Maya was angry\")\n\nPhase 3 — Page-by-page art briefs.\nFor each page:\n- Scene description (composition, characters' poses, expressions)\n- Color palette (specific to the page's mood)\n- Camera distance (wide / mid / close-up — vary across pages)\n- Recurring visual element (a pet, a comfort object, a background gag — kids love spotting these)\n- Reference style (artists / books / films the artist would recognize)\n\nPhase 4 — Cover + storefront.\n- Cover art brief (the hook image)\n- Title pattern (3-7 words, alliterative or rhyming if possible)\n- Back-cover blurb (50-80 words — to parents, mentioning the gift / moral / age)\n- Storefront listing: title, tags, description (parents read these, not kids)\n\nPhase 5 — Output.\n- Story manuscript (markdown)\n- Art-direction PDF (page-by-page briefs)\n- Cover brief + back-cover blurb\n- Storefront listing ready to paste\n- A 30-day promotion plan (3 social hooks for launch)\n\nFeedback signal (after launch):\n- Reviews mentioning re-readability — that means the rhythm worked\n- Comments from parents on the moral landing — bias next book toward the same effect\n- Sales by storefront — focus next launch's effort there\n\nQuality bar:\n- NEVER include scary content beyond the age range's tolerance\n- NEVER moralize at the reader — show the moral through the story\n- Verify cultural references (food, names, customs) with someone from that culture if it's not yours\n- Respect children's actual cognitive level — they're smarter than condescending books assume"
+    },
+    {
+      "id": "seed-series-a-pitch-deck",
+      "name": "Build a seed / Series A pitch deck",
+      "category": "Sales",
+      "tags": [
+        "founder",
+        "report",
+        "sales"
+      ],
+      "emoji": "🚀",
+      "description": "Build a fundable pitch deck. Get a Sequoia-style structure, a sharp 'why now', and a slide-by-slide pressure test.",
+      "works_best_with": {
+        "agent_profile": "marketing-agent",
+        "skills": [
+          "pptx",
+          "pdf",
+          "vale-brand-voice",
+          "concise-planning"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Lock the narrative + why-now",
+        "Draft slides in Sequoia structure",
+        "Pressure-test slide by slide",
+        "Output pdf + pptx + 1-page memo"
+      ],
+      "prompt": "Build a fundable seed / Series A pitch deck.\n\nInputs:\n- Stage: [seed / Series A / Series B]\n- Company one-liner: [paste]\n- Traction snapshot (revenue, growth rate, key metric): [paste]\n- Target VC list (5-10 funds): [paste]\n- Existing deck or memo (if any): [paste]\n- \"Why now\" answer: [a SPECIFIC 2024-26 technology or market enabler, NOT a macro trend]\n\nPhase 1 — Lock the narrative. Wait for my approval before slides.\n- One-sentence \"what we do\" (passes the \"explain to your mom\" test)\n- One-sentence \"why now\" tied to a specific enabler\n- The single most defensible traction claim (number + delta + duration)\n- The 3-bullet ask (round size, use of funds, milestone you'll hit)\n\nPhase 2 — Draft slides (Sequoia structure adapted to my stage).\n1. Title (company + one-liner + your name)\n2. Problem (one image, one number)\n3. Solution (one screenshot + the angle that makes it inevitable)\n4. Why now (specific enabler from Phase 1)\n5. Market (TAM/SAM/SOM with sourced numbers — not \"$1T market\")\n6. Competition (positioning grid with axes that segment the market)\n7. Product (3 screenshots: onboarding, magic moment, retention)\n8. Traction (ARR chart, cohort if compelling)\n9. Business model (price × volume math at scale)\n10. Team (LinkedIn + relevant \"why us\" credential per founder)\n11. Financials (Series A+: revenue + burn + runway + plan)\n12. The ask (round size + lead/follow + use of funds + 18-month plan)\n\nPhase 3 — Pressure-test.\nFor each slide, answer in one line: what question does this slide raise? What's the counter on the next slide? Fix any slide that raises an unanswered question.\n\nPhase 4 — Output.\n- .pdf for sending\n- .pptx / .key editable\n- Shareable Notion / Google Drive link\n- A 1-page memo version for first-touch outreach\n\nFeedback signal:\n- After each meeting: which slide did they linger on? Which raised an unanswered question?\n- Q&A volume per slide — surface the slides that consistently raise the same question\n- Which slides got cut by the partner you trusted most — that's the truth\n\nQuality bar:\n- NEVER round up TAM by an order of magnitude — sourceable or off the slide\n- NEVER include a logo wall unless logos are paying customers\n- Team slide is not a resume — it's \"why YOU are the team that wins\"\n- One idea per slide; if you need 2 bullets to explain, the slide is wrong"
+    },
+    {
+      "id": "investor-outreach-process",
+      "name": "Run the investor outreach process",
+      "category": "Sales",
+      "tags": [
+        "founder",
+        "pipeline",
+        "sales"
+      ],
+      "emoji": "🤲",
+      "description": "Run a tranched VC outreach process. Get a 50-fund target list, warm-intro mapping, and templated outreach + tracker.",
+      "works_best_with": {
+        "agent_profile": "marketing-agent",
+        "skills": [
+          "brave-search",
+          "concise-planning"
+        ],
+        "mcp_servers": [
+          "gmail-mcp",
+          "notion-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Build a 50-60 fund target list",
+        "Map warm-intro paths",
+        "Tranche the outreach in 3 waves",
+        "Write templated outreach",
+        "Track in a CRM-style sheet"
+      ],
+      "prompt": "Run a tranched investor outreach process for my round.\n\nInputs:\n- Stage of round: [seed / Series A]\n- Round size + expected check size per investor: [paste]\n- Existing investor list (if any): [paste or CRM link]\n- Industry / thesis fit (for filtering): [paste]\n- Timeline (when do I want to close?): [paste]\n- Existing intros I have: [paste]\n\nPhase 1 — Build the 50-60 fund target list.\n- Filter by stage they lead, sector thesis, check size, recent investment activity (last 90 days)\n- For each fund: lead partner name, sector focus, most relevant 3 portfolio companies, last public talk / blog / podcast\n- Mark cold vs warm (warm = mutual connection, common angel, public engagement)\n- Drop funds whose thesis clearly excludes you\n\nPhase 2 — Build the warm-intro map.\n- For each warm fund: 2-3 intro paths, scored \"would they vouch with conviction?\" (1-3)\n- For cold funds I really want: identify a \"wedge\" — a partner whose latest investment is most similar\n- Output: CSV ranked by P(meeting) × fit\n\nPhase 3 — Tranche the outreach.\n- Tranche 1 (5-10 funds): friendliest warm intros — they meet first, give feedback, sharpen the pitch\n- Tranche 2 (20-25 funds): main push — fire 7-10 days after Tranche 1 feedback\n- Tranche 3 (rest): cold + lower-priority — fire only if Tranches 1-2 haven't closed\nNEVER blast all 50 at once. The market talks. Sharpen between tranches.\n\nPhase 4 — Templates.\n- Warm-intro request to the connector (60 words, makes their forward easy)\n- Cold outreach (80 words, references a specific portfolio investment + your \"why now\")\n- Forward-ready deck link + memo\n- The \"no thanks\" reply (gracious, leaves the door open)\n\nPhase 5 — Tracking.\n- CSV: fund | partner | tranche | intro path | last touch | response | next step | meeting date | outcome\n- Updated daily during a live round\n\nFeedback signal:\n- Conversion rate per tranche — Tranche 1 conversion calibrates Tranche 2 narrative\n- Drop-off reasons (\"too early\", \"no thesis fit\", \"come back at $X ARR\") — refine the list\n- Time-to-meeting after intro — slow paths indicate weak relationship\n\nQuality bar:\n- NEVER outreach a fund whose thesis you can't articulate in one sentence\n- NEVER skip the \"thank you for the intro\" reply to the connector\n- Personalize Tranches 1 + 2; templatize only Tranche 3\n- If you're getting \"too early\" 3+ times in a row, stop — the round may not be ready"
+    },
+    {
+      "id": "cap-table-safe-model",
+      "name": "Model SAFE vs priced round dilution",
+      "category": "Finance",
+      "tags": [
+        "finance",
+        "founder",
+        "report"
+      ],
+      "emoji": "🧾",
+      "description": "Model SAFE conversion + priced round dilution. Get a cap table, scenarios, and a minimum-acceptable-terms sheet.",
+      "works_best_with": {
+        "agent_profile": "finance-agent",
+        "skills": [
+          "concise-planning",
+          "pdf"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Model the current cap stack",
+        "Convert SAFEs at the next round",
+        "Apply the new round + ESOP top-up",
+        "Run base / bigger / smaller / down-round scenarios",
+        "Output editable .xlsx + minimum-terms sheet"
+      ],
+      "prompt": "Model SAFE vs priced round dilution. Get a cap table I can change inputs in.\n\nInputs:\n- Current cap table (post-money simple — founders + ESOP + prior investors): [paste]\n- Stack of existing SAFEs (cap, discount, MFN clauses): [list each one separately]\n- Proposed next round size + valuation: [paste]\n- Target ESOP top-up at the round: [paste %]\n- Investors leading vs following + check sizes: [paste]\n\nPhase 1 — Model the current stack.\n- Compute current ownership for: founders, ESOP available, employees holding, each angel / SAFE holder\n- Surface the most-dilutive SAFEs (lowest cap, biggest check)\n- Flag any unusual provisions (full ratchet, MFN, side letter)\n\nPhase 2 — Convert SAFEs at next round.\nFor each SAFE:\n- Applied valuation (cap vs discount vs price, whichever is lowest for the SAFE holder)\n- Shares issued\n- Net ownership after conversion\n\nPhase 3 — Apply the new round.\n- Pre-money calculation INCLUDING converted SAFEs\n- Top up ESOP per target — MODEL BOTH pre-money and post-money ESOP top-ups (the difference is a real negotiation lever)\n- New share issuance for new investors\n- Final post-money ownership table\n\nPhase 4 — Scenarios (side-by-side columns).\n- Base case\n- 25% bigger round\n- 25% smaller round\n- Down round (10% lower than the last cap)\n- Bridge SAFE before round (extra $1M)\nFor each: founder ownership after, ESOP available, dilution per founder\n\nPhase 5 — Output.\n- Cap table .xlsx WITH FORMULAS (so I can change inputs)\n- 1-page scenario comparison PDF\n- A \"minimum acceptable terms\" sheet I can take into term sheet negotiation\n- A list of red flags in the stack (full ratchets, MFN clauses, pro-rata stacking)\n\nFeedback signal:\n- After the round closes: which assumption was wrong? (commonly: ESOP top-up timing)\n- Track post-round dilution against the model — surface drift for the next round\n- If certain SAFEs surprised you on conversion, document for future SAFEs\n\nQuality bar:\n- NEVER skip MFN / ratchet provisions when modeling — they silently change the math\n- NEVER assume \"standard\" SAFE terms without reading each one\n- This is modeling, NOT legal advice — your lawyer signs off on actual terms\n- Pre-money vs post-money ESOP top-up is a real negotiation lever — show both"
+    },
+    {
+      "id": "fundraise-data-room",
+      "name": "Set up a fundraise data room",
+      "category": "Sales",
+      "tags": [
+        "audit",
+        "founder",
+        "sales"
+      ],
+      "emoji": "🗂️",
+      "description": "Set up a fundraise data room with the right gating. Get a folder structure, missing-artifact list, and a diligence Q&A pre-answered.",
+      "works_best_with": {
+        "agent_profile": "marketing-agent",
+        "skills": [
+          "concise-planning",
+          "audit-context-building"
+        ],
+        "mcp_servers": [
+          "notion-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Build the folder structure",
+        "Generate missing artifacts per folder",
+        "Gate by investor tier",
+        "QA pass for deck-vs-data consistency",
+        "Output index + diligence Q&A"
+      ],
+      "prompt": "Set up a fundraise data room for a live round.\n\nInputs:\n- Stage of round: [seed / Series A / Series B]\n- Existing data room (if any): [link]\n- Sensitive items I want gated: [list]\n- Investors who'll get access + tier (lead vs follow): [paste]\n\nPhase 1 — Build the structure (standard 8 folders).\n1. Corporate (incorporation, cap table, board minutes, prior SAFEs / notes)\n2. Financial (P&L, balance sheet, cash flow, MRR/ARR walk, customer concentration)\n3. Product (product spec, roadmap, screenshots, security architecture)\n4. Customer (customer list, NRR/GRR, contract values, top-10 logos)\n5. Team (org chart, key hires, founder bios, equity grants)\n6. Legal (MSA template, DPA template, redlined customer contracts, IP assignment)\n7. Pipeline (sales pipeline, marketing funnel, growth experiments)\n8. Strategic (positioning, competitive analysis, roadmap, \"why now\")\n\nPhase 2 — Generate the missing artifacts per folder.\n- Cap table: clean version (no informal notes)\n- Customer list: logos + start dates (anonymize the smallest if needed)\n- Pipeline: 90-day forward snapshot\n- Key hires planned: role + comp + timeline\n\nPhase 3 — Gate appropriately.\n- Lead tier: full access (watermarked + NDA)\n- Follow tier: numbers + summary, not the raw customer list\n- Pre-NDA: just the public stuff (deck + one-line metrics)\n\nPhase 4 — QA pass.\n- Find every assertion in the pitch deck. Is it sourced in the data room?\n- Find every number in the deck. Is the supporting query / file in the data room?\n- Any inconsistency between deck and data room → fix immediately\n\nPhase 5 — Output.\n- Folder structure deployed (Notion / Google Drive / Docsend with watermarking)\n- A \"what's where\" index PDF investors get at intro\n- An audit log of who accessed what (for follow-up calibration)\n- A diligence Q&A doc — the 30 questions investors always ask, pre-answered\n\nFeedback signal:\n- Which questions investors ask repeatedly that aren't in the diligence Q&A — add them\n- Which docs investors actually open (Docsend tells you) — promote those\n- Which gaps stalled diligence — backfill before the next round\n\nQuality bar:\n- NEVER include customer contracts with active redlines\n- NEVER share unredacted customer info with follow-only investors\n- Watermark every PDF with the recipient's email — leaks happen\n- Keep a SINGLE source of truth; never have two versions of the cap table"
+    },
+    {
+      "id": "series-a-board-deck",
+      "name": "Build the quarterly board deck",
+      "category": "Sales",
+      "tags": [
+        "founder",
+        "report",
+        "sales"
+      ],
+      "emoji": "🪧",
+      "description": "Build a quarterly board deck with KPIs + benchmarks + asks. Get numbers + narrative + pre-board 1:1 prep.",
+      "works_best_with": {
+        "agent_profile": "finance-agent",
+        "skills": [
+          "concise-planning",
+          "pdf",
+          "pptx"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Pull KPIs vs plan + last Q + benchmark",
+        "Draft the numbers section",
+        "Draft the narrative section + asks",
+        "Prep pre-board 1:1s",
+        "Output deck + pre-read + recap template"
+      ],
+      "prompt": "Build this quarter's board deck.\n\nInputs:\n- Board members + their information preferences: [paste]\n- Last quarter's deck (so we can diff): [link]\n- This quarter's KPIs (ARR / NRR / burn / runway / pipeline / hiring): [paste]\n- Bessemer / OpenView benchmark quartile I'm tracking against: [paste]\n- Strategic asks for this meeting: [paste]\n- Time slot: [60 / 90 / 120 min]\n\nPhase 1 — Numbers section (7-10 slides).\n- Headline KPIs vs plan + last quarter (traffic-light colors sparingly)\n- ARR growth + monthly walk\n- NRR + GRR with cohort detail\n- Burn multiple (net new ARR / cash burned) — flag if >1.5x\n- CAC payback period\n- Cash position + runway at current burn vs target burn\n- Pipeline by stage with conversion rates\n- Headcount + planned hires\n\nPer KPI: this Q vs last Q vs plan, plus a benchmark line against Bessemer / OpenView quartile.\n\nPhase 2 — Narrative section (3-5 slides).\n- What's working (one win with a defensible number)\n- What's not working (be specific — and what you're doing about it)\n- The one strategic question for the board (NOT \"any feedback?\")\n- Pre-decided proposals for board approval (option pool top-up, exec hire, large customer concession)\n\nPhase 3 — Appendix.\n- Detailed financials for deep-divers\n- Customer logos + biggest deals shipped this Q\n- Product roadmap detail\n- Any specific board member's pet topic\n\nPhase 4 — Pre-meeting prep.\n- Send the deck 48h before\n- 1:1 calls with each board member 24-48h ahead to surface friction\n- Adjust any slide likely to draw a board-member grandstand\n\nPhase 5 — Output.\n- Deck (.pdf + editable)\n- Pre-read summary (1 page — what we'll cover, what we need from you)\n- Action-item template for the meeting\n- Post-meeting recap template (action items go out <=24h)\n\nFeedback signal:\n- Which slides drove the most board discussion — promote those\n- Action items completed by next board meeting\n- Board member 1:1 feedback vs surprises in the room — minimize the gap\n\nQuality bar:\n- NEVER bury bad news in the appendix — surface it on the headline slide\n- NEVER ask \"any questions?\" without specific questions ready\n- A 90-min board meeting is 30 min content + 60 min discussion — don't fill all 90 with slides\n- Investors hate surprises — surface drift WEEKS before the meeting, not in the deck"
+    },
+    {
+      "id": "quarterly-operating-cadence",
+      "name": "Run the quarterly operating cadence",
+      "category": "Productivity",
+      "tags": [
+        "founder",
+        "loop",
+        "productivity"
+      ],
+      "emoji": "🌗",
+      "description": "Stand up a quarterly operating cadence (David Sacks-style). Get a calendar, ritual templates, and an end-of-quarter review.",
+      "works_best_with": {
+        "agent_profile": "personal-assistant",
+        "skills": [
+          "concise-planning",
+          "pdf"
+        ],
+        "mcp_servers": [
+          "notion-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Lay out the quarter's spine",
+        "Schedule the core rituals",
+        "Define artifacts per ritual",
+        "Set up tooling + calendar",
+        "Review at quarter end"
+      ],
+      "prompt": "Stand up the quarterly operating cadence for the company.\n\nInputs:\n- Company size + functional teams: [paste]\n- Current rituals (if any): [paste]\n- Fiscal quarter dates: [paste]\n- Last quarter's plan + actuals: [paste or link]\n\nPhase 1 — Lay out the quarter's spine.\n- Month 1: Plan finalization + kickoff\n- Month 2: Mid-quarter check + course correction\n- Month 3: Wrap + next quarter prep + board meeting\n\nPhase 2 — Schedule the core rituals.\n- Monday: exec team weekly + functional standups\n- Bi-weekly: 1:1s between exec team\n- Monthly: investor update (last business day)\n- Monthly: all-hands\n- Quarterly: board meeting (week 11)\n- Quarterly: QBR with top customers (week 12)\n- Quarterly: roadmap review (week 10 — gates next quarter's plan)\n- Quarterly: hiring review (week 11)\n\nPhase 3 — Define artifacts per ritual.\n- Weekly exec: 1-page status dashboard\n- Investor update: 5-section template (headline / KPIs / wins / misses / asks)\n- All-hands: 30-min deck (CEO update + a guest team's deep dive)\n- Board meeting: see board-deck playbook\n- QBR: customer-facing 1-pager (usage + outcomes + asks)\n- Roadmap review: trade-off matrix (ship / won't / defer)\n- Hiring review: open reqs / candidates / decisions needed\n\nPhase 4 — Tooling.\n- Calendar invites for the full quarter (do it once, not weekly)\n- Document templates linked in the calendar invite\n- A status dashboard that auto-pulls from CRM / financial system / GitHub if possible\n\nPhase 5 — Output.\n- Quarterly cadence calendar (PDF for the team)\n- A template library (8 templates) in one Notion folder\n- A \"Cadence v1\" doc the whole team reads at the start of the quarter\n- An end-of-quarter 3-question review: what worked, what didn't, what changes\n\nFeedback signal (closes loop quarter over quarter):\n- Rituals you skipped — those were either wrong or wrong frequency\n- Attendance + participation patterns — engagement signals fit\n- Decisions made in rituals vs side conversations — too many side conversations means rituals aren't load-bearing\n\nQuality bar:\n- NEVER schedule a recurring meeting without a written agenda template\n- NEVER let a ritual run past its allotted time — that's a structure failure\n- Kill any ritual that runs 3 quarters without producing a decision\n- One person owns each ritual — they don't run it, but they're accountable for it happening"
+    },
+    {
+      "id": "okrs-v2mom-plan",
+      "name": "Set company OKRs + V2MOM",
+      "category": "Productivity",
+      "tags": [
+        "founder",
+        "productivity",
+        "report"
+      ],
+      "emoji": "🧭",
+      "description": "Set company OKRs + V2MOM. Get a 1-page V2MOM, cascading OKRs, and a confidence + dependency map.",
+      "works_best_with": {
+        "agent_profile": "personal-assistant",
+        "skills": [
+          "concise-planning",
+          "pdf"
+        ],
+        "mcp_servers": [
+          "notion-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Draft the V2MOM",
+        "Draft 3-5 company OKRs",
+        "Cascade to teams",
+        "Map confidence + dependencies",
+        "Output planning doc + tracking dashboard"
+      ],
+      "prompt": "Set the company OKRs + V2MOM for the cycle.\n\nInputs:\n- Scope (quarter or year): [paste]\n- Company vision (1 sentence): [paste]\n- Last cycle's OKRs + outcomes: [paste]\n- Functional team count + leads: [paste]\n- The single biggest strategic bet for this cycle: [paste]\n\nPhase 1 — Draft the V2MOM (Benioff style).\n- Vision: where we're going (1 sentence)\n- Values: 3-5 we'll trade off for\n- Methods: 3-5 ways we'll get there\n- Obstacles: what could prevent it\n- Measurements: how we'll know we got there\n\nShow me the V2MOM. Wait for confirmation before drafting OKRs.\n\nPhase 2 — Draft 3-5 company OKRs.\nEach:\n- Objective (qualitative, ambitious, 1 sentence, no metric)\n- 3-5 Key Results (quantitative, time-bound, measurable, ambitious — \"50%\" not \"increase\")\n- Owner (single person on the exec team)\n- The single experiment / project that drives each KR\n\nConstraints:\n- NEVER more than 5 company OKRs — that's how strategy dies\n- Every team's OKRs roll up to a company OKR\n- Sum of team OKRs across teams should NOT add to 100% — overlap means coordination\n\nPhase 3 — Cascade to teams.\n- Each team writes 2-3 OKRs rolling up to a company OKR\n- Sales / Marketing / Eng / Product / CS / Ops / People\n- Review the cascade as a group — kill anything that doesn't connect\n\nPhase 4 — Confidence + dependency map.\n- Each KR: confidence score (1-10) at start of cycle\n- Dependencies between teams' KRs — surface them on a map\n- The 3 KRs the company NEEDS to hit vs the 3 nice-to-have stretch\n\nPhase 5 — Output.\n- V2MOM as a 1-page doc (company-wide)\n- OKR doc (Notion / sheet) with all teams rolling up\n- A dashboard query / pull for tracking each KR\n- A weekly OKR check (15 min in the exec meeting) and a mid-cycle reset moment\n\nFeedback signal (closes loop cycle over cycle):\n- KRs hit vs missed — patterns in misses (over-planned? wrong owners? dependency stuck?)\n- KRs nobody looked at — those weren't load-bearing\n- Confidence score at start vs actual outcome — calibrates planning realism\n\nQuality bar:\n- KRs that aren't measurable aren't KRs — rewrite or cut\n- Don't pile KRs to fill the cycle — quality over quantity\n- One owner per KR — \"everyone\" = no one\n- Aspirational ≠ ambiguous — \"double revenue\" is clear; \"drive innovation\" is fluff"
+    },
+    {
+      "id": "executive-role-scorecard",
+      "name": "Build an executive role scorecard with extreme referencing",
+      "category": "Career",
+      "tags": [
+        "career",
+        "founder"
+      ],
+      "emoji": "🔎",
+      "description": "Hire an executive with rigor. Get a scorecard, structured interview loop, and a backchannel reference plan.",
+      "works_best_with": {
+        "agent_profile": "personal-assistant",
+        "skills": [
+          "concise-planning",
+          "audit-context-building"
+        ],
+        "mcp_servers": [
+          "gmail-mcp",
+          "notion-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Build the role scorecard",
+        "Source the longlist + score",
+        "Design the interview loop + working session",
+        "Run extreme referencing",
+        "Output offer + 30/60/90 link"
+      ],
+      "prompt": "Run a rigorous executive hire end-to-end.\n\nInputs:\n- Role I'm hiring (VP Sales / VP Engineering / Head of CS / etc.): [paste]\n- Stage: [pre-revenue / $1-5M ARR / $5-20M / $20M+]\n- Current team + culture notes: [paste]\n- Salary band + equity range I'm willing to pay: [paste]\n- Timeline to fill: [paste]\n\nPhase 1 — Build the role scorecard.\n- Mission (1 sentence): why this role exists this year\n- Outcomes (3-5, time-bound, measurable): what they'll achieve in 12 months\n- Competencies (5-8): what they need to do the job\n- Cultural fit dimensions (3-5): how they need to operate at our stage\n- Anti-patterns: what disqualifies (won't roll sleeves up, comes from too-big company, etc.)\n\nPhase 2 — Source the longlist.\n- Map the talent market: relevant talent communities + 5 closest comparable companies + 3 levels of network\n- For each prospect: last 3 roles, public artifacts (talks, posts), outcome at each stop\n- Score against scorecard — top 30-50 enter top of funnel\n\nPhase 3 — Interview design.\n- Loop: founder screen → working session → 4-person panel → ref calls → CEO close\n- Each interviewer owns 2 scorecard dimensions — never overlap\n- Working session: a real problem at the company, time-boxed, evaluated against scorecard\n\nPhase 4 — Extreme referencing.\n- 10-12 references per finalist, not just on their list\n- Backchannel through: prior reports (most signal), prior peers, prior managers\n- Question bank: \"What would make you not rehire them?\", \"When did they fail and what did they do?\", \"What would their team say if anonymous?\"\n- The true bar: would I bet $5M of company runway on this person?\n\nPhase 5 — Output.\n- Role scorecard (1-page Notion doc)\n- Longlist + score CSV\n- Interview kit (loop, scorecard mapping, working-session prompt)\n- Reference call doc per finalist\n- Offer + onboarding plan (link to 30/60/90 playbook)\n\nFeedback signal:\n- At 6 months: did the hire hit scorecard outcomes?\n- Patterns in misses (over-indexed on competency, under-indexed on culture, etc.)\n- Reference signals that predicted vs missed — calibrate the question bank\n\nQuality bar:\n- NEVER hire on resume alone — scorecard or no hire\n- NEVER skip backchannel references — they reveal what listed refs hide\n- \"Move fast\" doesn't mean skip diligence — exec mishires cost 4-12 months\n- A \"B+ that culture-fits\" beats an \"A that doesn't\" at startup stage"
+    },
+    {
+      "id": "hiring-sequence-by-arr",
+      "name": "Plan the hiring sequence by ARR",
+      "category": "Career",
+      "tags": [
+        "career",
+        "founder",
+        "report"
+      ],
+      "emoji": "👥",
+      "description": "Plan the exec + senior hiring sequence by ARR milestones. Get a hiring map tied to revenue plan with comp benchmarks.",
+      "works_best_with": {
+        "agent_profile": "finance-agent",
+        "skills": [
+          "concise-planning",
+          "pdf"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Project ARR + revenue plan",
+        "Map exec roles to ARR triggers",
+        "Benchmark comp via Pave + Levels",
+        "Output a hiring plan tied to revenue",
+        "Define readiness signals per role"
+      ],
+      "prompt": "Plan the exec + senior hiring sequence tied to my ARR trajectory.\n\nInputs:\n- Current ARR + 12-month plan: [paste]\n- Current team (with titles + tenure): [paste]\n- Industry: [paste — comp benchmarks vary]\n- Cash position + runway: [paste]\n- Fundraising plan (timing + size): [paste]\n\nPhase 1 — ARR trigger map (Jason Lemkin defaults).\n- VP Marketing: ~$0.2M ARR\n- VP Sales: $1-1.5M ARR\n- VP Customer Success: $2M ARR\n- VP Product: $3-4M ARR\n- VP Engineering: $5-6M ARR\n- CFO: $10M ARR\n- COO: $20M ARR\n\nFor each, output: ARR trigger / role / when (month) / why now.\n\nPhase 2 — Calibrate to my stage.\n- For each role: is it under-hired vs over-hired given my growth rate?\n- For roles I should hire NEXT: scorecard reqs (link to executive-role-scorecard)\n- Roles I should DELAY: which of my current team can stretch?\n\nPhase 3 — Comp benchmarks.\nFor each near-term hire:\n- Salary band (Pave + Levels.fyi market data)\n- Equity grant (% of company by stage)\n- Acceleration clauses (single vs double trigger)\n- Performance review cadence + refresh grants\n\nPhase 4 — Cash + runway impact.\n- Burn-rate impact per hire (fully loaded)\n- Runway extension required to ship a hire\n- Fundraise dependencies (do we need to close round X before hiring role Y?)\n\nPhase 5 — Output.\n- Hiring plan PDF (1-page Gantt of who/when/why/cost)\n- Per-role scorecard stubs (link out to executive-role-scorecard for the deep dive)\n- A \"readiness checklist\" per role: signals that say \"now is the right time\" + signals that say \"wait\"\n- A comp benchmark sheet\n\nFeedback signal:\n- After each exec hire: did the ARR trigger justify the cost?\n- Roles where my team stretched successfully — promote that pattern\n- Hires that came too early — costly lesson, capture in the plan\n\nQuality bar:\n- NEVER hire an exec to \"build the function\" before you've done the function yourself\n- NEVER over-hire on title in exchange for raw output (\"VP\" titles inflate fast at startups)\n- This is planning, NOT a commitment — markets shift, plans shift\n- Bias toward stretch + builder hires over executive-from-big-co at <$10M ARR"
+    },
+    {
+      "id": "exec-30-60-90-plan",
+      "name": "Write a 30/60/90 onboarding plan for an exec hire",
+      "category": "Career",
+      "tags": [
+        "career",
+        "founder"
+      ],
+      "emoji": "🎒",
+      "description": "Write a 30/60/90 plan for a new exec. Get learn / contribute / lead phases with specific deliverables.",
+      "works_best_with": {
+        "agent_profile": "personal-assistant",
+        "skills": [
+          "concise-planning",
+          "pdf"
+        ],
+        "mcp_servers": [
+          "notion-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Set the mission + 12-month outcomes",
+        "Define 30/60/90 expectations",
+        "List meetings + reading + access",
+        "Set check-in cadence with CEO",
+        "Output the plan as a shared doc"
+      ],
+      "prompt": "Write a 30/60/90 onboarding plan for a new exec hire.\n\nInputs:\n- Role + hire's name: [paste]\n- Their first day + first major board / customer meeting: [paste]\n- 12-month outcomes from the scorecard: [paste]\n- Current team + cultural notes: [paste]\n- Stretch goals the hire said they want to drive: [paste]\n\nPhase 1 — Mission + outcomes (1-page header).\n- Mission: why this role exists (1 sentence)\n- Top 3 12-month outcomes the hire owns\n- Top 3 things the hire is NOT responsible for in year one (kill scope creep)\n- Boundaries / handoffs with peers\n\nPhase 2 — Days 0-30: LEARN.\n- People to 1:1 (named): direct reports + peers + key cross-functional + 5 customers + 2 board members\n- Reading: company history (founding story, strategic memos), roadmap, last 3 board decks, OKRs\n- Access (technical): tools, dashboards, repos, customer data\n- Tangible deliverable at day 30: a \"what I learned\" memo to the CEO + a \"what I'd change in 90 days\" note (the latter for context-setting, not committing)\n\nPhase 3 — Days 31-60: CONTRIBUTE.\n- One small, scoped project that delivers value in their function (not a strategic bet)\n- First public artifact (board update, all-hands talk, customer call, hire decision)\n- Cross-functional working relationships established (named: who do they have monthly 1:1s with?)\n- Tangible deliverable at day 60: a written plan for days 61-180 (their plan, not yours)\n\nPhase 4 — Days 61-90: LEAD.\n- One real strategic decision they own (with CEO as escalation, not co-owner)\n- Hiring or restructure proposals if needed\n- Their function's input into the next OKR cycle\n- Tangible deliverable at day 90: a self-assessment + a CEO assessment, side by side\n\nPhase 5 — CEO check-in cadence.\n- Weekly 1:1 for first 90 days\n- Bi-weekly after\n- Quarterly: explicit \"is this working?\" conversation with named criteria\n\nPhase 6 — Output.\n- The 30/60/90 plan as a 2-page Notion doc, shared with the hire + their manager\n- A calendar template auto-populating the check-ins\n- A \"success metrics by day 90\" checklist for the post-90 review\n\nFeedback signal:\n- Patterns in what gets done by day 30 vs day 60 vs day 90 — calibrates pace\n- Which onboarding meetings produced signal vs which were performative\n- Where the plan was too rigid / too vague — feeds the next plan\n\nQuality bar:\n- NEVER expect strategic bets in day 0-30 — that's setup for failure\n- NEVER skip the bi-directional CEO assessment at day 90\n- Be specific about boundaries — vague mission = scope creep\n- If the hire is failing the plan, raise it at week 6, not week 12"
+    },
+    {
+      "id": "value-metric-pricing-redesign",
+      "name": "Redesign pricing around a value metric",
+      "category": "Sales",
+      "tags": [
+        "founder",
+        "sales"
+      ],
+      "emoji": "🏗️",
+      "description": "Redesign pricing around a value metric. Get tiers, packaging, a pricing page, and a price-test plan.",
+      "works_best_with": {
+        "agent_profile": "marketing-agent",
+        "skills": [
+          "concise-planning",
+          "vale-brand-voice"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Pick the right value metric",
+        "Design good/better/best tiers",
+        "Build the pricing page",
+        "Plan the price test",
+        "Communicate to existing customers"
+      ],
+      "prompt": "Redesign pricing around a value metric (Patrick Campbell / ProfitWell style).\n\nInputs:\n- Product + current pricing model: [paste]\n- Top 3 customer use cases / personas: [paste]\n- Current ACV distribution + churn by tier: [paste]\n- Closest 3 competitors' pricing: [paste]\n- Constraints (existing contract terms, grandfathering policy): [paste]\n\nPhase 1 — Pick the value metric.\n- Map options: seats, API calls, GMV, projects, records, msgs, MAUs, storage\n- Score each: does it scale WITH customer value? Is it predictable? Is it gameable?\n- Recommend ONE primary value metric. Explain the trade-offs of the runners-up.\n\nShow me the metric + reasoning. Wait for me to approve.\n\nPhase 2 — Tier design (good / better / best).\n- 3 tiers (not 5+ — choice paralysis)\n- Anchor: top tier 3-4x the middle (anchors against \"I'll never need that\")\n- Feature gating: middle tier gets 80% of features; top tier gets the team / governance / SLA layer\n- Value-metric thresholds per tier\n- \"Most popular\" badge on the middle tier (it works)\n- An \"Enterprise / Talk to us\" CTA for the top tier (preserves negotiation room)\n\nPhase 3 — Pricing page.\n- Headline: outcome-based (\"scale to X without Y\")\n- 3-column layout, annual default (with monthly toggle)\n- Each plan: 1-sentence positioning + 3-5 bullets + the value metric line + CTA\n- FAQ: 5 questions (\"can I switch plans?\", \"do you offer a trial?\", \"what counts as a [value metric]?\")\n- Social proof: 3-5 logos + 1 testimonial\n\nPhase 4 — Price-test plan.\n- A/B: control = current, variant = new pricing\n- Run 30 days minimum or N conversions, whichever later\n- Track: signups, trial-to-paid, ACV, churn at 30/60/90\n- Kill rules: if conversions drop >X%, revert\n\nPhase 5 — Communicate to existing customers.\n- Grandfathering policy (clear, time-bound)\n- Email sequence (3 emails): change preview → final notice → \"what to do\" recap\n- One-pager FAQ to give to support\n- Renewal flow: existing customers either grandfather or migrate at renewal\n\nPhase 6 — Output.\n- New pricing page (markdown for the dev to build)\n- Tier comparison PDF (for sales)\n- Customer comms email sequence\n- A/B test rig spec + kill rules\n\nFeedback signal:\n- Tier mix shift (are people picking the middle? top?)\n- ACV delta vs control\n- Churn at 30 / 60 / 90 — pricing changes show churn signal at month 2\n- Sales push-back themes — surface objections to refine messaging\n\nQuality bar:\n- NEVER hide pricing — every \"talk to sales\" without a starting number scares devs\n- NEVER ship pricing without a kill rule\n- Communicate price changes to existing customers BEFORE prospects see them\n- Don't fix pricing while also redesigning packaging — change one variable at a time"
+    },
+    {
+      "id": "reverse-trial-conversion-test",
+      "name": "Run a reverse-trial conversion experiment",
+      "category": "Sales",
+      "tags": [
+        "loop",
+        "sales"
+      ],
+      "emoji": "🔀",
+      "description": "Test reverse trial vs opt-in trial. Get an experiment plan, upgrade nudge sequence, and a 30-day measurement.",
+      "works_best_with": {
+        "agent_profile": "marketing-agent",
+        "skills": [
+          "concise-planning"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Design the reverse-trial mechanic",
+        "Identify the Pro-only feature that drives upgrade",
+        "Build the upgrade nudge sequence",
+        "A/B against current trial",
+        "Read out at 30 days"
+      ],
+      "prompt": "Run a reverse-trial conversion test (Notion / Canva / Airtable pattern).\n\nInputs:\n- Current trial / freemium setup: [paste]\n- Current trial-to-paid conversion rate: [paste]\n- Top 5 Pro-only features (with usage data if you have it): [paste]\n- Activation event (the moment users get value): [paste]\n- Sample size + traffic per day to the trial: [paste]\n\nPhase 1 — Design the mechanic.\n- Reverse trial: 14 days full Pro access from signup, NO card required, auto-downgrade to free at day 15\n- Confirm activation event flows in days 1-7\n- Define which Pro features are visible during the trial period\n- Define the friction-free downgrade (\"you're now on Free; here's what changes\")\n\nPhase 2 — Identify the upgrade hook.\n- For each Pro-only feature: usage frequency during trial × feature stickiness × difficulty to replace\n- Pick the SINGLE feature most likely to drive upgrade\n- Plan the in-product nudge that appears exactly when the user hits that feature\n\nPhase 3 — Build the upgrade nudge sequence.\n- In-product: feature-specific modal on day 10 + day 14\n- Email day 12: \"your trial ends in 2 days; here's what you'll lose\"\n- Email day 15: \"you're on Free; here's how to come back\"\n- Email day 22: \"Pro-only feature you used X times — want it back?\"\n\nPhase 4 — A/B against current trial.\n- Split: 50/50 over 30 days minimum\n- Track: trial-to-paid conversion, ACV by cohort, churn at 30 / 60 / 90, NPS at trial end\n- Kill rule: if conversion drops >20%, revert immediately\n\nPhase 5 — Read out at 30 days.\n- Headline metric: trial-to-paid conversion vs control\n- Mix: are users converting because of the SINGLE feature you bet on, or something else?\n- Churn signal: do reverse-trial converters churn faster (lower commitment)?\n- Verdict: ship / kill / iterate\n\nPhase 6 — Output.\n- Experiment doc (hypothesis + arms + metrics + kill rules)\n- The upgrade nudge sequence (in-product copy + email copy)\n- A 30-day readout template\n- A scaling plan if the test wins\n\nFeedback signal (closes the loop):\n- Per cohort: trial-to-paid + retention at 90 days\n- Which Pro feature actually drove conversion vs which you bet on\n- Time-to-conversion distribution — surface the bandit's sweet spot\n\nQuality bar:\n- NEVER ship \"free Pro forever\" by accident — confirm the auto-downgrade fires\n- NEVER claim the test won at day 7 — wait for the full window\n- Cohort the analysis by acquisition channel — some channels convert differently\n- If the test loses, surface why before throwing it away — sometimes the hook was wrong, not the mechanic"
+    },
+    {
+      "id": "willingness-to-pay-study",
+      "name": "Run a willingness-to-pay study",
+      "category": "Sales",
+      "tags": [
+        "founder",
+        "research",
+        "sales"
+      ],
+      "emoji": "💸",
+      "description": "Run a willingness-to-pay study (van Westendorp + Gabor-Granger). Get a price recommendation segmented by persona.",
+      "works_best_with": {
+        "agent_profile": "finance-agent",
+        "skills": [
+          "concise-planning",
+          "pdf"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Define the persona segments",
+        "Design the survey instrument",
+        "Sample 200+ respondents",
+        "Analyze + segment WTP",
+        "Output a price recommendation"
+      ],
+      "prompt": "Run a willingness-to-pay study to set defensible pricing.\n\nInputs:\n- Product description + value prop: [paste]\n- Closest 3 alternative tools customers compare against: [paste]\n- Persona segments to test: [paste — e.g. solo creators / SMB teams / enterprise]\n- Existing customer list (for current users) + prospect list (for non-users): [paste]\n- Target sample size (200+ for stat-sig): [paste]\n\nPhase 1 — Persona segmentation.\n- Define 2-3 personas with distinct contexts (use case, team size, prior tool, budget authority)\n- For each: estimate population size + how to recruit (email list, X/LinkedIn DMs, panel provider)\n\nPhase 2 — Design the instrument.\nVan Westendorp 4 questions:\n1. At what price would the product be SO EXPENSIVE you would not consider buying it?\n2. At what price would it be SO CHEAP you would question its quality?\n3. At what price would it be expensive but still consider it?\n4. At what price would it be a bargain?\n\nGabor-Granger (sequential):\n- Present prices in random order; ask \"would you buy at $X?\" Yes/No\n- Use to estimate demand curve\n\nPlus:\n- \"What's the most important reason this would be worth $X?\" (open text)\n- Persona-qualifier questions (size, role, current solution, budget)\n\nPhase 3 — Sample 200+ respondents.\n- Run the survey via Typeform / SurveyMonkey\n- Recruit via channels matched to personas (no LinkedIn for solo creators, no Reddit for enterprise)\n- Incentive: $5-10 gift card or product credit\n- QA: filter for speeders (<2 min completion), straight-liners\n\nPhase 4 — Analyze.\n- Van Westendorp: plot the 4 curves; identify Optimal Price Point (OPP), Indifference Price (IPP), Point of Marginal Cheapness (PMC), Point of Marginal Expensiveness (PME)\n- Gabor-Granger: estimate price-elastic demand per persona\n- Segment by persona — surface meaningful WTP differences\n- Cross-tabulate by current solution (price-anchored against the alternative)\n\nPhase 5 — Price recommendation.\n- Recommended price points per persona\n- Confidence interval (this is research, not law)\n- Implications for packaging (where to draw tier lines)\n- The single test you should run to confirm in-market\n\nPhase 6 — Output.\n- Survey results raw + cleaned (.csv)\n- Van Westendorp + Gabor-Granger charts (PDF)\n- A 3-page recommendation memo\n- Discussion guide for the 5 qualitative follow-up calls\n\nFeedback signal (closes loop for the next study):\n- Discrepancy between WTP and actual conversion at the recommended price — calibrates response bias\n- Which personas were under- vs over-sampled\n- New segments that emerged in the open-text responses\n\nQuality bar:\n- NEVER set price ON the WTP point — use it as a SIGNAL, not gospel\n- NEVER skip current-solution anchoring — context shifts WTP by 30%+\n- Cite sample size + confidence range whenever you cite a WTP number\n- Stated preference ≠ revealed preference — pair with an in-market A/B before locking"
+    },
+    {
+      "id": "positioning-workshop",
+      "name": "Run an Obviously Awesome positioning workshop",
+      "category": "Marketing",
+      "tags": [
+        "founder",
+        "marketing",
+        "research"
+      ],
+      "emoji": "🧩",
+      "description": "Run April Dunford's 10-step positioning workshop. Get a positioning statement that drives messaging, sales, and website.",
+      "works_best_with": {
+        "agent_profile": "marketing-agent",
+        "skills": [
+          "concise-planning",
+          "vale-brand-voice",
+          "pdf"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "List competitive alternatives",
+        "Identify unique attributes",
+        "Map attributes to value",
+        "Pick the best-fit customer",
+        "Pick a market category",
+        "Output the statement + messaging"
+      ],
+      "prompt": "Run the Obviously Awesome positioning workshop (April Dunford's 10 steps).\n\nInputs:\n- Product + current positioning (if any): [paste]\n- 3-5 best customers + why they bought: [paste]\n- Top 5 customer interview quotes about what we replaced: [paste]\n- Closest 3 competitors / alternatives: [paste]\n- Founder gut feel on the category: [paste]\n\nPhase 1 — Competitive alternatives.\n- What would customers use if we didn't exist? (NOT just direct competitors — spreadsheets, agencies, doing-nothing all count)\n- Cluster alternatives by type\n- For each, note: why customers reject it, what they're optimizing for instead\n\nPhase 2 — Unique attributes.\n- What capabilities does our product have that customers care about?\n- Filter: must be true AND differentiated AND defensible\n- Drop anything customers don't actually mention in interviews\n- Output: 5-10 attributes\n\nPhase 3 — Map attributes to value.\n- For each attribute: what's the customer benefit? (translate features to value)\n- Cluster benefits into themes (typically 2-3 themes)\n- Identify the SINGLE highest-leverage theme\n\nPhase 4 — Best-fit customer.\n- Describe the customer for whom our value is most valuable\n- Persona attributes that predict fit (industry, team size, current tool, trigger event)\n- Anti-persona: who is this NOT for (saying no sharpens the yes)\n\nPhase 5 — Market category.\n- Pick the market frame that makes your differentiation matter\n- Three options: existing category, sub-category, new category — score each on credibility + market readiness\n- Recommend ONE category with one paragraph of why\n\nPhase 6 — Trends (the \"why now\").\n- 2-3 macro / market / tech trends that make your positioning resonate now\n- Tie each to your differentiation\n\nPhase 7 — Positioning statement (1 paragraph).\n- For [best-fit customer]\n- Who has [trigger / problem]\n- [Product] is a [market category]\n- That unlike [alternative]\n- Delivers [highest-leverage benefit theme]\n- Because [unique attribute that makes it credible]\n\nPhase 8 — Messaging cascade.\n- Homepage H1 (one sentence, based on the positioning)\n- 3 supporting messages (one per feature theme)\n- One-line pitch for sales\n- One-line pitch for fundraising\n\nPhase 9 — Output.\n- A 2-page positioning doc (statement + workshop outputs)\n- Homepage copy draft tied to the positioning\n- Sales deck refresh outline\n- A \"what changes\" memo (so the team knows what's different)\n\nFeedback signal:\n- Customer interviews 90 days post-launch — does the positioning land?\n- Sales meeting outcomes — does the new pitch shorten sales cycles?\n- Inbound lead quality — better-fit leads = the positioning works\n\nQuality bar:\n- NEVER position around features — position around value\n- NEVER claim a category you can't credibly own\n- The positioning statement is NOT the website headline — it's the input to the headline\n- Re-run the workshop annually OR when the market shifts (new competitor, new buyer)"
+    },
+    {
+      "id": "north-star-metric-tree",
+      "name": "Define the North Star Metric + input tree",
+      "category": "Productivity",
+      "tags": [
+        "founder",
+        "productivity",
+        "report"
+      ],
+      "emoji": "🌟",
+      "description": "Define a North Star Metric + its input tree. Get a one-pager that drives OKRs and dashboards.",
+      "works_best_with": {
+        "agent_profile": "personal-assistant",
+        "skills": [
+          "concise-planning",
+          "pdf"
+        ],
+        "mcp_servers": [
+          "notion-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Pick a candidate NSM",
+        "Validate it leads revenue",
+        "Decompose into 3-5 input metrics",
+        "Map inputs to team ownership",
+        "Output a 1-page NSM doc"
+      ],
+      "prompt": "Define the company's North Star Metric (NSM) + its input tree.\n\nInputs:\n- Business model (subscription / usage / marketplace / transactional): [paste]\n- Current top-level metrics (ARR, GMV, sessions, etc.): [paste]\n- Last 6 months of revenue + customer behavior data: [paste]\n- Strategic 2-year goal: [paste]\n\nPhase 1 — Pick the NSM candidate.\nThe NSM is a SINGLE customer-behavior metric that leads revenue. Examples:\n- Spotify: time spent listening\n- Airbnb: nights booked\n- Slack: messages sent in connected teams\n- Figma: weekly active editors\n\nScore candidates against:\n- Does it lead revenue? (a customer doing more of THIS predicts more revenue)\n- Is it customer-behavior, not company output? (not \"ARR\" itself)\n- Is it measurable WEEKLY, not quarterly?\n- Will it survive a strategic pivot?\n\nRecommend ONE candidate with reasoning. Wait for me to confirm.\n\nPhase 2 — Validate it leads revenue.\n- For the last 12 months: plot the NSM trend vs revenue\n- If they correlate, what's the lag? (NSM should lead revenue by 1-3 months)\n- Cohort: do customers with high NSM values retain better?\n- If correlation is weak, reconsider the NSM choice\n\nPhase 3 — Decompose into 3-5 input metrics.\nThe classic decomposition: Breadth (how many) × Depth (how much per) × Frequency (how often) × Efficiency (per unit cost)\nOutput: a tree with the NSM at the root, 3-5 inputs in the next layer, sub-inputs below.\n\nPhase 4 — Map inputs to team ownership.\n- Each input metric has one owner (a team or function)\n- Each team's OKRs should ladder into their NSM input\n- Surface dependencies (where two teams share an input)\n\nPhase 5 — Build the dashboard.\n- Single screen showing: NSM weekly + 4-week MA + last quarter\n- Inputs: same view per metric\n- Cohort filters: by acquisition channel, by tier, by tenure\n\nPhase 6 — Output.\n- 1-page NSM doc (Lenny / Amplitude style)\n- The input tree diagram\n- A team-ownership map\n- Dashboard spec (for the data team to build)\n- A \"review the NSM annually\" reminder + criteria for changing it\n\nFeedback signal:\n- Per quarter: did movement in NSM predict revenue? (validates the choice)\n- Inputs that decoupled from the NSM — surface and re-decompose\n- Inputs nobody worked on — surface ownership gaps\n\nQuality bar:\n- The NSM is ONE metric — not \"the top 5 KPIs\"\n- NEVER pick a metric you can't measure weekly\n- NEVER pick a vanity metric (signups, downloads) — pick a value-creating behavior\n- The NSM should survive the next pivot — if not, you have a feature metric, not a strategy metric"
+    },
+    {
+      "id": "customer-advisory-board",
+      "name": "Launch a Customer Advisory Board",
+      "category": "Customer Success",
+      "tags": [
+        "customer-success",
+        "founder"
+      ],
+      "emoji": "🎤",
+      "description": "Launch and run a Customer Advisory Board. Get a charter, member selection, agenda template, and a roadmap-input loop.",
+      "works_best_with": {
+        "agent_profile": "personal-assistant",
+        "skills": [
+          "concise-planning",
+          "pdf"
+        ],
+        "mcp_servers": [
+          "notion-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Write the CAB charter + objectives",
+        "Pick 8-12 members across segments",
+        "Design the meeting cadence + agenda",
+        "Capture inputs into the roadmap",
+        "Run a 90-day post-meeting follow-through"
+      ],
+      "prompt": "Launch and run a Customer Advisory Board (CAB) for strategic input.\n\nInputs:\n- Stage + ARR: [paste]\n- Top 30 customers (with ACV, tenure, industry): [paste]\n- Strategic questions I want CAB input on this year: [paste]\n- Time commitment I can sustain (2-3 meetings/year is realistic): [paste]\n\nPhase 1 — Write the CAB charter.\n- Purpose (NOT \"feedback\" — be specific: roadmap input, strategic direction, market signal)\n- Term length (12-24 months)\n- Member commitments (attend N meetings, complete pre-reads, share NPS-like input)\n- What CAB members get (early access, exec relationships, peer network, brand benefit)\n- What the company does NOT promise (feature commitments, exclusive deals)\n\nPhase 2 — Pick 8-12 members.\nMix:\n- 4-5 enterprise (high ACV, governance buyers)\n- 3-4 mid-market (operational buyers)\n- 1-2 power users (champions, not buyers — heard differently)\n- Diverse industries (so no one industry dominates the input)\n\nPer member: name, title, company, ACV, tenure, what they bring (operator vs strategist vs technical voice)\n\nPhase 3 — Meeting cadence + agenda.\n- 2 in-person meetings/year (1 at your office or HQ, 1 at industry event) + 2 virtual quarterlies\n- Agenda per meeting:\n  - State of the company (CEO, 15 min)\n  - Strategic question 1 + open discussion (60 min)\n  - Strategic question 2 + open discussion (60 min)\n  - Open round (each member: top-of-mind, 5 min each)\n  - Next steps + commitments\n- Pre-read sent 7 days ahead\n\nPhase 4 — Capture inputs into the roadmap.\n- Real-time scribe during the meeting (not the CEO)\n- 48h post-meeting: a \"what we heard, what we're committing to\" memo back to members\n- 30-day check-in: status on the commitments made\n- Surface CAB inputs in the next quarter's roadmap review with explicit attribution\n\nPhase 5 — Run a 90-day follow-through.\n- Per commitment: owner + deadline + outcome\n- 90-day public update to CAB on what shipped (and what didn't and why)\n- Annual NPS-style survey of CAB members themselves (\"is this CAB worth your time?\")\n\nPhase 6 — Output.\n- CAB charter PDF (sent to invitees before they say yes)\n- Member roster + roles\n- Meeting agendas (4 per year, pre-built)\n- A roadmap-input log linking CAB sessions to shipped features\n- A \"thank you\" gift cadence (small, thoughtful, recurring)\n\nFeedback signal:\n- CAB-attributed roadmap items: did they outperform other roadmap items?\n- Member attendance + engagement — surface decay\n- The 1 strategic question per meeting that produced the BEST debate — calibrate future agendas\n\nQuality bar:\n- NEVER use the CAB as a sales channel — that breaks trust fast\n- NEVER over-promise on inputs — be honest about what you can/can't ship\n- Skipping the follow-through memo is the single biggest reason CABs die\n- The CEO attends every meeting — delegating signals it's not strategic"
+    },
+    {
+      "id": "case-study-pipeline",
+      "name": "Run a case-study + reference customer pipeline",
+      "category": "Sales",
+      "tags": [
+        "founder",
+        "pipeline",
+        "sales"
+      ],
+      "emoji": "🪪",
+      "description": "Run a case-study + reference customer pipeline. Get a tiered advocacy program from logo to CAB.",
+      "works_best_with": {
+        "agent_profile": "marketing-agent",
+        "skills": [
+          "concise-planning",
+          "vale-brand-voice",
+          "pdf"
+        ],
+        "mcp_servers": [
+          "notion-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Audit current proof assets + gaps",
+        "Build the advocacy tier ladder",
+        "Identify candidates per tier",
+        "Production-line case studies",
+        "Track reference health + freshness"
+      ],
+      "prompt": "Run a case-study + reference customer pipeline as a tiered advocacy program.\n\nInputs:\n- Current proof assets (logos, quotes, case studies): [paste or link]\n- Customer list with NRR, ACV, tenure, NPS, usage: [paste]\n- Sales team's most-requested case study types: [paste]\n- Brand voice + production capacity (in-house vs agency): [paste]\n\nPhase 1 — Audit current proof.\n- What proof do we have? (logos / quotes / 1-page case / long-form / video / quantified ROI)\n- What's MISSING for the top 3 buyer personas?\n- Which assets are stale (>12 months old) and need a refresh?\n- Which logos have permission to use vs which we use without permission (risky)?\n\nPhase 2 — Build the advocacy ladder.\nTier 1: logo permission (low ask, big value)\nTier 2: pull-quote with name + title\nTier 3: 1-page case study with metric\nTier 4: long-form case study + customer interview\nTier 5: live reference call (1:1, scheduled by sales)\nTier 6: CAB member / on-stage speaker / co-marketing\n\nEach tier graduates from the previous. Don't ask for tier 4 from a customer who hasn't done tier 1-3 first.\n\nPhase 3 — Identify candidates per tier.\nScore every customer:\n- Outcome strength: do they have a defensible metric? (NPS, ROI, time saved, growth)\n- Vocal quality: do they speak well about us in any forum? (review sites, Slack, LinkedIn)\n- Buyer match: do they map to a top-3 buyer persona we need proof for?\n- Legal risk: are they in a regulated industry (banks, healthcare) that limits public refs?\n\nOutput: a ranked list per tier with the next ask per customer.\n\nPhase 4 — Production line.\nFor tier 3-4 case studies:\n- 60-min interview with the buyer (recorded, transcribed)\n- 60-min follow-up with the user (recorded, transcribed)\n- Draft within 7 days; customer review within 14 days; publish within 30 days\n- Promote across: website, sales deck, sales emails, social, conference\n\nPhase 5 — Track reference health.\n- Per reference: last touched, current state (active / dormant / churning), open asks\n- Refresh every 12 months OR after major customer outcome change\n- Watch for churn signals — pull references BEFORE they leave\n\nPhase 6 — Output.\n- Advocacy ladder spreadsheet (per customer: current tier + next ask)\n- Case study production template (interview guide, draft outline, approval flow)\n- Reference health dashboard\n- A \"thank you\" cadence (concrete: swag, exec lunch, in-person at the conference)\n\nFeedback signal:\n- Conversion rate per tier ask — calibrate the request copy\n- Sales cycle impact: deals with case studies vs without\n- Customer churn rate among active references vs general — surface the \"ref → churn\" signal\n\nQuality bar:\n- NEVER use a customer logo without explicit written permission\n- NEVER ship a case study without customer sign-off on every number and quote\n- Tier 5 (live reference) is rare — protect references from over-asking\n- If a customer says no, ask why — sometimes the answer reveals a churn signal"
+    },
+    {
+      "id": "founder-led-sales-script",
+      "name": "Run founder-led sales to repeatable revenue",
+      "category": "Sales",
+      "tags": [
+        "founder",
+        "loop",
+        "sales"
+      ],
+      "emoji": "🤜",
+      "description": "Run founder-led sales toward repeatable revenue. Get an ICP doc, discovery script, demo flow, and the first AE-ready playbook.",
+      "works_best_with": {
+        "agent_profile": "bd-partnerships",
+        "skills": [
+          "concise-planning",
+          "vale-brand-voice"
+        ],
+        "mcp_servers": [
+          "gmail-mcp",
+          "notion-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Run the first 50 sales calls personally",
+        "Diagnose what made wins win",
+        "Write the ICP + discovery + demo flow",
+        "Codify the sales playbook for the first AE",
+        "Hand off readiness checklist"
+      ],
+      "prompt": "Run founder-led sales toward a repeatable motion ($0-$5M ARR, Meka Asonye / First Round pattern).\n\nInputs:\n- Product + current ACV range: [paste]\n- Closed-won deals to date (with story per deal: who, why, how long): [paste]\n- Closed-lost deals (with reason): [paste]\n- My current weekly outbound + inbound volume: [paste]\n- My current top-of-funnel: [paste]\n\nPhase 1 — Diagnose existing wins.\n- For each closed-won: what was the trigger (Why did they buy? Why now?), what did they replace, who championed it inside, who held the budget, what was the sales cycle, what was the discount\n- Cluster the patterns\n- Surface the \"looks-like\" ICP from the wins (not your imagined ICP)\n\nPhase 2 — Diagnose existing losses.\n- For each closed-lost: why did they say no? (Price? Fit? Timing? Competitor? Internal politics?)\n- Cluster by reason\n- The reason that recurs most = the next sales-cycle blocker to address\n\nPhase 3 — Write the ICP doc.\n- Industry, company size, role of buyer, role of user, current solution\n- Trigger events (hiring spike, funding round, public price change at incumbent)\n- Disqualifiers (do not pursue if they have X)\n- Score model: 0-5 fit per dimension\n\nPhase 4 — Write the discovery script.\n- 30-min discovery call structure\n- Opening (90 sec — set context)\n- Pain qualification (10 min — using a MEDDIC / SPICED frame)\n- Solution narrative (5 min — NOT a feature dump)\n- Next-step proposal (3 min — concrete, time-bound)\n- Q&A (10 min — but front-load value before they ask)\n\nPhase 5 — Demo flow.\n- Pre-demo: confirm what they want to see (NOT a \"tour\")\n- Open with the magic moment + the customer outcome (15 sec)\n- Walk through 3-4 specific user stories tied to the pain they raised in discovery\n- Save Q&A for the end\n- Always end with the next step explicitly named\n\nPhase 6 — Output (playbook for the first AE).\n- ICP doc (1-page)\n- Discovery script (printable)\n- Demo flow with screenshots\n- Objection-handling card (top 10 objections from the loss data + responses)\n- Proposal + SOW template\n- Sales cycle map (stage gates with required artifacts)\n- Quota model (realistic, calibrated against your conversion data)\n\nFeedback signal (closes the loop):\n- AE win rate vs founder win rate — track the gap (it's normal, not a failure)\n- Stage where deals stall — promote interventions\n- Objections that appear with new ICP segments — refine the doc\n\nQuality bar:\n- NEVER hire an AE before you can answer \"what's the script that won 10 deals in a row?\"\n- NEVER hand off without sitting in on the first 10 calls together\n- The discovery script is a guide, not a script — train the AE to listen first\n- If the AE pushes back on the playbook, that's signal — they're seeing what you missed"
+    },
+    {
+      "id": "pql-definition-handoff",
+      "name": "Define PQLs and the sales handoff",
+      "category": "Sales",
+      "tags": [
+        "founder",
+        "pipeline",
+        "sales"
+      ],
+      "emoji": "🚦",
+      "description": "Define product-qualified leads and the sales handoff. Get a multi-step PQL definition + dashboard + outreach trigger.",
+      "works_best_with": {
+        "agent_profile": "bd-partnerships",
+        "skills": [
+          "concise-planning"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Map current product usage signals",
+        "Define the multi-step PQL threshold",
+        "Design the handoff to sales",
+        "Build the dashboard + alert",
+        "Read out PQL→close conversion"
+      ],
+      "prompt": "Define product-qualified leads (PQLs) and the sales handoff (Slack / Atlassian model).\n\nInputs:\n- Current product usage signals you can measure: [paste]\n- Closed-won deals' usage profiles BEFORE buying: [paste]\n- Sales team's current handoff (MQL definitions, lead routing): [paste]\n- Target ACV for sales-touched deals: [paste]\n\nPhase 1 — Map signals.\n- List every measurable usage signal (events, frequency, breadth)\n- For each: how strongly does it correlate with paid conversion in your data?\n- Drop signals with weak correlation\n- Keep 3-6 strong signals\n\nPhase 2 — Define the PQL threshold (multi-step).\nExample Slack model: 2+ channels created AND 1+ teammate invited AND first conversation completed AND 2,000+ messages sent.\nFor your product:\n- Combine 3-5 signals into a SINGLE definition (all must be true)\n- Validate against closed-won data: what % of converted accounts hit this? what % of free accounts that hit this convert?\n- Iterate the threshold until both numbers look strong\n\nPhase 3 — Design the handoff.\n- Trigger: account crosses the PQL threshold\n- Action: Slack alert to assigned AE + auto-create CRM opportunity at \"PQL\" stage\n- AE response: contact within 24h with a specific message (\"noticed your team scaled from X to Y last week — want to talk through how others handled the next step?\")\n- NEVER send a generic \"ready to upgrade?\" — the PQL is contextual, the outreach must be too\n\nPhase 4 — Build the dashboard.\n- PQL count per week\n- PQL → opportunity conversion\n- Opportunity → close conversion\n- Time from PQL to close (vs MQL-sourced)\n- ACV by source (PQL vs MQL)\n\nPhase 5 — Read out at 90 days.\n- PQL conversion vs MQL: it should be 3-5x\n- Sales feedback: are PQLs better conversations than MQLs?\n- The threshold may need to tighten OR loosen — calibrate\n\nPhase 6 — Output.\n- PQL definition document (the rule + the validating data)\n- Handoff workflow (Slack alert + CRM auto-create + AE response template)\n- Dashboard spec (for the data team)\n- A \"what counts as a PQL\" 1-pager for the sales team\n\nFeedback signal (closes the loop):\n- PQL-to-close conversion rate quarter over quarter — sharpen the threshold\n- Which signal in the definition is doing the most work — focus instrumentation\n- New product behaviors that correlate strongly with conversion — promote to PQL\n\nQuality bar:\n- NEVER let \"PQL\" mean \"free user who clicked pricing\" — that's not a PQL\n- NEVER skip the validation against closed-won data — PQLs without validation are MQLs renamed\n- The PQL definition will change every 2-3 quarters as the product evolves — review it\n- If sales says \"PQLs are bad leads\", listen — the threshold is wrong, not the strategy"
+    },
+    {
+      "id": "pmf-engine-survey",
+      "name": "Run the Superhuman PMF engine",
+      "category": "Customer Success",
+      "tags": [
+        "customer-success",
+        "founder",
+        "loop"
+      ],
+      "emoji": "🩺",
+      "description": "Run Superhuman's PMF engine. Get a 4-question survey, the very-disappointed cohort analysis, and a roadmap split.",
+      "works_best_with": {
+        "agent_profile": "personal-assistant",
+        "skills": [
+          "concise-planning",
+          "pdf"
+        ],
+        "mcp_servers": [
+          "gmail-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Identify active-user cohort",
+        "Send the 4-question survey",
+        "Calculate PMF score",
+        "Split roadmap 50/50 (double-down vs unblock)",
+        "Re-survey monthly"
+      ],
+      "prompt": "Run Rahul Vohra's Superhuman PMF engine (he lifted Superhuman from 22% to 58% in under a year).\n\nInputs:\n- Active users (used the product 2+ times in last 14 days): [paste count + sample]\n- Existing PMF measurement (if any): [paste]\n- Current top complaints + delighters surfaced via support: [paste]\n- Current roadmap: [paste]\n\nPhase 1 — Identify the active-user cohort.\n- Filter to users who used the product 2+ times in last 14 days (Vohra's threshold)\n- Drop users <14 days tenure (they don't know yet)\n- Verify the cohort represents your target customer (not just everyone)\n\nPhase 2 — Send the 4-question survey.\n1. How would you feel if you could no longer use [product]?\n   - Very disappointed / Somewhat disappointed / Not disappointed / N/A I no longer use [product]\n2. What type of people do you think would most benefit from [product]? (1 sentence)\n3. What's the main benefit you get from [product]? (1 sentence)\n4. How can we improve [product] for you? (open text)\n\nDistribution: in-product modal + email to non-modal-shown users. Target 100+ responses.\n\nPhase 3 — Calculate PMF + analyze.\n- PMF score = % \"very disappointed\" / (very + somewhat + not disappointed)\n- Score >40% = strong PMF; 20-40% = developing; <20% = weak\n- Segment the \"very disappointed\" cohort: who are they? What benefit do they cite?\n- Read the \"somewhat disappointed\" open text: what's the SINGLE biggest blocker?\n\nPhase 4 — Split the roadmap 50/50.\n- 50% of next-quarter roadmap: double down on what the \"very disappointed\" cohort loves\n- 50%: remove the top blocker cited by \"somewhat disappointed\"\n- The remaining 0%: anything else (yes, this is uncomfortable)\n\nPhase 5 — Re-survey monthly.\n- Same 4 questions, same cohort definition\n- Track PMF score trend: are you climbing toward 40%?\n- Track the \"very disappointed\" cohort growth: is it expanding to new personas?\n- If PMF stalls for 2 months, the diagnosis is wrong — re-read the open text\n\nPhase 6 — Output.\n- Survey instrument (ready to deploy)\n- Cohort analysis dashboard\n- Monthly PMF score with trend chart\n- A roadmap doc that explicitly maps every feature to \"double down\" or \"unblock\"\n- The \"very disappointed\" persona doc (used for marketing + sales targeting)\n\nFeedback signal (closes the loop):\n- Month-over-month PMF score trend — the engine working = climbing\n- \"Very disappointed\" cohort growth — new personas joining = expansion territory\n- \"Somewhat disappointed\" blockers that recur — that's the systemic friction\n\nQuality bar:\n- NEVER conflate PMF score with NPS — they measure different things\n- NEVER survey users who haven't tried the product enough to have an opinion\n- The \"very disappointed\" cohort IS your ICP — use their language in marketing\n- If you ignore the open text, you've wasted the survey"
+    },
+    {
+      "id": "activation-3-moments-audit",
+      "name": "Audit activation in 3 moments (setup, aha, habit)",
+      "category": "Productivity",
+      "tags": [
+        "audit",
+        "founder",
+        "loop",
+        "productivity"
+      ],
+      "emoji": "⚡",
+      "description": "Audit activation as setup / aha / habit (Reforge framework). Get a step-by-step diagnosis with the largest-drop fix.",
+      "works_best_with": {
+        "agent_profile": "marketing-agent",
+        "skills": [
+          "concise-planning",
+          "pdf"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Define each of the 3 moments concretely",
+        "Measure drop-off at each",
+        "Diagnose the largest-drop moment",
+        "Ship the fix + re-measure",
+        "Loop weekly until activation lifts"
+      ],
+      "prompt": "Audit activation as 3 moments (Setup → Aha → Habit) — the Reforge framework that lifted Attention Insight from 47% → 69% activation.\n\nInputs:\n- Current activation rate (define your existing metric): [paste]\n- Onboarding flow screenshots or recording: [paste or path]\n- Product analytics access (Mixpanel / Amplitude / PostHog / etc.): [paste how to access]\n- Top 5 customer interview quotes about onboarding: [paste]\n\nPhase 1 — Define each moment concretely.\n\nSetup moment: the user completes the minimum configuration needed for the product to function\n- For Slack: workspace created + 1 channel + 1 teammate\n- For Notion: workspace created + 1 page\n- For your product: ?\n\nAha moment: the user experiences the SINGLE highest-leverage outcome the product delivers\n- For Loom: first share + recipient watches\n- For Calendly: first meeting booked through the link\n- For your product: ?\n\nHabit moment: the user performs the aha moment at the frequency that predicts retention\n- For Slack: 2,000+ messages in connected teams\n- For Notion: 3+ pages created per week over 3 weeks\n- For your product: ?\n\nPick the 3 moments. Wait for me to confirm.\n\nPhase 2 — Measure drop-off at each.\n- % of signups completing Setup\n- % of Setup-completers hitting Aha\n- % of Aha-hitters reaching Habit\n- Each step is its own funnel\n\nPhase 3 — Diagnose the largest-drop moment.\n- For the worst step: where exactly do users drop?\n- Pair with customer interview quotes for context\n- Identify the SINGLE friction (a missing instruction, a confusing UI, a permission gate, a slow API call)\n- Validate: would removing this friction lift the step's conversion by 10+ pp?\n\nPhase 4 — Ship the fix.\n- Smallest possible change that addresses the friction\n- A/B against the current flow (50/50, 30 days)\n- Kill rule: if it doesn't move the step's conversion by 5 pp+, revert\n\nPhase 5 — Re-measure and loop.\n- After 30 days: read out and decide ship/iterate/kill\n- Move to the next-largest drop and repeat\n- Weekly: 15-min activation review with the team\n\nPhase 6 — Output.\n- The 3-moments definition doc\n- Funnel dashboard (one screen, all 3 moments visible)\n- Top 3 hypotheses + experiments queued\n- A weekly review template\n\nFeedback signal (closes the loop):\n- Per moment: conversion delta after each fix\n- Which fixes moved the metric vs which didn't — surface the patterns\n- New friction that emerges after fixing one (sometimes the bottleneck just moves)\n\nQuality bar:\n- NEVER count signups as activation — that's an acquisition metric\n- NEVER define the Aha moment without customer interviews — your guess is usually wrong\n- Habit metric must be defined at the FREQUENCY that retains — not just \"uses the product\"\n- If activation lifts but retention doesn't, your Aha definition is wrong"
+    },
+    {
+      "id": "product-hunt-launch",
+      "name": "Run a Product Hunt launch playbook",
+      "category": "Marketing",
+      "tags": [
+        "founder",
+        "marketing",
+        "social"
+      ],
+      "emoji": "🎉",
+      "description": "Run a Product Hunt launch end-to-end. Get a 4-week prep plan, day-of script, and supporter outreach templates.",
+      "works_best_with": {
+        "agent_profile": "marketing-agent",
+        "skills": [
+          "concise-planning",
+          "vale-brand-voice"
+        ],
+        "mcp_servers": [
+          "gmail-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Pick the launch date + category",
+        "Assemble a supporter list (400+)",
+        "Build assets to PH spec",
+        "Run the day-of playbook hour-by-hour",
+        "Post-launch follow-through"
+      ],
+      "prompt": "Run a Product Hunt launch end-to-end (4-week prep + day-of script + follow-through).\n\nInputs:\n- Product + one-liner: [paste]\n- Launch date target: [paste]\n- Existing supporter network on PH (likers from prior launches, hunter friends): [paste]\n- Founder's PH account history + karma: [paste]\n- Asset capacity (designer? video?): [paste]\n\nPhase 1 — Pick date + category.\n- Avoid Mondays (low traffic) and Fridays (PH-employee distraction)\n- Tuesdays or Wednesdays optimal\n- Avoid major news events / holidays that suck attention\n- Category choice matters: AI category needs ~800-1,200 upvotes for #1; non-AI ~500-700\n- Output: launch date + 4 backup dates\n\nPhase 2 — Assemble supporters (4 weeks out).\n- Goal: 400+ committed supporters with PH accounts\n- Source 1: scrape your previous launches' upvoters and message via PH inbox\n- Source 2: your X / LinkedIn audience that mentioned PH\n- Source 3: 10 hunter-friend asks (they comment + nudge their network)\n- Track in a sheet: name, account, last-checked-active, committed?, posted?, commented?\n\nPhase 3 — Build assets to PH spec.\n- Gallery images: 1270x760 pixels, 4-7 images (hero + features + social proof + team + roadmap)\n- Tagline: <=60 characters, outcome-driven (NOT \"Powered by AI\")\n- Description: 260 chars max, hook + 3 features + CTA\n- Maker comment: drafted in advance, 200-400 words, shows the human story\n- First-comment thread script: 10 angles to seed (hunter friends post these)\n\nPhase 4 — Day-of (hour-by-hour, PT time).\n- 00:01 PT: post goes live\n- 00:01-00:15: founder posts the maker comment + 3 hunter friends comment\n- 00:15-08:00: every hour, respond to every comment within 30 min; rotate posts across X, LinkedIn, Reddit, niche Slack/Discord\n- 08:00-20:00: peak voting window — maintain comment cadence, drive supporters via DM blast\n- 20:00 PT: final push email to supporters who haven't voted\n\nPhase 5 — Post-launch follow-through.\n- Thank-you post on X / LinkedIn with the result + lessons\n- Email everyone who signed up during the launch (within 48h) with a personal note\n- Convert engagement to email list / waitlist / paying customer — design the funnel BEFORE you launch\n- A \"what went well / what didn't\" memo for the next launch\n\nPhase 6 — Output.\n- 4-week prep timeline (Notion doc)\n- Supporter outreach template + tracking sheet\n- Asset checklist with PH specs\n- Day-of script with hour-by-hour actions\n- Post-launch follow-up plan\n\nFeedback signal (closes the loop for next launch):\n- Ranking outcome vs target\n- Comment volume + sentiment vs control launches\n- Conversion of PH visitors to signups + paid — that's the real metric, not upvotes\n\nQuality bar:\n- NEVER pay for votes — PH detects and de-ranks\n- NEVER schedule a launch on a Friday or holiday\n- The maker comment is NOT a feature dump — it's a story about why this exists\n- Day-of: respond to every comment within 30 min, even the critical ones — the engagement signal matters"
+    },
+    {
+      "id": "programmatic-seo-sprint",
+      "name": "Run a programmatic SEO sprint",
+      "category": "Marketing",
+      "tags": [
+        "marketing",
+        "pipeline",
+        "seo"
+      ],
+      "emoji": "🕷️",
+      "description": "Run a programmatic SEO sprint. Get a templated landing-page matrix, schema, internal-link map, and quality gate.",
+      "works_best_with": {
+        "agent_profile": "marketing-agent",
+        "skills": [
+          "brave-search",
+          "firecrawl",
+          "concise-planning"
+        ],
+        "mcp_servers": [
+          "notion-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Pick the 2-dimension matrix",
+        "Validate search volume + intent",
+        "Build the template + unique-content slots",
+        "Generate + hand-tune top 50",
+        "Track + iterate"
+      ],
+      "prompt": "Run a programmatic SEO sprint (Zapier / Calendly / Webflow pattern — Zapier 6.3M monthly visits, Calendly 1.1M).\n\nInputs:\n- Product + ICP: [paste]\n- Existing site domain authority (DA / DR): [paste]\n- Existing top-ranking pages (so we don't cannibalize): [paste]\n- Data source for unique content (your DB, public API, your integrations list): [paste]\n- Capacity to hand-tune (humans + days): [paste]\n\nPhase 1 — Pick the 2-dimension matrix.\nExamples:\n- {App A} × {App B} (integration pages — Zapier)\n- {Tool} × {Use case} (Calendly: scheduling × CRM)\n- {City} × {Job role} (talent marketplaces)\n- {Industry} × {Software type} (vertical SaaS)\n\nScore candidates:\n- Total page count (matrix size): aim for 100-10,000, not 1,000,000 (Google penalizes thin)\n- Search volume: every cell needs SOMEONE searching; ideally most cells have monthly volume >10\n- Intent: commercial > informational > navigational\n- Existing competition: low-DA pages ranking on this matrix = opportunity\n\nRecommend ONE matrix. Wait for me to confirm.\n\nPhase 2 — Validate search volume + intent.\n- Pull volume per cell from Ahrefs / Semrush / KWFinder\n- Sample 50 cells; look at the current SERP — what dominates? Can we credibly compete?\n- Identify cells where intent is COMMERCIAL (closer to purchase) and prioritize\n\nPhase 3 — Build the template + unique content slots.\n- Template structure: H1, hero (intro paragraph with both keywords), use-case examples, screenshots, CTA, FAQ, schema markup (FAQPage + Product + BreadcrumbList)\n- Unique content per cell: pulled from your data source (e.g., for {App A} × {App B} integration: actual fields synced, popular use cases, customer count if available)\n- DO NOT use the same paragraph across cells — Google will downgrade\n\nPhase 4 — Generate + hand-tune top 50.\n- Generate the full matrix programmatically\n- Hand-tune the TOP 50 cells (by search volume × intent): better intro, custom screenshots, real-customer quotes\n- These 50 carry the quality signal that lifts the rest of the matrix\n\nPhase 5 — Internal link map.\n- Every page links to: 5 related cells (same dimension A or B), the pillar page, and the relevant product page\n- Pillar page links out to top 100 cells\n- Each cell page has 2-3 incoming internal links minimum\n\nPhase 6 — Quality gate before publishing.\n- Lighthouse score >85 mobile\n- Schema validates (Rich Results Test)\n- No cell has <300 unique words\n- Robots.txt + sitemap.xml updated\n\nPhase 7 — Output.\n- Matrix spec + template\n- Generated pages staged for publish\n- Internal link map (CSV)\n- A 90-day measurement plan (organic clicks per cell, conversion to signup, pages indexed)\n\nFeedback signal:\n- Per cell type: organic traffic growth + ranking\n- Conversion rate by cell to product signup\n- Cells Google chose NOT to index (these are the thin ones — improve or delete)\n\nQuality bar:\n- NEVER publish 10,000 pages with thin content — Google de-ranks the WHOLE site\n- NEVER duplicate paragraphs across cells — that's the death signal\n- A 100-cell matrix that ranks beats a 10,000-cell matrix that doesn't\n- Disclose AI-generated content if your audience cares (devs, journalists do)"
+    },
+    {
+      "id": "build-in-public-launch",
+      "name": "Run a build-in-public launch sequence",
+      "category": "Marketing",
+      "tags": [
+        "founder",
+        "marketing",
+        "social"
+      ],
+      "emoji": "📡",
+      "description": "Run a build-in-public launch sequence (Pieter Levels / Marc Lou). Get a daily posting plan, revenue-screenshot cadence, and an audience-to-revenue funnel.",
+      "works_best_with": {
+        "agent_profile": "marketing-agent",
+        "skills": [
+          "concise-planning",
+          "vale-brand-voice"
+        ],
+        "mcp_servers": [
+          "twitter-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Audit current audience + funnel",
+        "Set the daily posting cadence",
+        "Build the metric-screenshot rhythm",
+        "Plan the launch with the audience",
+        "Measure audience-to-revenue conversion"
+      ],
+      "prompt": "Run a build-in-public launch sequence (Pieter Levels $3M ARR / Marc Lou $4K/day pattern).\n\nInputs:\n- Existing X / LinkedIn / IH audience size + engagement rate: [paste]\n- Product + launch date: [paste]\n- Existing revenue (if any): [paste]\n- Comfort level with public transparency (revenue, churn, mistakes): [paste]\n- Founder's voice samples (what's already worked): [paste]\n\nPhase 1 — Audit current audience + funnel.\n- Audience size per platform + engagement rate\n- Bio CTA (what's it driving to?)\n- Existing funnel: posts → profile visits → product signups → revenue\n- Surface the conversion gap\n\nPhase 2 — Set the daily posting cadence.\n- X: 2-3 posts/day (a build update + a lesson + an engagement post)\n- LinkedIn: 1 post/day (longer-form, founder narrative)\n- Indie Hackers: 2-3 posts/week (community-focused, more transparent)\n- Each post matched to the platform's norms (X tight, LinkedIn narrative, IH peer-to-peer)\n\nPhase 3 — Build the metric-screenshot rhythm.\n- Weekly: Stripe MRR screenshot with one lesson\n- Monthly: full revenue + churn + cost transparency\n- Each milestone: shipping screenshot ($1k MRR, $10k, $100k, etc.)\n- Failures shared candidly — fails build trust faster than wins\n\nPhase 4 — Plan the launch with the audience.\n- 30 days out: tease the problem you're solving (NOT the product yet)\n- 14 days out: tease the build with screenshots\n- 7 days out: open a waitlist (or \"DM me to be a beta tester\")\n- Launch day: drop the URL + price + first-customer offer\n- Post-launch: daily revenue screenshots + lessons for 14 days\n\nPhase 5 — Measure audience-to-revenue.\n- Per-platform: clicks to product, signups, paid conversions\n- Which post types convert (build updates? lessons? failures?)\n- Average revenue per follower (RPF) — a real metric for indie founders\n\nPhase 6 — Output.\n- 30-day content calendar (per platform, per day)\n- Screenshot rhythm calendar (what to share, when)\n- Launch sequence checklist (30-day countdown)\n- A spreadsheet tracking audience size + engagement + revenue weekly\n\nFeedback signal (closes the loop):\n- Post type that drove most clicks vs signups vs revenue — bias next month's mix\n- Platform that converts best for your ICP — focus your time\n- \"Big number\" milestones that compound (each milestone is a content asset)\n\nQuality bar:\n- NEVER fake the screenshots — the internet finds out\n- NEVER post revenue screenshots if you're loss-leading (it confuses ICP)\n- Engage with comments — passive build-in-public underperforms active engagement\n- Be honest about what's not working — that's what builds trust (and the audience)"
+    },
+    {
+      "id": "oss-to-commercial-conversion",
+      "name": "Plan an open-source → commercial conversion",
+      "category": "Sales",
+      "tags": [
+        "founder",
+        "sales"
+      ],
+      "emoji": "🔓",
+      "description": "Plan an OSS → commercial transition (dbt / PostHog / Plausible / n8n). Get a tier design, hosted offering spec, and OSS commit guarantees.",
+      "works_best_with": {
+        "agent_profile": "marketing-agent",
+        "skills": [
+          "concise-planning",
+          "pdf"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Audit current OSS community + usage",
+        "Design the commercial wrapper (hosted / governance / SLA)",
+        "Spec OSS commits the company guarantees",
+        "Plan the launch + comms",
+        "Measure OSS → commercial conversion"
+      ],
+      "prompt": "Plan an open-source → commercial transition (dbt / PostHog / Plausible / n8n pattern).\n\nInputs:\n- OSS project + GitHub stats (stars, contributors, deploys): [paste]\n- Current community (Discord / Slack / Discourse size): [paste]\n- Top 10 self-hosted users you know about: [paste]\n- License (MIT? AGPL? Fair-code?): [paste]\n- Founder principles (what stays free FOREVER): [paste]\n\nPhase 1 — Audit OSS community + usage.\n- Self-hosted deploy count (rough estimate from telemetry, npm/pip downloads, Docker pulls)\n- Community engagement: Discord activity, GitHub issue velocity, PR cadence\n- Top 5 use cases (ask the community in the Discord)\n- Top 5 pain points self-hosters cite (these are your hosted-tier value props)\n\nPhase 2 — Design the commercial wrapper.\nFree (OSS, forever):\n- Core functionality\n- Single-instance, single-user / small-team usage\n- Community-supported\n\nHosted (paid, value metric per the product):\n- Zero-ops deployment\n- Backups, monitoring, scaling\n- Per usage tier (events, GMV, seats, whatever scales with value)\n\nTeam / Enterprise (paid, governance):\n- SSO + SCIM\n- Audit logs\n- SLA + dedicated support\n- Compliance (SOC2, HIPAA, GDPR controls)\n\nPhase 3 — Spec OSS commits the company guarantees.\n- Which features will ALWAYS be in OSS (no take-backs)\n- Pace of OSS commits vs commercial features\n- Public governance: who decides what goes where\n- Public roadmap with commercial-vs-OSS labels\n\nPhase 4 — Plan the launch + comms.\n- The blog post: why we're doing this, what changes for users, what doesn't\n- Community AMA in Discord — answer the hard questions live\n- Migration story for current users (free hosted credit, white-glove migration for top users)\n- Pricing-page launch with side-by-side OSS / Hosted / Enterprise\n\nPhase 5 — Measure OSS → commercial conversion.\n- Hosted-paid conversion rate from self-hosted users (target 1-3% in year one)\n- Enterprise conversion from hosted-paid (target 5-10% by year two)\n- Community sentiment: are commits accelerating or decelerating after launch?\n- NPS in Discord pre vs post\n\nPhase 6 — Output.\n- Tier design doc + pricing\n- OSS commit guarantee + governance doc\n- Migration playbook for top self-hosted users\n- Launch comms package (blog, Discord AMA, email to known self-hosters)\n\nFeedback signal:\n- Per quarter: hosted conversion + enterprise upgrade + community sentiment\n- Backlash patterns — surface what looks like betrayal vs honest concern\n- Features the community wants in OSS that you held back — re-evaluate\n\nQuality bar:\n- NEVER pull a feature from OSS into commercial — that breaks trust permanently\n- NEVER ship a license change without 90-day community notice\n- The OSS project must remain genuinely useful standalone — anything else is bait-and-switch\n- Hire community-first: the community manager comes BEFORE the second sales rep"
+    },
+    {
+      "id": "marketplace-cold-start",
+      "name": "Solve the marketplace cold-start problem (supply-first)",
+      "category": "Sales",
+      "tags": [
+        "founder",
+        "pipeline",
+        "sales"
+      ],
+      "emoji": "🏪",
+      "description": "Solve marketplace cold start by saturating supply first (Andrew Chen pattern). Get a city-by-city supply plan and demand trigger.",
+      "works_best_with": {
+        "agent_profile": "marketing-agent",
+        "skills": [
+          "concise-planning",
+          "pdf"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Identify the supply concentration unit (city / niche / time)",
+        "Saturate one unit at a time",
+        "Define the supply density that unlocks demand",
+        "Open demand only after the threshold",
+        "Iterate to the next unit"
+      ],
+      "prompt": "Solve the marketplace cold-start problem by saturating supply first (Andrew Chen pattern — Airbnb / Uber / Tinder hard-side).\n\nInputs:\n- Marketplace concept + take rate: [paste]\n- Supply side (sellers / drivers / hosts / etc.) + demand side: [paste]\n- Geographic or vertical concentration unit (city, niche, time-slot): [paste]\n- Capital available for supply incentives: [paste]\n- Competitive supply (where do they already sell?): [paste]\n\nPhase 1 — Identify the concentration unit.\n- For Airbnb: city (a host in NYC matters to NYC demand only)\n- For Uber: city + time-of-day\n- For a vertical talent marketplace: niche (frontend devs)\n- For a creator marketplace: niche × creator-size tier\n\nRecommend ONE concentration unit. Wait for me to confirm.\n\nPhase 2 — Pick the first unit and saturate.\n- Pick the unit where you have the strongest founder-network edge (NOT the biggest market)\n- Define \"saturated\": e.g., Airbnb required 300 listings + 100 reviewed per city BEFORE opening demand\n- For your unit: what's the equivalent threshold?\n\nPhase 3 — Acquire supply.\n- Tactic 1: poach from competitor marketplaces (personally email 100+ existing supply, offer \"list with us free + send you a check minus reduced take rate\")\n- Tactic 2: white-glove onboarding (founder personally onboards first 50 supply — record what they ask)\n- Tactic 3: anchor supply (recruit 3-5 high-status supply that draws others — celebrity hosts, top devs, signature restaurants)\n- Tactic 4: subsidize early — pay supply directly to be present for the first 90 days\n\nPhase 4 — Hold demand back.\n- Resist the urge to acquire demand before supply is dense\n- A poor first-demand experience kills brand\n- Only open demand when supply density gives a 90%+ \"find what you came for\" rate\n\nPhase 5 — Open demand (carefully).\n- One channel only at first (e.g., one neighborhood, one Reddit community, one influencer)\n- Measure: completion rate, NPS, return-visit rate\n- Tune the supply mix based on demand feedback\n\nPhase 6 — Iterate to the next unit.\n- Once unit 1 is humming, replicate the supply-acquisition playbook in unit 2\n- Don't open unit 3 until unit 2 has demand traction\n- City-by-city beats nationwide-launch for the first 10 units\n\nPhase 7 — Output.\n- Concentration-unit choice + reasoning memo\n- Supply density threshold per unit\n- Supply acquisition playbook (4 tactics with scripts + budgets)\n- 90-day plan for unit 1 with weekly milestones\n- A \"launch criteria\" checklist for opening demand\n\nFeedback signal:\n- Supply density → demand completion rate curve — calibrates the threshold for next unit\n- Supply churn per unit — surface why supply leaves\n- Which acquisition tactic worked best per unit — bias the next unit's playbook\n\nQuality bar:\n- NEVER open demand before supply is saturated — first-impression damage compounds\n- NEVER assume one supply playbook works in every unit — each unit has its own dynamics\n- Subsidies expire — plan unit-economics that work without subsidy by month 12\n- Order: supply, demand, supply, supply, supply (Andrew Chen's heuristic for hard-side marketplaces)"
+    },
+    {
+      "id": "founder-time-audit",
+      "name": "Run a 5-day founder time audit + delegation log",
+      "category": "Personal",
+      "tags": [
+        "audit",
+        "founder",
+        "personal"
+      ],
+      "emoji": "⏱️",
+      "description": "Run a 5-day founder time audit. Get a leverage map, a delegation log, and a 90-day re-audit plan.",
+      "works_best_with": {
+        "agent_profile": "personal-assistant",
+        "skills": [
+          "concise-planning",
+          "pdf"
+        ],
+        "mcp_servers": [
+          "gmail-mcp",
+          "notion-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Log activity in 30-min blocks for 5 workdays",
+        "Categorize hours by leverage tier",
+        "Identify delegation candidates",
+        "Write the delegation log",
+        "Schedule 90-day re-audit"
+      ],
+      "prompt": "Run a 5-day founder time audit + delegation log (First Round pattern — re-audit at 90 days).\n\nInputs:\n- Last week's calendar (or paste a screenshot): [paste]\n- Last week's journal / Slack messages / commits: [paste or path]\n- My current top 3 priorities: [paste]\n- Team I could delegate to (with role + capacity): [paste]\n- My self-perceived \"energy zones\" (high / low productivity times): [paste]\n\nPhase 1 — Log 5 days in 30-min blocks.\n- For each block: activity, who I was with, mode (deep work / shallow / meeting / reactive), energy level (high/med/low)\n- Be honest — count Twitter scrolling and email refresh\n- Don't skip the bathroom breaks and lunch — those have signal too\n\nPhase 2 — Categorize by leverage tier.\nTier 1 (10x leverage — only-the-founder-can-do):\n- Strategic decisions, hiring critical roles, top-customer relationships, public face\nTier 2 (3x — founder-best-equipped, but delegable later):\n- Founder-led sales, fundraising prep, key product decisions\nTier 3 (1x — important but generic):\n- Email management, scheduling, reporting, expenses\nTier 4 (<1x — reactive, eats time):\n- Slack noise, low-stakes context-switching, reactive meetings\n\nTotal hours per tier. Surface where 60%+ of your week is going.\n\nPhase 3 — Identify delegation candidates.\n- Every Tier 3 / 4 activity: who could do this today? (name a person)\n- If no one can do it today, what would they need to be ready in 30 days?\n- Compute the cost: hiring vs delegating to an existing teammate vs automating\n\nPhase 4 — Write the delegation log.\nFor each delegation:\n- Activity, owner, transition plan (shadow → co-do → handoff)\n- Approval needed before owner takes over (and how often that approval shrinks)\n- Quality bar — what does \"good\" look like?\n- The \"I take back\" condition (when do I re-own this?)\n\nPhase 5 — Schedule the 90-day re-audit.\n- Same 5-day log in 90 days\n- Compare leverage-tier mix before vs after\n- If Tier 3 / 4 still >40% of week, delegation isn't sticking — diagnose\n\nPhase 6 — Output.\n- 5-day log (filled in)\n- Leverage tier pie chart\n- Delegation log (Notion / sheet) with owners + transition plans\n- A \"stop list\" — things I'll just stop doing (not delegate)\n- 90-day re-audit calendar block\n\nFeedback signal:\n- Tier mix delta over 90 days — are you actually shifting?\n- Delegations that snapped back to founder — why?\n- Energy zone shifts — did peak hours move into Tier 1 work?\n\nQuality bar:\n- NEVER skip the embarrassing entries (scrolling, distraction) — they're the highest-ROI signal\n- NEVER delegate without naming the quality bar — that's how delegation fails\n- \"Stop\" beats \"delegate\" for low-ROI work — kill it entirely\n- Founders systematically over-estimate the value of their reactive work — audit honestly"
+    },
+    {
+      "id": "burn-runway-model",
+      "name": "Build a burn + runway scenario model",
+      "category": "Finance",
+      "tags": [
+        "finance",
+        "founder",
+        "report"
+      ],
+      "emoji": "🔥",
+      "description": "Build a burn + runway model with burn multiple, scenarios, and a board-ready dashboard.",
+      "works_best_with": {
+        "agent_profile": "finance-agent",
+        "skills": [
+          "concise-planning",
+          "pdf"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Pull current P&L + cash position",
+        "Compute base burn + growth burn",
+        "Calculate burn multiple",
+        "Run base / aggressive / defensive scenarios",
+        "Output a board-ready 1-pager"
+      ],
+      "prompt": "Build a burn + runway scenario model (Tomasz Tunguz / Theory pattern).\n\nInputs:\n- Current cash + bank balance: [paste]\n- Last 12 months P&L (revenue + costs by category): [paste]\n- Current MRR / ARR + growth rate: [paste]\n- Hiring plan for the next 12 months: [paste]\n- Fundraise plan (timing + size + dilution target): [paste]\n\nPhase 1 — Pull current state.\n- Monthly revenue (recurring + one-time)\n- Monthly costs by category: payroll (split eng / sales / G&A), infra, marketing, tools, other\n- Monthly burn = costs - revenue\n- Cash position + months of runway at current burn\n\nPhase 2 — Compute base burn vs growth burn.\n- Base burn: spend required to keep the lights on (payroll for existing team + infra + minimum marketing)\n- Growth burn: incremental spend going into new acquisition + new hires\n- Net new ARR added per quarter\n\nPhase 3 — Calculate burn multiple.\n- Burn multiple = net burn / net new ARR\n- <1x = exceptional; 1-1.5x = good; 1.5-2x = OK; >2x = problem\n- Track over the last 6 months — surface the trend\n\nPhase 4 — Run scenarios.\n\nBase case:\n- Current trajectory + planned hires\n- Months of runway at current burn growth\n\nAggressive growth:\n- 50% more spend on growth (more sales, more marketing)\n- Modeled revenue lift (be skeptical — most growth assumptions are too optimistic)\n- Runway impact\n\nDefensive:\n- Hold spend flat for 6 months\n- Reduced growth assumption\n- Extended runway\n\nCuts (if needed):\n- Where you'd cut 20% of monthly burn if you had to (named line items + dollar impact + revenue risk)\n\nPhase 5 — Fundraise timing.\n- Months of runway at each scenario\n- Target: raise when you have 9+ months runway (NEVER let it dip below 6 unless you've committed term sheet)\n- What metrics you need to hit BEFORE the raise (NRR, NDR, growth rate, ICP convergence)\n\nPhase 6 — Output.\n- Cash flow model .xlsx (with assumptions on a single sheet so I can vary them)\n- 1-page board dashboard PDF (current burn, burn multiple, runway, scenario table)\n- A \"cut list\" memo — where I'd cut and what the revenue risk is\n- A fundraise timing memo\n\nFeedback signal:\n- Actual vs forecast burn per month — surface drift\n- Burn multiple trend — improving or degrading?\n- Which scenarios played out — refine assumptions for next model\n\nQuality bar:\n- NEVER model revenue growth that requires hiring you haven't made yet\n- NEVER assume infra costs scale linearly with users — they don't (usually super-linear)\n- Reserve 3-month buffer in the runway calculation — fundraises slip\n- This is modeling, NOT a commitment — share with the board WITH the assumptions visible"
+    },
+    {
+      "id": "why-we-lost-battlecard",
+      "name": "Run a 'why we lost' battlecard loop",
+      "category": "Sales",
+      "tags": [
+        "audit",
+        "loop",
+        "sales"
+      ],
+      "emoji": "🃏",
+      "description": "Run a weekly why-we-lost battlecard loop (Klue pattern). Get a 1-screen battlecard refreshed weekly with rep-usage tracking.",
+      "works_best_with": {
+        "agent_profile": "marketing-agent",
+        "skills": [
+          "concise-planning",
+          "vale-brand-voice"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Interview every closed-lost deal within 7 days",
+        "Pull 3 quotes/week into the battlecard",
+        "Update the 1-screen battlecard weekly",
+        "Track rep adoption + correlated win rate",
+        "Refresh competitor positioning quarterly"
+      ],
+      "prompt": "Run a \"why we lost\" battlecard loop (Klue + Primary Intelligence pattern — weekly cadence, 1-screen format).\n\nInputs:\n- Closed-lost deals from last 90 days: [paste with company + competitor + lost-reason if known]\n- Top 3 competitors I lose to: [paste]\n- Current battlecard format (if any): [paste]\n- Sales team size + competitive deal volume per week: [paste]\n\nPhase 1 — Interview every closed-lost deal within 7 days.\n- Founder personally calls the buyer (NOT the rep) for a 20-min conversation\n- Open: \"I'm not trying to re-pitch — I want to understand what happened so we can be a better fit next time\"\n- Questions:\n  - When did you first realize we weren't the right fit?\n  - What did [competitor] do that we didn't?\n  - What would have changed your decision?\n  - Who else weighed in on the decision?\n  - What's your honest take on our pitch?\n- Take notes verbatim (NOT paraphrased)\n\nPhase 2 — Pull 3 quotes/week into the battlecard.\nPer competitor, surface:\n- The 3 most recurring objections we lose on\n- The 3 wedge angles competitors use against us\n- The 3 things buyers WISH we did differently\n\nPhase 3 — 1-screen battlecard per competitor.\nSingle screen format (don't fit a 30-page PDF — reps don't use those):\n- Positioning (1 sentence on competitor + 1 sentence on us vs them)\n- Top 3 traps (what they say about us — and the counter)\n- Top 3 landmines (questions to ask that surface their weakness)\n- Pricing reality (their actual price, not website)\n- Best customer quote that lands the differentiation\n- \"Trigger to switch\" (events at the buyer that signal we win)\n\nPhase 4 — Track rep adoption.\n- Embed the battlecard in the CRM at the deal stage where competitor is identified\n- Track: which reps click the battlecard? Which use the talking points?\n- Correlate rep usage with their win rate vs competitor — promote the winning patterns\n\nPhase 5 — Weekly cadence.\n- Friday 30-min: review last week's losses + 1 new quote per battlecard\n- Update the 1-screen with the freshest material\n- Notify sales of changes (Slack #competitive)\n\nPhase 6 — Quarterly deep refresh.\n- Re-research competitor pricing (their website lies)\n- Customer interviews with 5 lost buyers + 5 won buyers\n- Update the positioning paragraph if the market moved\n\nPhase 7 — Output.\n- 1-screen battlecard per top-3 competitor (Notion or PDF, fit on one screen)\n- Closed-lost interview script + question bank\n- Weekly refresh template\n- Rep-usage dashboard\n- Quarterly competitor pricing tracker\n\nFeedback signal (closes the loop):\n- Win rate vs competitor over time — improving = the battlecard is working\n- Quote / objection frequency — surface emerging patterns\n- Rep adoption rate — if low, the format is wrong (or the content is)\n\nQuality bar:\n- NEVER skip the 7-day interview window — memory fades fast\n- NEVER put battlecard content in a 30-page PDF — it dies there\n- The buyer's words matter MORE than the rep's interpretation — capture verbatim\n- If a battlecard doesn't change for a month, the loop is broken — fix it"
+    },
+    {
+      "id": "churned-customer-winback",
+      "name": "Run a reason-segmented winback campaign",
+      "category": "Customer Success",
+      "tags": [
+        "customer-success",
+        "loop"
+      ],
+      "emoji": "🔙",
+      "description": "Run a reason-segmented winback (Getir-style — outperformed benchmark without a discount). Get sequences branched by cancel reason.",
+      "works_best_with": {
+        "agent_profile": "marketing-agent",
+        "skills": [
+          "concise-planning",
+          "vale-brand-voice"
+        ],
+        "mcp_servers": [
+          "gmail-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Map cancel-reason taxonomy",
+        "Segment churned customers by reason",
+        "Branch a 90-day sequence per reason",
+        "Send from a founder-from address",
+        "Read out at 90 days"
+      ],
+      "prompt": "Run a reason-segmented winback campaign for churned customers.\n\nInputs:\n- Churned customer list (last 12 months, with cancel reason if captured): [paste]\n- Current cancel-flow questions: [paste]\n- Top product changes since they churned (features shipped, pricing changes, partner integrations): [paste]\n- My sending email + signature: [paste]\n- Brand voice: [paste]\n\nPhase 1 — Map the cancel-reason taxonomy.\nStandard buckets:\n- Price-sensitive (cited cost / budget)\n- Missing feature (cited specific feature gap)\n- Competitor switch (named another tool)\n- Inactive / lost-champion (no usage in last 60 days before cancel; champion left)\n- Wrong fit (bought the wrong product for their need)\n- Reason-unstated (no signal — typically the smallest sub-segment)\n\nFor each: count of churned customers in last 12 months + total ARR lost.\n\nPhase 2 — Branch a 90-day sequence per reason.\n\nPrice-sensitive (3 emails over 30 days):\n- Email 1 (day 0): \"we shipped X\" (the cost-impact feature) + a discount or annual deal\n- Email 2 (day 14): ROI calculator showing their specific use case\n- Email 3 (day 30): \"would 6 months at half price help you re-evaluate?\"\n\nMissing feature (3 emails, triggered when the feature ships):\n- Email 1 (day 0): \"you asked for X. We shipped it. Here's how it works.\"\n- Email 2 (day 14): \"want to try it free for 30 days?\"\n- Email 3 (day 30): \"interested? Here's a 1:1 walkthrough offer.\"\n\nCompetitor switch (3 emails over 60 days):\n- Email 1 (day 30): \"how's [competitor] working out? Honest take from us\"\n- Email 2 (day 60): head-to-head battle card on the specific gap they hit\n- Email 3 (day 90): one-time migration offer\n\nInactive / lost-champion (3 emails over 30 days):\n- Email 1 (day 0): \"your champion [name if known] left — are you using [product] differently?\"\n- Email 2 (day 14): \"if you need a re-onboarding, we'll do it free\"\n- Email 3 (day 30): clean break — \"let us know if you ever come back\"\n\nWrong fit (1 email — be honest):\n- Day 0: \"we weren't the right fit. Here's who we send people like you to.\"\n- This builds reputation > revenue\n\nPhase 3 — Send from a founder-from address.\n- Personal email from founder (not @marketing or @noreply)\n- Plain text, no images, no template feel\n- Sign with name + role\n\nPhase 4 — Read out at 90 days.\n- Per reason: response rate + reactivation rate + ARR recovered\n- Compare to no-action churn baseline\n- Top-performing reason / email — promote to default winback\n\nPhase 5 — Output.\n- Reason-bucket dashboard (counts + ARR)\n- 4-track email sequence (one per actionable reason)\n- A \"do not contact\" list (customers who explicitly asked)\n- A 90-day measurement template\n\nFeedback signal (closes the loop):\n- Reactivation rate per reason — calibrate which sequences are worth running\n- Average revenue recovered per email — surface the highest-ROI track\n- New reasons emerging in replies — add buckets\n\nQuality bar:\n- NEVER send to a customer who opted out of marketing — re-confirm before send\n- NEVER fake personalization — the founder-from address must actually come from a real person\n- Don't discount price-sensitive customers below what new customers pay — that breaks trust\n- Sometimes the right answer is \"we weren't the right fit, here's a better alternative\" — those replies build long-term reputation"
+    },
+    {
+      "id": "sleep-recovery-audit",
+      "name": "Audit sleep and recovery from wearable data",
+      "category": "Health",
+      "tags": [
+        "audit",
+        "health",
+        "personal"
+      ],
+      "emoji": "🛌",
+      "description": "Audit 30 days of wearable data. Get a narrative of what's helping, what's hurting, and tonight's one action.",
+      "works_best_with": {
+        "agent_profile": "personal-assistant",
+        "skills": [
+          "concise-planning",
+          "pdf"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Pull 30 days of biometric data",
+        "Compute baselines + recent drift",
+        "Cluster what helps vs hurts recovery",
+        "Recommend the single biggest lever",
+        "Schedule a 14-day re-check"
+      ],
+      "prompt": "Audit my last 30 days of sleep + recovery from wearable data.\n\nInputs:\n- Source: [Oura / Whoop / Apple Watch / Garmin / Fitbit — export or paste]\n- 30 days of nightly metrics (sleep stages, HRV, RHR, temperature deviation, sleep score): [paste or path]\n- Daily context I tracked (workouts, alcohol, late meals, travel, caffeine): [paste]\n- My current sleep goal (recovery / cognition / mood / training): [paste]\n- Any sleep issues I'm tracking (waking at 3am, sleep onset, etc.): [paste]\n\nPhase 1 — Compute baselines + drift.\n- 30-day mean and SD for HRV, RHR, total sleep, REM %, deep %\n- Last 7 days vs prior 23 — surface meaningful drift (>1 SD)\n- Compare against age + sex norms (cite the source)\n\nPhase 2 — Cluster what helps vs hurts.\n- Cross-tab biometrics against my daily context (alcohol, late meals, hard workouts, etc.)\n- Surface the 3 strongest signals helping recovery\n- Surface the 3 strongest signals hurting it\n- Distinguish correlation from causation — flag what needs an experiment\n\nPhase 3 — Recommend the single biggest lever.\n- One change I can make TONIGHT (not 5 — one)\n- One experiment to run over the next 14 days (A/B-style: do X on odd days, skip on even)\n- Explicit predictions: what biometric should move + by how much\n\nPhase 4 — Output.\n- 1-page audit PDF in my workspace\n- A \"tonight's action\" line at the top\n- 14-day experiment plan + the metric to watch\n- A \"what I'm NOT going to change\" list (so I don't over-optimize)\n\nFeedback signal (14-day re-check):\n- Did the predicted metric move?\n- Surprises (a signal you missed)\n- Patterns to test next round\n\nQuality bar:\n- This is data interpretation, NOT medical advice — frame as such\n- NEVER claim a clinical diagnosis from wearable data\n- If you see consistent hypoxia / extreme HRV / new arrhythmia signals, recommend a doctor visit\n- Don't over-fit on small differences — wearable accuracy has known limits"
+    },
+    {
+      "id": "doctor-appointment-prep",
+      "name": "Prep a symptom log and doctor's appointment",
+      "category": "Health",
+      "tags": [
+        "health",
+        "personal",
+        "report"
+      ],
+      "emoji": "🩻",
+      "description": "Build a symptom timeline + question list for a doctor visit. Get a 1-page summary and a prioritized question stack.",
+      "works_best_with": {
+        "agent_profile": "personal-assistant",
+        "skills": [
+          "concise-planning",
+          "pdf"
+        ],
+        "mcp_servers": [
+          "notion-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Build the symptom timeline",
+        "Cluster by severity + frequency",
+        "Draft a 1-page handout",
+        "Write a question stack",
+        "Map answers expected"
+      ],
+      "prompt": "Prep for a doctor's appointment with a symptom log + question list.\n\nInputs:\n- Reason for the visit: [paste]\n- Symptom log (free text — when, how bad, what helped, what hurt): [paste]\n- Medications + supplements + dosages: [paste]\n- Recent labs / vitals / imaging (paste or path): [paste]\n- Family / personal history relevant to the visit: [paste]\n- Appointment length (most are 15-20 min — plan accordingly): [paste]\n\nPhase 1 — Build the symptom timeline.\n- Sort symptoms chronologically with onset, severity (1-10), pattern (constant / episodic / worsening), triggers, things that helped\n- Note any consistent time-of-day or correlation with food / stress / movement\n- Flag any symptom that's NEW since last visit\n\nPhase 2 — Cluster.\n- Severity × frequency matrix — which symptoms get priority\n- Group by likely system (cardiac / GI / neuro / etc.) to help the doctor\n- Surface what you're NOT sure is related (let them connect the dots)\n\nPhase 3 — Draft a 1-page handout to give the doctor.\n- Top: reason for visit (1 sentence)\n- Timeline: 5-8 bullets of the key events\n- Current meds + supplements\n- What I've tried already + what helped\n- What I'm worried about (be honest — saves time)\n\nPhase 4 — Write the question stack (ranked by priority).\n- Top 3: questions you MUST get answered\n- Next 3-5: nice-to-have\n- For each: phrase it openly (\"what could cause X?\" not \"is it Y?\")\n- Map each question to \"tests / treatment / next steps\" bucket\n\nPhase 5 — Output.\n- 1-page handout PDF\n- Question list (print or phone-ready)\n- A \"what I'll do if they say X / Y / Z\" decision tree\n\nFeedback signal (after the appointment):\n- Which questions got answered, which got deferred\n- Any test or referral suggested — log to follow up\n- New symptoms or angles the doctor surfaced — add to the next log\n\nQuality bar:\n- NEVER self-diagnose — describe symptoms, let the doctor diagnose\n- Bring the handout printed AND on phone (some doctors prefer one)\n- If you have a worst-fear question, ask it — most doctors prefer directness\n- For chronic conditions, ask about the next 90-day plan, not just the next pill"
+    },
+    {
+      "id": "cbt-mood-journal",
+      "name": "Run a CBT mood journal with weekly trends",
+      "category": "Health",
+      "tags": [
+        "health",
+        "loop",
+        "personal"
+      ],
+      "emoji": "🧘",
+      "description": "Run a daily CBT journal companion. Get cognitive-distortion catches, weekly mood trends, and one experiment per week.",
+      "works_best_with": {
+        "agent_profile": "personal-assistant",
+        "skills": [
+          "concise-planning"
+        ],
+        "mcp_servers": [
+          "notion-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Daily check-in (mood + thought)",
+        "Spot cognitive distortions",
+        "Socratic reframe",
+        "Weekly mood trend + one experiment",
+        "Track PHQ-9 / GAD-7 monthly"
+      ],
+      "prompt": "Run a daily CBT-style mood journal as my reflective partner.\n\nInputs:\n- Today's mood (1-10) + 2-line description of the day: [paste]\n- A specific thought that's been sticky (worry, regret, self-criticism): [paste]\n- Sleep last night + caffeine + exercise today: [paste]\n- Current life context (job, relationship, health, money — what's loud right now): [paste — once, will persist for the journal]\n- Any therapy or coaching I'm doing in parallel: [paste]\n\nPhase 1 — Reflect, don't fix.\n- Restate what I said back to me (validates the feeling first)\n- Ask one open follow-up question to draw out detail\n- DO NOT give advice in this phase\n\nPhase 2 — Spot cognitive distortions (gentle Socratic).\nFor the sticky thought, identify any of these patterns:\n- All-or-nothing\n- Catastrophizing\n- Mind-reading\n- Personalization\n- \"Should\" statements\n- Discounting positives\n- Emotional reasoning\n\nIf you spot one, name it as a possibility (NOT a verdict) and ask: \"is there another way to read this?\"\n\nPhase 3 — Socratic reframe.\n- Ask: what evidence supports the thought? What evidence contradicts it?\n- Ask: what would I say to a friend in this exact situation?\n- Help me draft a reframe — NOT a happier lie, a more accurate one\n- The reframe is mine to accept or reject\n\nPhase 4 — Weekly trend (Sundays).\n- Mood graph for the week + average\n- Recurring distortions\n- The 1-2 themes that came up most often\n- One experiment to try this week (small, concrete, reversible)\n\nPhase 5 — Monthly check-in (1st of the month).\n- PHQ-9 / GAD-7 short-form\n- Trend over the last 3 months\n- Whether to escalate to a therapist if not already in care\n\nPhase 6 — Output.\n- Daily entry saved as a markdown file (so I can search later)\n- Weekly Sunday summary (mood + themes + experiment)\n- Monthly trend PDF\n\nFeedback signal:\n- Mood trajectory over weeks (climbing / falling / volatile)\n- Which experiments stuck vs which fizzled\n- Distortion patterns that recur — those are the ones to bring to a therapist\n\nQuality bar:\n- This is a journal companion, NOT therapy. Frame as such.\n- NEVER diagnose. If I describe symptoms of harm to self or others, immediately recommend professional help + crisis resources.\n- Use my words, not yours — the reframe must feel like mine\n- Be warm but not saccharine — the language matters"
+    },
+    {
+      "id": "strength-program-builder",
+      "name": "Build a periodized strength training program",
+      "category": "Health",
+      "tags": [
+        "health",
+        "personal"
+      ],
+      "emoji": "💪",
+      "description": "Build a periodized strength program. Get a 4-12 week mesocycle with RPE targets, deloads, and weekly auto-adjust.",
+      "works_best_with": {
+        "agent_profile": "personal-assistant",
+        "skills": [
+          "concise-planning",
+          "pdf"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Confirm goal + 1RMs + constraints",
+        "Pick the methodology",
+        "Generate the mesocycle",
+        "Tune for recovery + RPE feedback",
+        "Output weekly + auto-adjust rules"
+      ],
+      "prompt": "Build a periodized strength training program tailored to me.\n\nInputs:\n- Goal: [strength / hypertrophy / power / fat loss with muscle / general]\n- Current 1RMs (squat, bench, deadlift, OHP — if known) OR honest training maxes: [paste]\n- Days per week I can train: [paste]\n- Equipment available: [home / commercial gym / minimal]\n- Methodology preference (if any): [5/3/1 / GZCL / GVT / Daniels / RPE-based / \"you pick\"]\n- Recent injury history + movements to avoid: [paste]\n- Cardio + sport context (running, climbing, etc.): [paste]\n\nPhase 1 — Pick the methodology.\n- Score 5/3/1, GZCL, Daniels GVT, RPE-based, classic linear against my goal + experience level\n- Recommend ONE with reasoning (one paragraph)\n- If I push back, propose a runner-up\n\nPhase 2 — Generate the mesocycle (4-12 weeks).\n- Weekly split (e.g., 4-day upper/lower)\n- Per session: main lifts (sets × reps × % 1RM or RPE), accessory lifts, conditioning\n- Progression scheme (linear / wave / RPE-adjusted)\n- Deload week(s) inserted appropriately (typically week 4 or 6)\n- A test week at the end (top set or rep test)\n\nPhase 3 — Recovery + RPE feedback rules.\n- Per session: log RPE on the top set\n- If RPE is >1 higher than target for 2 sessions in a row: drop next session's load 5%\n- If RPE is >1 lower for 2 sessions in a row: bump next session 5-10 lb\n- HRV / sleep red flag (if I track): swap heavy day for technique work\n\nPhase 4 — Movement quality + safety.\n- Cues for the 4 main lifts (form points I should check on warmups)\n- Warmup protocol\n- Conditioning options that don't tank recovery\n\nPhase 5 — Output.\n- A printable per-week plan (PDF)\n- A spreadsheet for logging (sets × reps × weight × RPE × notes)\n- The auto-adjust rules in a 1-page reference\n- A \"what to do if I miss a session\" cheat sheet\n\nFeedback signal:\n- Weekly: RPE drift vs plan — calibrate the next week's loads\n- Monthly: are the top sets going up at the planned rate?\n- Body comp / strength trajectory at the end of the mesocycle — confirms goal alignment\n\nQuality bar:\n- This is a training plan, NOT medical or PT advice\n- NEVER prescribe past a movement I said I'd avoid\n- If I report sharp pain (vs DOMS), advise stopping the lift and seeing a PT\n- Defaults are conservative — I can always do more, but starting too aggressive injures"
+    },
+    {
+      "id": "habit-retrospective-loop",
+      "name": "Run a habit-tracker weekly retrospective",
+      "category": "Personal",
+      "tags": [
+        "loop",
+        "personal"
+      ],
+      "emoji": "✅",
+      "description": "Run a weekly habit retrospective. Get adherence patterns, slip triggers, and one experiment for the next week.",
+      "works_best_with": {
+        "agent_profile": "personal-assistant",
+        "skills": [
+          "concise-planning"
+        ],
+        "mcp_servers": [
+          "notion-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Pull habit check-ins + notes",
+        "Compute adherence per habit",
+        "Spot slip triggers",
+        "Propose one experiment",
+        "Re-measure next week"
+      ],
+      "prompt": "Run my weekly habit retrospective.\n\nInputs:\n- Habits I'm tracking + the rule for each (e.g., \"read 20 min before bed\"): [paste]\n- Last 7 days of check-ins (Y/N per habit per day): [paste]\n- Notes I wrote about misses or wins: [paste]\n- Last week's experiment + outcome (if any): [paste]\n\nPhase 1 — Adherence math.\n- Per habit: completion rate this week vs 4-week average\n- The habit with the steepest decline — surface first\n- The habit with the strongest streak — that's your anchor\n\nPhase 2 — Spot slip triggers.\n- Cluster misses by day-of-week + by surrounding context (late work day, travel, social, sick)\n- Identify the ONE recurring trigger most predictive of misses\n- Validate: do you have evidence over multiple weeks, or is it a hunch?\n\nPhase 3 — Recommend one experiment.\n- ONE small change for next week (anchor habit to existing routine, shift time, lower the bar)\n- Make it concrete: \"swap evening reading from after dinner to right after kids' bedtime\"\n- Predict: what completion rate will this lift the slipping habit to?\n\nPhase 4 — Output.\n- Adherence table (this week vs trend)\n- Slip-trigger note\n- Next week's experiment (one line)\n- A \"do nothing\" list (habits that are working — don't tinker)\n\nFeedback signal (closes the loop next week):\n- Did the experiment lift the metric?\n- Did fixing one habit hurt another? (energy budget is real)\n- Recurring triggers across weeks — surface as systemic\n\nQuality bar:\n- Total output <250 words — this is a tight reflection, not an essay\n- Be honest about slips — sugar-coating doesn't help\n- Don't add a new habit on top of failure — fix what's slipping first\n- If a habit slips 3 weeks in a row, propose killing it OR splitting it into something smaller"
+    },
+    {
+      "id": "textbook-anki-builder",
+      "name": "Turn a textbook chapter into an Anki deck",
+      "category": "Personal",
+      "tags": [
+        "personal",
+        "research"
+      ],
+      "emoji": "📑",
+      "description": "Turn a textbook chapter into an Anki deck. Get cloze + Q&A cards tagged by topic, ready to import as CSV.",
+      "works_best_with": {
+        "agent_profile": "personal-assistant",
+        "skills": [
+          "concise-planning"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Identify load-bearing concepts",
+        "Generate cloze cards for facts",
+        "Generate Q&A cards for understanding",
+        "Tag by topic + difficulty",
+        "Output CSV ready to import"
+      ],
+      "prompt": "Turn this textbook chapter into a high-quality Anki deck.\n\nInputs:\n- Chapter text or PDF: [paste or path]\n- Subject + course context: [e.g. USMLE Step 1 immunology, AP biology, organic chemistry 1]\n- My current skill level (new / reviewing / mastery): [paste]\n- Tag scheme to use (e.g. organ system, exam topic, week): [paste]\n- Card budget for this chapter: [default 50-80 cards — quality over quantity]\n\nPhase 1 — Identify load-bearing concepts.\n- Read the chapter end-to-end\n- Surface the 10-15 concepts you'd test on for understanding (not trivia)\n- Surface the facts that students MUST memorize (definitions, named effects, numeric thresholds)\n- Drop \"nice to know\" content — don't pad the deck\n\nPhase 2 — Cloze cards for facts.\n- One blank per card (NEVER multi-blank — bad for retention)\n- The blank is the load-bearing word, not a function word\n- Wrap context: \"The {{c1::renin-angiotensin}} system regulates blood pressure via aldosterone.\"\n- 20-30 cloze cards max per chapter\n\nPhase 3 — Q&A cards for understanding.\n- Q is an open question, not \"what is X?\" — instead \"Why does X happen when Y?\"\n- A is concise (2-3 sentences max)\n- Include one card per concept that connects to PRIOR chapters (spaced linking)\n- 15-25 Q&A cards max\n\nPhase 4 — Tag every card.\n- Chapter / topic\n- Type (cloze / qa / image-occlusion-if-applicable)\n- Difficulty (basic / intermediate / advanced)\n- A custom tag matching my scheme\n\nPhase 5 — Output.\n- CSV ready to import to Anki (tab-separated or CSV per Anki's format)\n- A 1-line summary of what the deck covers (paste into Anki notes)\n- A \"skip these in your first pass\" tag for the harder cards (build confidence first)\n\nFeedback signal (after 30 days):\n- Per card: how often did you flip \"again\" / \"hard\" / \"good\" / \"easy\"?\n- Cards that consistently fail — rewrite or split\n- Concepts where retention dies despite cards — surface; might need a different format (image occlusion, mnemonic)\n\nQuality bar:\n- NEVER write multi-blank cloze cards — they tank retention\n- NEVER pad with trivia (\"the textbook author was born in 1948\")\n- Cards should test understanding, NOT recall of textbook phrasing\n- If you can answer the card without thinking about the concept, the card is wrong"
+    },
+    {
+      "id": "language-learning-daily-plan",
+      "name": "Plan a daily language-learning routine",
+      "category": "Personal",
+      "tags": [
+        "loop",
+        "personal"
+      ],
+      "emoji": "🗨️",
+      "description": "Plan a daily language-learning routine. Get vocab + listening + speaking + writing slots tuned to your CEFR level.",
+      "works_best_with": {
+        "agent_profile": "personal-assistant",
+        "skills": [
+          "concise-planning"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Confirm target language + CEFR level + time budget",
+        "Allocate the 4 skills across the day",
+        "Generate today's specific content",
+        "Plan a weekly review",
+        "Adapt to your weak skill"
+      ],
+      "prompt": "Plan today's language-learning routine.\n\nInputs:\n- Target language + my CEFR level (A1 / A2 / B1 / B2 / C1 / C2): [paste]\n- Daily time budget (30 min / 60 min / 90 min): [paste]\n- Specific goal (travel / work / read a novel / pass an exam): [paste]\n- Resources I have (Anki deck, textbook, podcasts, tutor, apps): [paste]\n- This week's weak skill (listening / speaking / reading / writing): [paste]\n\nPhase 1 — Allocate skills across the time budget.\nFor 60 min total (scale others proportionally):\n- 15 min: vocabulary + grammar review (Anki + 1 new grammar point)\n- 15 min: listening (a podcast, video, or song at +1 CEFR level)\n- 15 min: output — speaking OR writing (active production)\n- 15 min: reading (a graded reader, news, or excerpt at your level)\n\nAdjust weighting toward this week's weak skill (give it +30%).\n\nPhase 2 — Generate today's specific content.\nFor each slot:\n- Vocab + grammar: 5-10 new words pulled from yesterday's input + 1 grammar pattern\n- Listening: a specific recommendation (podcast episode, YouTube video) with timestamps\n- Output:\n  - Speaking: 3 prompts to roleplay with an AI tutor (in target language)\n  - Writing: 1 prompt to write 100-200 words on, with self-check questions\n- Reading: a specific text excerpt + 5 comprehension questions\n\nPhase 3 — Weekly review schedule.\n- Sunday: a 20-min review of the week's new vocab (sentence-level use, not just card flips)\n- Monthly: a self-assessment against CEFR descriptors\n\nPhase 4 — Output.\n- Today's plan (1 page) with timing + resource links\n- A \"if I only have 20 minutes\" fallback (minimum viable session)\n- A vocab log to add to Anki tonight\n- A \"today I learned\" line to log\n\nFeedback signal (weekly):\n- Which slot was most engaging — bias time toward it\n- Which slot got skipped most — friction signal; redesign\n- Weak-skill progress vs last week\n\nQuality bar:\n- Choose content at the right level — too easy is boring, too hard kills momentum\n- Prioritize INPUT over output for A1-B1; flip toward output at B2+\n- Don't drill conjugation tables for an hour — context beats drill\n- If a session feels like a chore, the plan is wrong — adjust ratios"
+    },
+    {
+      "id": "test-prep-study-plan",
+      "name": "Plan an adaptive test-prep study schedule",
+      "category": "Career",
+      "tags": [
+        "career",
+        "personal"
+      ],
+      "emoji": "✏️",
+      "description": "Plan an adaptive test-prep schedule. Get a diagnostic-driven plan, targeted drills, and an A-week vs B-week structure.",
+      "works_best_with": {
+        "agent_profile": "personal-assistant",
+        "skills": [
+          "concise-planning",
+          "pdf"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Take a diagnostic + score per topic",
+        "Calculate study weeks to test",
+        "Allocate hours by weak topic",
+        "Build A-week vs B-week templates",
+        "Plan a final-week peaking taper"
+      ],
+      "prompt": "Plan my test-prep schedule, tuned to my weakest topics.\n\nInputs:\n- Test: [LSAT / MCAT / SAT / GMAT / GRE / bar / step 1 / step 2 / etc.]\n- Test date: [paste]\n- My diagnostic score (overall + per section + per topic if available): [paste]\n- Target score: [paste]\n- Hours I can study per week (be honest): [paste]\n- Resources I own (UWorld / Kaplan / Magoosh / OPL / books): [paste]\n- Big constraints (work, family, travel): [paste]\n\nPhase 1 — Diagnostic analysis.\n- Score per section + per topic\n- Identify the 3-5 weakest topics that block target score\n- Identify the 3-5 strongest topics (don't over-study these)\n- Compute the gap: target − current → translate to topic-level hours needed\n\nPhase 2 — Weeks remaining + hours budget.\n- Total weeks × hours/week = total budget\n- Reserve 2 weeks for final review + 1 week for peaking taper\n- Remaining weeks → topic study\n\nPhase 3 — Allocate hours by weak topic.\n- Per weak topic: target hours (more for weakest)\n- Each topic block: theory (read / watch) + drill (timed questions) + review (re-do misses)\n- Mix in cumulative practice tests every 2-3 weeks\n\nPhase 4 — A-week vs B-week templates.\n\nA-week (heavy practice):\n- 3-4 days: topic drills (90 min each)\n- 1 day: full-length practice test\n- 1 day: review the test in detail\n- 1 day: off\n\nB-week (build foundations):\n- 4-5 days: theory + new content + light drills\n- 1 day: cumulative review\n- 1 day: off\n\nAlternate A/B weeks until 3 weeks before the test, then go A-heavy.\n\nPhase 5 — Final 3 weeks (peaking).\n- Week -3: 2 full-length tests + intensive review\n- Week -2: 1 full-length test + targeted weak-topic drills\n- Week -1: light review + sleep + logistics\n- Test day: warmup with 3-5 easy problems, no new content\n\nPhase 6 — Output.\n- Full schedule (PDF, daily breakdown)\n- Weekly check-in template\n- Diagnostic re-take dates\n- A \"what to do if you miss a week\" fallback\n\nFeedback signal (every 2 weeks):\n- Topic-level score on cumulative tests vs plan\n- Hours actually studied vs planned\n- Stamina / fatigue patterns — adjust intensity\n\nQuality bar:\n- Don't study what you're already good at to feel better — that wastes hours\n- Spaced repetition beats massed practice — return to weak topics weekly, not in blocks\n- Full-length tests under real conditions matter more than question count\n- If burnout hits, take a 3-day break — better than a month of half-effort"
+    },
+    {
+      "id": "mock-interview-rehearsal",
+      "name": "Rehearse mock interviews with feedback",
+      "category": "Career",
+      "tags": [
+        "career",
+        "loop"
+      ],
+      "emoji": "🗒️",
+      "description": "Rehearse a structured mock interview. Get role-tuned questions, STAR practice, and rubric-scored feedback.",
+      "works_best_with": {
+        "agent_profile": "personal-assistant",
+        "skills": [
+          "concise-planning"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Confirm role + company + interview type",
+        "Generate role-specific questions",
+        "Rehearse with STAR + critique",
+        "Score against the rubric",
+        "Plan focused practice"
+      ],
+      "prompt": "Rehearse a mock interview as my practice partner.\n\nInputs:\n- Role + level (e.g., senior PM at series B B2B SaaS, staff SWE at FAANG): [paste]\n- Company + interview round type (recruiter screen, hiring manager, technical, behavioral, system design, on-site): [paste]\n- My resume / current role context: [paste]\n- 2-3 stories I want to land + the competencies they show: [paste]\n- Public info about the company / interviewer if I have it: [paste]\n\nPhase 1 — Generate role-specific questions.\n- 5-10 likely questions for this round (behavioral / technical / case / system design)\n- Each question: the competency it tests + the trap the interviewer is watching for\n- Tag by difficulty (easy warmup → hard differentiator)\n\nPhase 2 — Rehearse (rounds of 3).\nFor each question:\n- Ask the question; wait for my answer\n- Critique using a STAR rubric (Situation, Task, Action, Result)\n- Flag filler (\"um\", \"kind of\", \"I guess\"), vague claims, missed metrics, missing reflection\n- Offer one rewrite of the strongest part of my answer\n\nAfter 3 questions, summarize: what's landing, what's not.\n\nPhase 3 — Behavioral rubric scoring.\nFor each story:\n- Specificity (1-5): named the project, the people, the numbers?\n- Conflict + decision quality (1-5): showed the hard moment + the reasoning?\n- Impact (1-5): quantified outcome and your contribution?\n- Self-awareness (1-5): owned a mistake or a stretch zone?\n- Communication (1-5): clear, paced, fielded the follow-up?\n\nPhase 4 — Technical round (if applicable).\n- Use the role's standard format (Leetcode-style, system design, case study)\n- Watch for: assumption-naming, time management, communication-while-solving, edge cases\n- Score against the round's rubric\n\nPhase 5 — Focused practice plan.\n- The 3 weakest patterns to drill before the real interview\n- One specific story to refine (here's the rewrite)\n- Logistics check (sleep, route to office, water, calendar buffer)\n\nPhase 6 — Output.\n- Score sheet per round\n- Rewrites for my top 3 stories\n- A drill list (specific questions to practice on my own)\n- A \"day-of cheat sheet\" with 3 reminders\n\nFeedback signal (after the real interview):\n- Which prep predicted what came up?\n- Surprises (questions I didn't prep for) — feed into next round's prep\n- My energy / pacing notes — refine the day-of plan\n\nQuality bar:\n- Critique kindly, not harshly — I'm here to improve, not be judged\n- Quote my actual words — vague feedback doesn't help\n- If a story doesn't land for the role, say so — don't polish a turd\n- Honest about probability — don't tell me I crushed it if I didn't"
+    },
+    {
+      "id": "performance-review-draft",
+      "name": "Draft a performance review from evidence",
+      "category": "Career",
+      "tags": [
+        "career",
+        "founder",
+        "report"
+      ],
+      "emoji": "🎖️",
+      "description": "Draft a performance review from goals + peer feedback + 1:1 notes. Get a narrative aligned to a competency rubric.",
+      "works_best_with": {
+        "agent_profile": "personal-assistant",
+        "skills": [
+          "concise-planning",
+          "pdf"
+        ],
+        "mcp_servers": [
+          "notion-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Pull goals + peer feedback + 1:1 notes",
+        "Map to competency rubric",
+        "Draft strengths + growth narrative",
+        "Recommend rating + comp suggestion",
+        "Flag development plan"
+      ],
+      "prompt": "Draft a performance review for one of my direct reports.\n\nInputs:\n- Report's name + role + level: [paste]\n- Review period: [Q3 2026 / full year / etc.]\n- Their goals for the period + outcomes: [paste]\n- Peer / cross-functional feedback collected: [paste]\n- My 1:1 notes from the period: [paste]\n- Our competency rubric (e.g., scope / execution / leadership / craft / collaboration): [paste]\n- Calibration constraints (target rating distribution, comp band): [paste]\n\nPhase 1 — Map evidence to rubric.\n- For each competency: list 2-3 specific behavioral examples (with dates if possible)\n- Mark gaps where I don't have enough evidence — flag for me to fill before drafting\n- Identify themes across multiple competencies\n\nPhase 2 — Draft strengths section.\n- 3-4 specific strengths, each with a concrete example\n- Use behavioral language (\"led the X project to Y outcome\") not personality (\"is a great team player\")\n- Tie each strength to business / customer impact\n\nPhase 3 — Draft growth section.\n- 2-3 areas with concrete behavioral examples\n- Frame as \"what would unlock the next level\" — not punitive\n- Pair each growth area with a specific action / project / coaching focus\n\nPhase 4 — Recommend rating + comp.\n- Rating against the rubric — calibrated against the distribution\n- Honest verdict (don't over-rate to avoid the conversation)\n- Comp suggestion if relevant (against the band you sent me)\n- A \"promotion-ready / on-track / needs improvement\" track verdict\n\nPhase 5 — Development plan for next period.\n- 2-3 specific goals tied to the growth areas\n- Coaching / mentorship plan\n- Stretch project recommendation\n\nPhase 6 — Output.\n- Review draft (markdown, ready to paste into the HRIS)\n- Calibration note for HR / your manager\n- Talking script for the live conversation (NOT the same as the doc — softer)\n- A list of compliments and growth points I should deliver in person, not in writing\n\nFeedback signal (after the conversation):\n- Did the report's self-assessment match yours? (Big delta = poor 1:1 cadence)\n- Which framing landed vs which felt blunt\n- Follow-up commitments to track over the next quarter\n\nQuality bar:\n- NEVER write a review that's softer than what I said in 1:1s — that's surprise-by-paper\n- NEVER copy template language — use the report's actual story\n- Behavioral examples > personality assessments\n- If there's a hard conversation needed, draft it explicitly — don't hide it"
+    },
+    {
+      "id": "comp-review-prep",
+      "name": "Prep a compensation review against benchmarks",
+      "category": "Career",
+      "tags": [
+        "career",
+        "founder",
+        "report"
+      ],
+      "emoji": "💵",
+      "description": "Run a comp review against Pave + Levels benchmarks. Get per-person raise + equity refresh recommendations with rationale.",
+      "works_best_with": {
+        "agent_profile": "finance-agent",
+        "skills": [
+          "concise-planning",
+          "pdf"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Pull current comp + tenure + perf rating",
+        "Benchmark against Pave + Levels",
+        "Recommend per-person raises + equity refresh",
+        "Flag retention risks + flight signals",
+        "Output a per-person + team-level summary"
+      ],
+      "prompt": "Run a compensation review against market benchmarks.\n\nInputs:\n- Team comp data (per person: role, level, base, bonus target, equity, hire date, last comp change): [paste]\n- Recent performance ratings + flight risk notes: [paste]\n- Comp philosophy + target percentile (e.g., 60th of Pave): [paste]\n- Total budget for raises + equity refresh this cycle: [paste]\n- Benchmark source (Pave / Levels.fyi / Carta / Radford): [paste]\n- Stage of company + funding context: [paste]\n\nPhase 1 — Per person: pull current comp + benchmark.\n- Current total comp vs target percentile (gap %)\n- Levels.fyi range for the role\n- Equity outstanding (vested + unvested + cliff status)\n- Last refresh date\n\nPhase 2 — Surface anomalies.\n- Anyone significantly below band (retention risk)\n- Anyone above band (over-paid; calibration check)\n- Anyone past the 1-year cliff or vesting acceleration trigger\n- New hires whose comp anchor is now stale\n\nPhase 3 — Recommend per-person actions.\nFor each person:\n- Base raise (% and $ amount with reasoning)\n- Bonus target change (if any)\n- Equity refresh (size + cliff terms)\n- Promotion recommendation if applicable\n- Comp letter framing (warm but clear)\n\nPhase 4 — Aggregate check.\n- Total raise pool used vs budget\n- Distribution across performance ratings (top performers should get meaningful skew)\n- DEI sanity check: are similar roles / levels getting similar treatment regardless of demographic?\n\nPhase 5 — Flag retention risks.\n- People significantly under-market with above-average perf — top priority\n- People at cliff inflection — refresh now or risk leave\n- People with recent disengagement signals (low NPS, missed 1:1s, vacation drop) + under-market\n\nPhase 6 — Output.\n- Per-person comp letter draft (warm, specific, no jargon)\n- Team-level summary table (delta % per person, total spend)\n- Calibration note for HR / your manager\n- A flight-risk list with recommended interventions\n\nFeedback signal (next cycle):\n- Did the comp change shift retention as predicted?\n- Did under-market people end up leaving anyway? (Comp wasn't the issue.)\n- Calibration drift over time — recalibrate annually against benchmark refresh\n\nQuality bar:\n- NEVER skip the equity refresh conversation — comp is base + bonus + equity + benefits\n- Treat the conversation, not the number, as the retention lever\n- Be transparent about how the number was set — not \"we're being generous\" but \"here's the benchmark\"\n- If you can't fund the right number, say so — and own the retention risk"
+    },
+    {
+      "id": "layoff-comms-package",
+      "name": "Prepare a layoff communications package",
+      "category": "Career",
+      "tags": [
+        "career",
+        "founder"
+      ],
+      "emoji": "📢",
+      "description": "Prepare a layoff comms package: manager script, impacted-employee message, and team re-recruitment talking points.",
+      "works_best_with": {
+        "agent_profile": "personal-assistant",
+        "skills": [
+          "concise-planning",
+          "vale-brand-voice",
+          "pdf"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Confirm business reason + impacted roster",
+        "Draft the manager notification script",
+        "Draft per-impacted-employee message + severance",
+        "Draft remaining-team re-recruitment plan",
+        "Plan the day-of logistics"
+      ],
+      "prompt": "Prepare a layoff communications package for a difficult day.\n\nInputs:\n- Business reason (be honest — restructuring / cost reduction / strategic shift / role elimination): [paste]\n- Impacted roster (roles, tenure, performance, manager): [paste]\n- Severance package details (weeks of pay, benefits continuation, equity treatment, references): [paste]\n- Day-of logistics window: [paste]\n- Remaining team context: [paste]\n- Legal review status: [paste — confirmed by counsel]\n\nPhase 1 — Confirm legal review.\n- Has counsel reviewed the impacted list and reasons?\n- Has each impacted person's protected class status been considered (WARN compliance, adverse impact)?\n- Are the severance terms locked?\nIf any answer is no, STOP. Get legal sign-off first.\n\nPhase 2 — Draft the manager notification script (15 min, structured).\n- Opening (60 sec): \"I have hard news. As you've heard / not heard, we've made the decision to eliminate your role. This is effective today. This is not about your performance.\"\n- Reason (60 sec): the honest business reason — no PR-speak\n- Severance (3 min): what they're getting (weeks, benefits, equity, references, LinkedIn rec, tooling for job search)\n- Logistics (3 min): last day, equipment return, COBRA, when comp lands, who they can reach with questions\n- Q&A (5 min): be present for whatever comes\n- Close (2 min): thank you for [specific contributions], wish them well\n\nPhase 3 — Per-impacted-employee message (written).\n- A personalized note (NOT a template) referencing their specific contributions\n- Severance + benefits summary in writing\n- Job-search support offer (references, intros, networking)\n- HR + manager contact info for questions\n\nPhase 4 — Remaining-team comms (the day after, NOT same day).\n- All-hands script: what happened, why, what's next\n- Honest framing — don't pretend the layoff didn't happen\n- Specific commitment about future (no layoff doesn't return is a promise you can't keep — be careful)\n- 1:1 talking points for every remaining manager: how to respond to \"am I next?\", how to address survivor's guilt, how to re-engage the team\n\nPhase 5 — Day-of logistics.\n- Comm schedule (impacted notifications block + all-hands)\n- Equipment / access offboarding timeline (immediate after notification, but with dignity — don't lock out mid-meeting)\n- Slack / email comms shutdown sequence\n- HR support availability for impacted employees\n\nPhase 6 — Output.\n- Manager script (printable, rehearsable)\n- Per-employee written package (one folder per person, ready to hand off)\n- Day-after all-hands deck + script\n- Manager talking-points doc for remaining-team 1:1s\n- A 30-day follow-up plan for impacted alumni (don't ghost them — keep relationships warm)\n\nFeedback signal:\n- Track impacted alumni outcomes (where they land, NPS of how the layoff was handled)\n- Remaining team engagement (eNPS, attrition) over 90 days\n- Manager confidence post-layoff — refine scripts if managers report struggling\n\nQuality bar:\n- NEVER hide the reason — people see through PR-speak immediately\n- NEVER do layoffs over Slack / email if you can avoid it — humans deserve a real conversation\n- Severance generosity is a long-term reputation investment — be at the top of market if you can\n- Treat impacted employees like alumni who'll be hired back — many will be"
+    },
+    {
+      "id": "promotion-packet-writer",
+      "name": "Write a promotion packet for an engineer",
+      "category": "Career",
+      "tags": [
+        "career",
+        "founder",
+        "report"
+      ],
+      "emoji": "🥇",
+      "description": "Write a promotion packet from accomplishments + impact + leveling rubric. Get a structured case + 30/60/90 development plan.",
+      "works_best_with": {
+        "agent_profile": "personal-assistant",
+        "skills": [
+          "concise-planning",
+          "pdf"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Pull accomplishments + impact + peer feedback",
+        "Map to the next-level rubric",
+        "Draft each rubric area with evidence",
+        "Surface gaps + close them",
+        "Output the packet + a script for advocacy"
+      ],
+      "prompt": "Write a promotion packet for one of my engineers (or any role with a leveling rubric).\n\nInputs:\n- Person's name + current level + target level: [paste]\n- Leveling rubric for the next level (paste the rubric or link): [paste]\n- Their accomplishments over the last 6-12 months (projects, outcomes, scope, impact): [paste]\n- Peer feedback collected: [paste]\n- My 1:1 notes + their growth trajectory: [paste]\n- Calibration context (your company's promo bar, expected hit rate): [paste]\n\nPhase 1 — Map accomplishments to the next-level rubric.\n- For each rubric dimension (scope, execution, leadership, craft, collaboration, impact, etc.): pull the relevant evidence\n- Mark dimensions with strong evidence (3+ examples) vs thin (1-2)\n- Mark dimensions with NO evidence — these are the gaps to address before submitting\n\nPhase 2 — Draft each rubric area.\nUse the \"Person, Verb, Task, Impact\" structure for each example:\n- Person: [name]\n- Verb: led / designed / shipped / mentored / etc.\n- Task: the specific thing they did\n- Impact: the measurable outcome (latency improvement, revenue, team capacity unlocked, etc.)\n\nAim for 2-3 strong examples per dimension. Quality > quantity.\n\nPhase 3 — Surface gaps.\n- Dimensions where they don't yet have evidence — be honest\n- A 30-60-90 development plan to fill those gaps before next cycle\n- Stretch projects available now\n\nPhase 4 — Calibration check.\n- Will this packet hold up against the committee's bar?\n- Comparable promotions at your company in the last 12 months — does this person look stronger?\n- Any honest concerns (scope is right, but impact is thin? leadership shown, but only with peers, not cross-functionally?)\n\nPhase 5 — Manager advocacy script.\n- 3-sentence intro for the committee\n- 3 strongest stories to lead with\n- Pre-empt the likely objections with a one-line response each\n- Specific recommendations from the peer feedback\n\nPhase 6 — Output.\n- The packet (markdown, formatted for the committee's template)\n- A \"still working on\" section that's honest about gaps\n- Manager advocacy script\n- A self-reflection version for the candidate (different framing)\n\nFeedback signal:\n- Committee feedback: which dimensions landed vs which raised questions\n- If denied: what specifically was the gap? Build the development plan around it.\n- For future packets: which evidence types win (technical leadership? cross-functional impact? mentorship?)\n\nQuality bar:\n- NEVER submit a packet with no evidence on a key dimension — the gap shows\n- NEVER submit if you don't believe — that's a bad bet on their year\n- Use their words in peer quotes — committee can smell paraphrased praise\n- If they're not ready, be honest with THEM first — submitting a weak packet damages trust"
+    },
+    {
+      "id": "nda-review-redlines",
+      "name": "Review an NDA with redlines",
+      "category": "Legal",
+      "tags": [
+        "founder",
+        "legal"
+      ],
+      "emoji": "📃",
+      "description": "Review an NDA against your playbook. Get redlines for term, residual, jurisdiction, and risky clauses.",
+      "works_best_with": {
+        "agent_profile": "personal-assistant",
+        "skills": [
+          "concise-planning"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Confirm NDA scope (mutual vs one-way)",
+        "Compare to playbook positions",
+        "Surface risky clauses",
+        "Draft redlines + fallback positions",
+        "Output a clean redlined version"
+      ],
+      "prompt": "Review this NDA and propose redlines against my playbook.\n\nInputs:\n- Counterparty NDA (paste full text): [paste]\n- My role (sender / recipient / mutual): [paste]\n- My playbook (standard positions on key clauses) — if none: use the conservative founder/consultant defaults\n- Risk tolerance (we lose this deal if they don't accept terms? or hold the line?): [paste]\n- Jurisdiction preferences: [paste]\n\nPhase 1 — Confirm scope.\n- Mutual vs one-way (huge difference — flag immediately)\n- What confidential info is in scope\n- Permitted uses (narrow = good for recipient, broad = good for sender)\n- Term (how long the obligation lasts)\n\nPhase 2 — Compare to playbook / defaults.\nStandard positions:\n- Term: 2-3 years typical, 5 years max for trade secrets\n- Definition of confidential info: must be marked or reasonably identifiable\n- Residual clause: usually present — but watch the scope (people's heads vs documents)\n- Permitted disclosures: lawyers, accountants, advisors with same NDA obligation\n- Return / destruction of materials: clear deadline\n- Remedies: injunctive relief is standard; specific performance is aggressive\n- Jurisdiction: home jurisdiction strongly preferred\n- Governing law: matches jurisdiction\n- Survival: standard for IP / trade secret clauses\n\nPhase 3 — Surface risky clauses.\n- Non-compete dressed up as NDA (red flag)\n- Indemnification clauses (NDAs shouldn't have these usually)\n- Liquidated damages (uncommon; risk-shifting)\n- \"Confidential information\" defined too broadly (everything we exchange)\n- Term > 5 years (unusual outside trade secrets)\n- Sub-disclosure restrictions that block normal advisory consultations\n- Exclusive jurisdiction in a foreign court\n\nPhase 4 — Draft redlines + fallback positions.\nFor each risky clause:\n- The proposed redline (specific replacement text)\n- The reasoning (one sentence)\n- A fallback if they push back (next-best position)\n- A \"deal-breaker?\" tag (would you walk?)\n\nPhase 5 — Output.\n- A redlined version of the NDA (track changes style)\n- A cover note explaining the changes (1 page, plain English)\n- A negotiation script for the call (anticipated objections + responses)\n- A \"minimum acceptable terms\" summary\n\nFeedback signal:\n- Patterns in redlines accepted vs rejected — refine playbook\n- Counterparties that consistently push back on the same clause — surface as systemic\n- Time-to-signature pre vs post redlining — calibrate aggressiveness\n\nQuality bar:\n- This is contract analysis, NOT legal advice — recommend counsel for non-routine deals\n- Be precise about what's red-flagged vs nice-to-have\n- Default to mutual when ambiguous — protects you on both sides\n- If a clause has unfamiliar language, surface it rather than guess"
+    },
+    {
+      "id": "tos-privacy-generator",
+      "name": "Generate ToS + Privacy Policy",
+      "category": "Legal",
+      "tags": [
+        "founder",
+        "legal"
+      ],
+      "emoji": "🛡️",
+      "description": "Generate ToS + Privacy Policy for an app or SaaS. Get jurisdiction-aware drafts with cookie + DPA mappings.",
+      "works_best_with": {
+        "agent_profile": "personal-assistant",
+        "skills": [
+          "concise-planning",
+          "pdf"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Inventory the product + data collected",
+        "Confirm target jurisdictions",
+        "Generate ToS + Privacy + Cookie Policy",
+        "Map sub-processors + DPA",
+        "Plan the update cadence"
+      ],
+      "prompt": "Generate ToS + Privacy Policy for my product. This is a starting draft, NOT a substitute for counsel.\n\nInputs:\n- Product description + URL: [paste]\n- User type: [B2B / B2C / both]\n- Data collected (auth, PII, payment, usage analytics, files, etc.): [list]\n- Third-party processors (Stripe, Segment, OpenAI, Auth0, etc.): [list]\n- Target jurisdictions (US, EU, UK, CA, AU, BR, etc.): [list]\n- Age restrictions (under 13 — COPPA; under 16 — GDPR; over 18): [paste]\n- Refund / cancellation policy: [paste]\n- Account-deletion process: [paste]\n\nPhase 1 — Product + data inventory.\n- Categorize data: identifiers / commercial / biometric / internet activity / geolocation / sensory / professional / education / inferences\n- Map data to source (signup form, payment, analytics, integrations)\n- Map data to retention period\n- Map data to sharing (sub-processors, advertisers, affiliates)\n\nPhase 2 — ToS draft sections.\n1. Acceptance + age requirements\n2. Account + responsibilities\n3. License grant + IP ownership (yours vs theirs)\n4. Acceptable use + prohibited conduct\n5. Payment + auto-renewal + refunds\n6. Termination (for cause / convenience)\n7. Disclaimers + limitation of liability (capped if possible)\n8. Indemnification\n9. Dispute resolution (arbitration? jurisdiction?)\n10. Changes to ToS + notice\n11. Governing law + jurisdiction\n\nPhase 3 — Privacy Policy sections.\n1. What data we collect (per category)\n2. How we collect it (sources)\n3. Why we collect it (purposes)\n4. Who we share it with (sub-processors + reason)\n5. Where it's stored (country) + transfers\n6. Retention periods\n7. Your rights (access, deletion, portability, correction, opt-out) — per jurisdiction\n8. Cookies + tracking technologies (link to Cookie Policy)\n9. Children's data\n10. International transfers + safeguards (SCCs)\n11. Data breach notification\n12. Contact for privacy requests (DPO if EU)\n\nPhase 4 — Cookie Policy.\n- Cookies in use (per category: essential, analytics, advertising, functional)\n- Consent mechanism reference (banner)\n- Opt-out path\n- Lifetime per cookie type\n\nPhase 5 — Sub-processor + DPA mapping.\n- Sub-processor list (vendor, what data, where)\n- Identify which require a DPA (any processor of EU/UK personal data)\n- Identify which have SCCs in place\n\nPhase 6 — Output.\n- ToS draft (markdown)\n- Privacy Policy draft (markdown)\n- Cookie Policy draft (markdown)\n- Sub-processor registry\n- A \"send to counsel for review\" checklist\n- An update cadence reminder (annual + on material product change)\n\nFeedback signal:\n- Compliance gaps surfaced by counsel review — feed into next draft\n- User complaints / DSARs — surface clauses that confuse users\n- Regulatory updates that require revisions (e.g., new state privacy laws)\n\nQuality bar:\n- This is a DRAFT — every business should have counsel review before publishing\n- NEVER copy-paste from a competitor — that creates IP + accuracy risks\n- Update annually + on material change (new processor, new data type, new jurisdiction)\n- Plain language wins — courts and regulators prefer it; users do too"
+    },
+    {
+      "id": "soc2-readiness-audit",
+      "name": "Run a SOC 2 Type 1 readiness audit",
+      "category": "Legal",
+      "tags": [
+        "audit",
+        "engineering",
+        "founder",
+        "legal"
+      ],
+      "emoji": "🔐",
+      "description": "Run a SOC 2 Type 1 readiness audit. Get a controls map, evidence checklist, gap remediation plan, and 6-12 week timeline.",
+      "works_best_with": {
+        "agent_profile": "backend-engineer",
+        "skills": [
+          "concise-planning",
+          "audit-context-building",
+          "pdf"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Confirm scope (Trust Services Criteria)",
+        "Map current controls + evidence",
+        "Identify gaps",
+        "Remediation plan + owners",
+        "Auditor-ready package"
+      ],
+      "prompt": "Run a SOC 2 Type 1 readiness audit.\n\nInputs:\n- Company + product description: [paste]\n- Scope: [Security only — most common — or Security + Availability + Confidentiality]\n- Cloud + infra stack (AWS / GCP / Azure / which services): [paste]\n- HRIS + identity provider: [paste]\n- Engineering team size + customer count: [paste]\n- Vanta / Drata / Secureframe in place? [paste]\n- Target audit date: [paste]\n\nPhase 1 — Confirm scope.\n- Trust Services Criteria (TSC) included\n- System boundaries (what's IN scope, what's OUT)\n- Subservice organizations (carve-out or inclusive)\n- Period covered (point-in-time for Type 1; period for Type 2)\n\nPhase 2 — Map current controls to TSC.\nFor each Common Criteria (CC1-CC9) and any included TSC:\n- The relevant control statement (e.g., \"logical access requires unique IDs and MFA\")\n- Current state (implemented / partial / missing)\n- Evidence location (system, doc, screenshot)\n- Owner\n\nPhase 3 — Identify gaps.\n- Controls with no evidence\n- Controls implemented but undocumented\n- Documentation outdated or inconsistent\n- Coverage gaps (some services have access controls, others don't)\n\nPhase 4 — Remediation plan.\nFor each gap:\n- The smallest action that closes it\n- Owner + deadline\n- Effort estimate (S / M / L)\n- Risk if not closed before audit\n\nPhase 5 — Critical \"table stakes\" controls (review explicitly).\n- MFA on all admin accounts + production access\n- SSO + access reviews (quarterly)\n- Background checks on new hires\n- Annual security training + acknowledgment\n- Vulnerability scanning + patching cadence\n- Incident response plan (with last tabletop)\n- Change management (PR review + approval requirements)\n- Backup + recovery testing\n- Vendor / sub-processor risk assessment\n- Data classification + handling\n\nPhase 6 — Auditor-ready package.\n- Control matrix (TSC → control → evidence → owner)\n- Policy library (info sec, AUP, change mgmt, IR, BCP, vendor mgmt)\n- Procedure docs (access provisioning, deprovisioning, etc.)\n- Sample evidence per control (access review screenshot, etc.)\n- A \"what auditor will ask\" Q&A\n- 6-12 week countdown checklist\n\nPhase 7 — Output.\n- Controls + evidence matrix (CSV)\n- Gap remediation plan + owners + deadlines (Notion / sheet)\n- Policy library outline (which docs you need)\n- A weekly cadence for the readiness sprint\n\nFeedback signal (during the audit):\n- Findings vs predicted gaps — refine the self-audit\n- Auditor questions that surprised you — bake into next year's scope\n- Time to remediate vs estimate — calibrate next year's planning\n\nQuality bar:\n- This is readiness, NOT audit certification — use a real auditor (CPA-licensed)\n- NEVER fake evidence — auditors find out and you fail\n- Vanta / Drata / Secureframe accelerate evidence collection 5-10x — use them\n- The Type 1 is the start. Type 2 (3-12 months of evidence) is where you actually prove the controls operate"
+    },
+    {
+      "id": "patent-prior-art-search",
+      "name": "Run a patent prior-art search",
+      "category": "Legal",
+      "tags": [
+        "legal",
+        "research"
+      ],
+      "emoji": "🪶",
+      "description": "Run a patent prior-art search. Get a ranked list of similar art, claim chart, and a patentability verdict.",
+      "works_best_with": {
+        "agent_profile": "personal-assistant",
+        "skills": [
+          "brave-search",
+          "concise-planning",
+          "pdf"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Describe the invention precisely",
+        "Extract searchable concepts + claim elements",
+        "Search USPTO + Google Patents + WIPO + non-patent lit",
+        "Rank results by similarity + relevance",
+        "Output a patentability brief"
+      ],
+      "prompt": "Run a prior-art search for a patentable invention.\n\nInputs:\n- Invention description (plain English): [paste]\n- Field of use + technical domain: [paste]\n- Claimed novel elements (in your view): [paste]\n- Existing products / patents you know are close: [paste]\n- Purpose of search (filing / freedom-to-operate / invalidity / competitive landscape): [paste]\n- Geographic scope (US-only / EP / international): [paste]\n- Risk tolerance (preliminary / publication-quality): [paste]\n\nPhase 1 — Describe the invention precisely.\n- Restate in 3 sentences: what it does, how it works, why it's different\n- List 3-5 key technical elements (algorithm, hardware feature, process step)\n- List likely IPC / CPC classification codes\n- List 10-15 search keywords + synonyms\n\nPhase 2 — Extract searchable claim elements.\nFor each claim element:\n- Functional description (what it does)\n- Structural description (how it's built)\n- Synonyms an examiner / opposing party might use\n\nPhase 3 — Search the patent corpus.\nFor each database (USPTO, Google Patents, Espacenet, WIPO PatentScope, J-PlatPat):\n- Run claim-element keyword combinations\n- Apply CPC class filters\n- Date filter (publications before priority date or filing target)\n- Capture top 30 hits per database\n\nPhase 4 — Search non-patent literature.\n- Google Scholar / arXiv / IEEE Xplore for academic papers\n- GitHub for open-source implementations\n- ProductHunt / Crunchbase for commercial product disclosures\n- Conference proceedings in the field\n- Blog posts / company whitepapers\n\nPhase 5 — Rank results by similarity.\nFor each hit, score:\n- Technical similarity to claim elements (1-5 per element)\n- Publication date relative to your priority date\n- Patent status (active / expired / withdrawn / never granted)\n- Geographic coverage\n- Citation count (downstream patents that cited it)\n\nTop 10-15 most relevant: enter the claim chart.\n\nPhase 6 — Claim chart per top reference.\n- Side-by-side: your claim element vs the prior art element\n- Per element: identical / similar / different / not disclosed\n- Combined: does this single reference anticipate or render obvious?\n\nPhase 7 — Patentability verdict.\n- Anticipation (single reference shows every claim element): YES / NO with reasoning\n- Obviousness (combination of references makes it obvious): YES / NO with reasoning\n- Suggested narrowing of claims to navigate the prior art\n- Risk score (high / medium / low) on filing as-is\n\nPhase 8 — Output.\n- Prior-art database (CSV) of all hits with scores\n- Claim chart (top 10-15 references)\n- Patentability brief (3-5 pages)\n- Strategy memo: file as-is / narrow / abandon / consider provisional\n\nFeedback signal:\n- USPTO examiner's office action vs your predicted prior art — calibrate next search\n- References you missed that the examiner found — surface to next search query refinement\n- Claims that survived rejection vs those that didn't — feed into claim drafting\n\nQuality bar:\n- This is research, NOT legal advice — engage a patent attorney for filing\n- NEVER use only one database — examiners search multiple\n- Non-patent literature (papers, code, products) is increasingly important — don't skip it\n- Searches >2 years old need refresh — prior art emerges constantly"
+    },
+    {
+      "id": "system-design-doc-hld",
+      "name": "Draft a high-level system design doc",
+      "category": "Engineering",
+      "tags": [
+        "engineering",
+        "report"
+      ],
+      "emoji": "🏛️",
+      "description": "Draft an HLD for a distributed system. Get components, data flow, capacity estimates, and trade-off analysis.",
+      "works_best_with": {
+        "agent_profile": "backend-engineer",
+        "skills": [
+          "concise-planning",
+          "pdf"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Confirm requirements + scale + SLO",
+        "Enumerate components + data flow",
+        "Capacity + cost estimates",
+        "Compare 2-3 architectures with trade-offs",
+        "Output the HLD + ADR stubs"
+      ],
+      "prompt": "Draft a high-level system design document (HLD) for a new system.\n\nInputs:\n- Problem statement (1-2 paragraphs): [paste]\n- Functional requirements (5-10 bullets): [paste]\n- Non-functional requirements (scale, latency, consistency, availability): [paste]\n- Constraints (existing stack, team skills, budget, deadline): [paste]\n- Known alternatives we're rejecting + why: [paste]\n- Audience for the doc (peer review / staff+ review / external): [paste]\n\nPhase 1 — Confirm requirements and scope.\n- Restate the problem in your own words\n- List the 5 most important requirements + 2-3 nice-to-haves\n- Out-of-scope explicitly stated\n- Wait for me to confirm\n\nPhase 2 — Enumerate components + data flow.\n- High-level component diagram (clients, gateway, services, queues, datastores, caches)\n- Data flow: end-to-end for the primary use case (with sequence)\n- Storage decisions: which data lives where + why (consistency model, partitioning, TTL)\n- Integration points (external APIs, internal services)\n\nPhase 3 — Capacity + cost estimates.\n- Read/write QPS at launch + at 12 months\n- Storage growth rate + retention policy\n- Bandwidth + egress estimates\n- Per-component cost (rough): compute, storage, DB, network\n- Total monthly run cost at scale\n\nPhase 4 — Trade-off analysis (2-3 architectures).\nFor each candidate:\n- Strengths (what makes it the right choice for some scenario)\n- Weaknesses\n- Performance characteristics\n- Operational burden\n- Cost\n- Recommendation: which one + why\n\nPhase 5 — Failure modes + mitigation.\n- Per component: what happens when it fails\n- Blast radius (1 user / 1 region / global)\n- Mitigation (replication, retries, circuit breakers, fallback)\n- Disaster recovery + backup strategy\n- Observability hooks (metrics, logs, traces — what's instrumented)\n\nPhase 6 — Security + privacy.\n- AuthN / AuthZ model\n- Data classification (PII, PCI, PHI)\n- Encryption in transit + at rest\n- Audit logging\n- Threat model (3-5 likely attacks + defenses)\n\nPhase 7 — Migration / rollout.\n- Backward compatibility (if replacing existing)\n- Migration steps + dual-write strategy\n- Rollback plan\n- Phased rollout (% traffic, canary, regions)\n\nPhase 8 — Output.\n- HLD doc (markdown, structured for design review)\n- A 1-page TL;DR for execs\n- ADR stubs for the 3-5 biggest decisions (context, decision, consequences)\n- A list of open questions + owners\n\nFeedback signal:\n- Design review comments — surface what wasn't clear or wasn't right\n- Implementation deltas from the HLD — capture as \"what we learned\"\n- Capacity / cost actual vs estimate — calibrate next HLD\n\nQuality bar:\n- NEVER skip capacity numbers — \"fast\" isn't a requirement\n- NEVER write \"we'll figure it out later\" — surface the open question as TODO\n- The HLD's audience matters — exec doc is different from engineer review\n- One decision per ADR — don't pile up trade-offs in one doc"
+    },
+    {
+      "id": "adr-writer",
+      "name": "Write an Architecture Decision Record",
+      "category": "Engineering",
+      "tags": [
+        "engineering",
+        "report"
+      ],
+      "emoji": "🪨",
+      "description": "Write an ADR (Architecture Decision Record). Get context, decision, alternatives considered, and consequences.",
+      "works_best_with": {
+        "agent_profile": "backend-engineer",
+        "skills": [
+          "concise-planning"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Confirm the decision being captured",
+        "Write context (forces in play)",
+        "Document the decision + alternatives",
+        "Surface consequences",
+        "Save to source control"
+      ],
+      "prompt": "Write an Architecture Decision Record (ADR) for a technical decision.\n\nInputs:\n- The decision (one sentence): [paste — e.g. \"use Postgres + pgvector instead of a dedicated vector DB\"]\n- Date + ADR number: [paste]\n- Author + reviewers: [paste]\n- Related design doc or PR (if any): [paste link]\n- Background context (5-10 min of conversation that led to this): [paste]\n\nPhase 1 — Title + metadata.\n- Title: short noun phrase, decision-focused (e.g., \"Use Postgres + pgvector for embeddings\")\n- Status: [proposed / accepted / deprecated / superseded]\n- Date\n- Deciders\n\nPhase 2 — Context (the forces in play).\n- The problem being solved\n- The constraints (skill, budget, deadline, scale, ops capacity)\n- The alternatives that were considered (briefly — detail comes later)\n- Why a decision is needed now\n\nPhase 3 — Decision.\n- The specific choice made\n- The reasoning in 3-5 sentences\n- The trade-offs accepted\n\nPhase 4 — Alternatives considered (deeper).\nFor each (typically 2-3):\n- What it is\n- Why it was attractive\n- Why it was rejected (concrete reason — not \"felt wrong\")\n\nPhase 5 — Consequences.\n- Positive consequences (what gets easier)\n- Negative consequences (what gets harder)\n- Neutral consequences (what changes but not better/worse)\n- Risks introduced + mitigation\n- What we'd need to see to reverse this decision\n\nPhase 6 — Output.\n- ADR markdown file (named like `adr-0042-use-pgvector.md`)\n- Save to `docs/adrs/` in the repo\n- Update the ADR index (table of contents)\n- Cross-reference from the related design doc if applicable\n\nFeedback signal:\n- ADRs reversed within 12 months — examine what we missed\n- Decisions made without an ADR that bit us later — surface as a process gap\n- ADRs nobody re-reads — they were written for compliance, not value\n\nQuality bar:\n- ADRs are short — 1-2 pages, not 10\n- Use plain language — these are for future-you and new hires\n- Write at decision time, not retrospectively\n- Mark superseded ADRs explicitly — never delete them"
+    },
+    {
+      "id": "database-schema-design",
+      "name": "Design a database schema with ER diagram",
+      "category": "Engineering",
+      "tags": [
+        "engineering",
+        "report"
+      ],
+      "emoji": "🗄️",
+      "description": "Design a relational database schema from app requirements. Get tables, FKs, indexes, an ER diagram, and migration DDL.",
+      "works_best_with": {
+        "agent_profile": "backend-engineer",
+        "skills": [
+          "concise-planning"
+        ],
+        "mcp_servers": [
+          "filesystem"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Inventory entities + relationships",
+        "Normalize to 3NF baseline",
+        "Choose denormalization for read paths",
+        "Add indexes + constraints",
+        "Output ER diagram + DDL"
+      ],
+      "prompt": "Design a relational database schema for this application.\n\nInputs:\n- Application description + key user flows: [paste]\n- Expected scale (rows in 12 months for each entity type): [paste]\n- Read / write ratio per entity: [paste]\n- Database engine: [Postgres / MySQL / SQLite / etc.]\n- Naming conventions (snake_case, plural tables, etc.): [paste]\n- Constraints we must support (multi-tenancy, soft delete, audit log, GDPR): [paste]\n\nPhase 1 — Entity inventory.\n- List every entity (User, Account, Order, Subscription, etc.)\n- For each: attributes (with types), uniqueness rules\n- Mark each as core (load-bearing) vs supporting\n\nPhase 2 — Relationships.\n- For each entity pair: relationship type (1:1, 1:N, M:N) + cardinality\n- Identify ownership (which side cascades on delete)\n- Identify nullable vs required associations\n\nPhase 3 — Normalize to 3NF.\n- No repeating groups\n- No partial dependencies\n- No transitive dependencies\n- Flag any intentional denormalization (and why)\n\nPhase 4 — Add keys + constraints.\n- Primary keys (UUID vs serial — pick + justify)\n- Foreign keys with cascade behavior\n- Unique constraints\n- Check constraints (enum-like fields, value ranges)\n- NOT NULL where required\n\nPhase 5 — Index strategy.\n- Per-query index list (start with the top 10 queries)\n- Compound indexes for common WHERE + ORDER BY patterns\n- Partial indexes for filtered queries (e.g., active rows only)\n- DON'T over-index — every index slows writes\n\nPhase 6 — Denormalization (where justified).\n- Read-heavy paths (e.g., user feed, leaderboards): consider materialized views or denormalized columns\n- Trade-offs: write amplification, consistency model, cache invalidation\n\nPhase 7 — Migration + ops considerations.\n- Soft delete strategy (deleted_at column? separate archive table?)\n- Audit log (separate table? built into rows?)\n- Multi-tenancy (single DB with tenant_id? schema-per-tenant? DB-per-tenant?)\n- GDPR deletion (cascade strategy + sub-processor sync)\n\nPhase 8 — Output.\n- ER diagram (Mermaid syntax)\n- Full DDL (CREATE TABLE statements)\n- Migration script (idempotent, with rollback)\n- A \"top 10 queries\" plan + the indexes that support them\n- A migration playbook (zero-downtime steps if rebuilding)\n\nFeedback signal:\n- Query plans after launch — surface missing or unused indexes\n- N+1 patterns surfaced by APM — design opportunities for denormalization\n- Schema drift from app code — surface as a process issue\n\nQuality bar:\n- NEVER skip foreign keys to \"save performance\" — fix performance other ways\n- NEVER use enum types for fast-changing values — separate lookup table\n- Naming consistency matters more than naming taste\n- Index reads carefully — measure before adding, not after"
+    },
+    {
+      "id": "rfp-scoring",
+      "name": "Score an RFP response against criteria",
+      "category": "Sales",
+      "tags": [
+        "audit",
+        "sales"
+      ],
+      "emoji": "🧮",
+      "description": "Score vendor RFP responses against a weighted rubric. Get a side-by-side matrix, flagged risks, and a recommendation.",
+      "works_best_with": {
+        "agent_profile": "personal-assistant",
+        "skills": [
+          "concise-planning",
+          "pdf"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Confirm the rubric + weights",
+        "Score each vendor section-by-section",
+        "Flag non-standard or risky clauses",
+        "Build the comparison matrix",
+        "Output a recommendation + negotiation plan"
+      ],
+      "prompt": "Score RFP responses against my evaluation criteria.\n\nInputs:\n- RFP responses (one per vendor, full text): [paste or path]\n- Evaluation rubric + weights: [paste — e.g., functionality 30%, security 25%, price 20%, vendor stability 15%, support 10%]\n- My must-have requirements (binary pass/fail): [paste]\n- Budget + procurement constraints (annual cap, payment terms): [paste]\n- Integration / migration requirements: [paste]\n- Anti-vendor signals (companies to avoid + why): [paste]\n\nPhase 1 — Confirm the rubric and binary gates.\n- Restate weights — do they sum to 100?\n- List must-have requirements that disqualify a vendor if missing\n- Any tied weights — break with a tiebreaker rule\n\nPhase 2 — Score each vendor section-by-section.\nPer response, per rubric section:\n- Score 1-10 with reasoning (1 sentence)\n- Evidence cited from the response\n- Score adjusted for clarity / specificity (vague answers downweighted)\n- A \"verify with reference call\" tag where confidence is low\n\nPhase 3 — Flag non-standard or risky clauses.\n- Pricing: hidden fees, auto-renewal traps, price-increase ceilings\n- Security: claims without certifications, vague data handling\n- SLA: weak commitments, unreasonable cure periods\n- Termination: unfavorable terms, long notice periods\n- Data: sub-processors not disclosed, no DPA willingness\n\nPhase 4 — Build the comparison matrix.\n- Side-by-side per vendor per rubric section\n- Total weighted score\n- Pass/fail on must-haves\n- TCO (total cost of ownership) over 3 years including ramp + onboarding\n\nPhase 5 — Recommend a vendor.\n- Recommended pick with reasoning\n- Runner-up (and why not #1)\n- Vendors to reject (with brief rationale)\n- Negotiation levers per vendor (where they're weakest)\n\nPhase 6 — Output.\n- Scoring matrix (CSV)\n- A 2-page recommendation memo\n- A negotiation prep doc with each vendor's pricing flexibility, missing requirements, and reference questions\n- A \"questions to ask references\" list per finalist\n\nFeedback signal (after the contract is signed):\n- Vendor performance vs your scoring — calibrate next RFP\n- Surprises during implementation — add to rubric for next round\n- Negotiation results — what gave way + what didn't (refine leverage)\n\nQuality bar:\n- NEVER score based on vendor charisma — only on the response evidence\n- Cite the section / page for every score\n- Reference calls matter more than the response — schedule them for the top 2\n- If two vendors tie, the better-fit POC wins (not the cheaper one)"
+    },
+    {
+      "id": "cloud-spend-finops-audit",
+      "name": "Audit cloud spend and recommend cuts",
+      "category": "Engineering",
+      "tags": [
+        "audit",
+        "engineering",
+        "finance"
+      ],
+      "emoji": "💻",
+      "description": "Audit cloud spend across AWS/GCP/Azure + AI APIs. Get idle resources, oversized instances, and a ranked cut list.",
+      "works_best_with": {
+        "agent_profile": "finance-agent",
+        "skills": [
+          "concise-planning",
+          "audit-context-building",
+          "pdf"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Pull current spend + 90-day trend",
+        "Identify idle + oversized resources",
+        "Audit AI / API spend",
+        "Recommend cuts ranked by ROI",
+        "Output a remediation plan"
+      ],
+      "prompt": "Audit cloud spend and recommend the highest-ROI cuts.\n\nInputs:\n- Cloud providers + access (AWS / GCP / Azure billing export, Cost Explorer access): [paste]\n- AI API providers (OpenAI / Anthropic / Bedrock / etc.) billing access: [paste]\n- Last 90 days monthly spend (by service / by tag if available): [paste]\n- Total monthly cloud spend: [paste]\n- Engineering team size + capacity for remediation: [paste]\n- Constraints (workloads we can't touch, compliance, customer SLAs): [paste]\n\nPhase 1 — Pull spend + trend.\n- Total spend last 90 days, monthly trend\n- Top 10 services by spend\n- Top 10 cost centers (tags / accounts / projects)\n- Spend growth rate (per service, per month)\n- Anomalies (spikes >20% MoM in any line item)\n\nPhase 2 — Identify idle resources.\n- EC2 / Compute Engine: low CPU (<10%) for 14+ days\n- Load balancers / NAT gateways without traffic\n- Unattached EBS / persistent disks\n- Old snapshots beyond retention policy\n- RDS / Cloud SQL with zero connections\n- Unused Elastic IPs\n- Forgotten dev / staging environments\n\nPhase 3 — Identify oversized resources.\n- Instances with CPU < 30% sustained — rightsize candidates\n- RDS instances with low IOPS — downgrade\n- Over-provisioned ECS / GKE capacity\n- DynamoDB / Bigtable with low utilization\n- Memory allocations far above actual usage\n\nPhase 4 — Audit reserved capacity + savings plans.\n- Coverage % of compute by reservations / savings plans\n- Expiring reservations in the next 60 days\n- Underutilized reservations (committed but not running)\n- Opportunity to commit to additional savings plans\n\nPhase 5 — Audit AI / API spend.\n- Spend per provider over the last 90 days\n- Spend per model (GPT-4 vs Claude vs GPT-3.5)\n- Top usage by feature / endpoint\n- Cache hit rate (if applicable)\n- Tokens per request — opportunities for prompt optimization\n- Cheaper-model fallback opportunities\n\nPhase 6 — Audit egress + bandwidth.\n- Top egress destinations\n- Cross-region transfer (often expensive and avoidable)\n- CDN coverage gaps\n\nPhase 7 — Rank cuts by ROI.\nFor each opportunity:\n- Estimated monthly savings ($ amount)\n- Effort to remediate (S / M / L)\n- Risk (zero / low / medium / high)\n- Reversibility\n- Owner\n\nTop 10 by ROI become the action list.\n\nPhase 8 — Output.\n- Audit report (1-page TL;DR + 5-page detail)\n- Ranked cut list (CSV with savings + effort + owner)\n- Tagging hygiene recommendations (so next audit is easier)\n- A monthly tracking dashboard spec\n- A \"what NOT to cut\" list (where saving $X costs you $10X in customer churn)\n\nFeedback signal:\n- Realized savings vs predicted — calibrate the next audit\n- Cuts that caused incidents — surface and avoid pattern in future\n- Spend trend post-audit — is it sticking or creeping back up?\n\nQuality bar:\n- NEVER cut without a rollback plan — savings aren't worth a customer-facing outage\n- Tag hygiene is the long-term lever — fix tags now and every audit gets faster\n- AI API spend is the fastest-growing line item — instrument it properly\n- Don't optimize for one-time savings if it kills a savings plan you'll need later"
+    },
+    {
+      "id": "ultralearning-zero-to-master",
+      "name": "Learn anything from zero to master",
+      "category": "Personal",
+      "tags": [
+        "audit",
+        "loop",
+        "personal",
+        "research"
+      ],
+      "emoji": "🧗",
+      "description": "Run an ultralearning sprint on any skill from zero to mastery. Get a metalearning memo, curriculum, schedule, drills, and a project test.",
+      "works_best_with": {
+        "agent_profile": "personal-assistant",
+        "skills": [
+          "brave-search",
+          "concise-planning",
+          "audit-context-building",
+          "pdf"
+        ],
+        "mcp_servers": [
+          "notion-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Phase 1 — Metalearning week (research how to learn it)",
+        "Phase 2 — Define the success project + sub-skills",
+        "Phase 3 — Build the directness-first curriculum",
+        "Phase 4 — Schedule the focus blocks + drill prescriptions",
+        "Phase 5 — Execute with weekly retrospective + retention layer",
+        "Phase 6 — Ship the project + lock in retention"
+      ],
+      "prompt": "You're my ultralearning coach for a zero-to-mastery sprint on a single skill. Use Scott H. Young's 9 Ultralearning principles (Metalearning, Focus, Directness, Drill, Retrieval, Feedback, Retention, Intuition, Experimentation), Anders Ericsson's deliberate practice, Tim Ferriss's DiSSS (Deconstruction, Selection, Sequencing, Stakes), and Josh Kaufman's first-20-hours framing where they fit. Hold the line on rigor.\n\nInputs:\n- The skill / topic I want to learn (be specific — \"conversational Spanish for travel\" not just \"Spanish\"): [paste]\n- My current level (true beginner / hobbyist / intermediate): [paste]\n- What \"mastery\" means TO ME (a concrete deliverable, capability, or test I can pass): [paste]\n- Time budget per week (be honest): [paste hours]\n- Total sprint duration: [paste — e.g. 3 months, 6 months, 1 year]\n- Why I want to learn this (motivation matters for follow-through): [paste]\n- Constraints (no in-person tutor / no $X budget / public commitment yes-no): [paste]\n- My known weak spots from prior learning attempts: [paste]\n\nPhase 1 — Metalearning (Principle 1). Week 1 only — DO NOT START LEARNING YET.\nThis is the highest-ROI week of the whole sprint.\n- Pull syllabi from the top 3 university or master-level programs on this skill\n- Identify 3-5 practitioners at the level I want; read what they wrote about their own learning paths\n- Identify the canonical resources (books, courses, mentors, communities, datasets, instruments)\n- Map the skill tree: prerequisites + sub-skills + how they compose\n- Identify the 20% of sub-skills that produce 80% of the outcome (Pareto — Ferriss \"Selection\")\n- Identify common dead ends (where novices waste months)\n- Estimate hours needed at the level I'm targeting\n\nOutput of this phase: a \"How to learn X\" memo (3-5 pages) saved to my workspace. Wait for me to read it before continuing to Phase 2.\n\nPhase 2 — Define the success project (Directness + Stakes).\n- The SINGLE deliverable that proves mastery (a shipped app, a 5K race time, a translated essay, a tournament rating, a publishable paper, a sold first commission)\n- The 3-5 sub-skills production of that deliverable demands\n- Sub-skills ranked by (current ability gap × project impact)\n- A public commitment OR external evaluator (Ferriss \"Stakes\" — accountability matters)\n\nPhase 3 — Build the curriculum (Directness, Principle 3 — the load-bearing principle).\nFor each sub-skill, prescribe:\n- The DIRECT practice activity (the actual skill in its actual context — NOT a proxy like \"watch lectures\")\n- The drill (Principle 4): the smallest sub-component to attack first; what specifically gets isolated and repeated\n- The retrieval activity (Principle 5): how I'll test myself rather than re-read / re-watch\n- The feedback source (Principle 6): who or what tells me I'm wrong — ranked from highest signal (expert critique, automated test, race time) to lowest (self-judgment)\n- Reject any resource adjacent but not direct (Anki cards on Spanish grammar are not Spanish conversation practice — both have a place, but don't confuse them)\n\nThe project starts in week 2, not after the curriculum is \"done.\" Direct work compounds.\n\nPhase 4 — Schedule the sprint (Focus, Principle 2).\n- Weekly deep-focus blocks (named on the calendar, phone in the other room, single-task)\n- Daily drill prescription (15-30 min on the highest-ROI weak spot)\n- Weekly project work session (2-4 hours uninterrupted)\n- Weekly feedback session (call with mentor, peer review, test run)\n- A retention layer: spaced-repetition deck built FROM drill sessions (Principle 7) — not from textbook bullets\n- One \"rest day\" per week (recovery is part of the protocol)\n\nPhase 5 — Execute with weekly retrospective (a loop, every Sunday).\n- Skills practiced this week + adherence rate (% of planned blocks completed)\n- Drills attempted + accuracy / speed delta\n- Project progress + blockers\n- Feedback received + what specifically to change next week\n- One thing to STOP, one to START, one to KEEP\n- Mid-week energy + injury / overload check (if applicable)\n\nPhase 6 — Intuition + Experimentation (Principles 8 + 9). Second half of sprint.\nOnce basics feel automatic:\n- Teach the skill to someone (Feynman technique — verifies mastery faster than self-test)\n- Try unconventional approaches: combine two sub-skills, attempt the \"weird\" project, copy a master then deviate\n- Read advanced material with the curiosity of a practitioner, not the anxiety of a beginner\n- Compete or perform in public — high-stakes practice compresses learning\n\nPhase 7 — Ship the project (sprint end).\n- Deliver the success project under realistic conditions\n- Get external evaluation (NOT self-grade)\n- Honest assessment: did I reach my definition of mastery?\n- If not: gap analysis + extended sprint OR accept current level with grace\n- Public retrospective post (optional but accelerates the next sprint)\n\nPhase 8 — Retention (Principle 7). Ongoing after sprint.\n- Spaced-repetition schedule for the cards built during sprint\n- Weekly minimum maintenance practice\n- A stretch project queued to keep applying the skill\n- 30 / 90 / 180-day retention checks\n\nOutput:\n- The \"How to learn X\" metalearning memo (PDF)\n- A full sprint curriculum doc (Notion + PDF)\n- Weekly schedule template (.ics file) with time-blocked focus sessions\n- Per-sub-skill drill prescription card\n- A ranked feedback-source list (free → paid, low → high signal)\n- Spaced-repetition seed deck (CSV ready for Anki)\n- Sunday review template\n- Project brief + success criteria + external evaluator commitment\n- A \"what to do if I fall off the wagon for a week\" recovery script\n\nFeedback signal (the sprint's own learning loop):\n- Weekly adherence to focus blocks → calibrates whether the time budget is realistic\n- Drill accuracy improvement → surfaces if the drills are right size (too easy or too hard kills motivation)\n- Project artifact quality at midpoint vs end → surfaces curriculum gaps\n- External evaluation gap from self-assessment → calibrates honest self-judgment\n- Retention check at 30 / 90 / 180 days → surfaces what stuck vs what evaporated\n- After the sprint: what worked + what wasted weeks → input to the next ultralearning sprint\n\nQuality bar:\n- NEVER skip Phase 1 metalearning week — the highest ROI is here, and skipping is the #1 reason sprints fail\n- NEVER substitute consumption for direct practice — reading about Spanish is not speaking Spanish\n- NEVER drill what you're already good at to feel competent — drill the painful weak spot (Principle 4)\n- NEVER re-read or re-watch when you could retrieve — testing beats reviewing every time (Principle 5)\n- Get the highest-signal feedback you can afford — bad or slow feedback wastes weeks (Principle 6)\n- Embrace failure as data — comfortable practice doesn't produce mastery\n- Public commitment + external evaluator beats motivation — design the system, don't rely on willpower\n- Pick a clear end date and ship the project — open-ended learning rarely concludes\n- This works for: languages, programming, music, sport, math, design, writing, sales, painting, public speaking, chess, anything with a feedback signal\n- This does NOT work for: skills with no clear feedback (taste, charisma, intuition-only fields) — for those, mentorship beats self-directed sprints"
+    },
+    {
+      "id": "wheel-strategy-scanner",
+      "name": "Scan for wheel-strategy candidates",
+      "category": "Investing",
+      "tags": [
+        "investing",
+        "loop"
+      ],
+      "emoji": "🎡",
+      "description": "Scan equity universe for cash-secured-put candidates. Get a wheel-fit-scored shortlist with IV rank, delta, and earnings dates.",
+      "works_best_with": {
+        "agent_profile": "finance-agent",
+        "skills": [
+          "brave-search",
+          "concise-planning",
+          "pdf"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Filter universe by liquidity + market cap",
+        "Score by IV rank + delta + earnings risk",
+        "Rank top 10 wheel candidates",
+        "Output strikes + sizing per portfolio rules",
+        "Track assignment + roll candidates weekly"
+      ],
+      "prompt": "Scan for wheel-strategy candidates (cash-secured puts → assignment → covered calls).\n\nInputs:\n- Account size + max cash per put position: [paste]\n- Risk tolerance (delta target — 0.30 conservative / 0.15-0.20 aggressive): [paste]\n- Sectors to include / exclude: [paste]\n- Minimum stock price + max stock price (for assignment risk): [paste]\n- Days to expiration target: [default 30-45 DTE]\n- Tax account type (taxable / IRA / Roth): [paste — drives strategy]\n- Existing positions + open Greeks: [paste]\n\nPhase 1 — Universe filter.\n- Equities with >500K avg daily volume + tight bid-ask\n- Market cap > $2B (avoid micro/small-cap assignment risk)\n- Optionable with weekly or monthly chains\n- Drop names with earnings inside the DTE window\n- Drop names with binary catalysts (FDA, merger vote, lawsuit ruling)\n\nPhase 2 — Score each candidate.\nFor each stock, compute:\n- IV rank (current IV vs 52-week range) — target >40%\n- IV percentile — target >50%\n- Implied move vs expected (skew the agent toward fair-priced premium)\n- Delta target match per my risk tolerance\n- Dividend ex-date conflict (avoid early assignment on covered call side)\n- Wheel Fit Score 0-10 (composite)\n\nPhase 3 — Rank top 10.\nFor each:\n- Recommended strike + DTE + premium estimate\n- Max risk (assignment cost) + breakeven\n- Annualized return if not assigned\n- Cost basis after assignment (would I want to own this stock?)\n- A \"what kills this trade\" line (earnings move, sector rotation, etc.)\n\nPhase 4 — Position sizing.\n- Per-name allocation per my portfolio rules\n- Total cash committed across new positions\n- Aggregate Greeks impact (delta, vega, theta) on portfolio\n\nPhase 5 — Output.\n- Ranked CSV: ticker | strike | DTE | premium | max risk | annualized return | wheel fit score | notes\n- A \"ready to enter\" subset I can paste into the broker\n- A weekly tracking sheet for open positions (P&L, roll candidates, assignment risk)\n- An alert list for when an open position needs action\n\nFeedback signal:\n- Per closed cycle: realized return vs expected\n- Which sectors / IV rank tiers delivered best risk-adjusted returns\n- Assignment rate vs IV rank tier — calibrates delta target\n\nQuality bar:\n- This is analysis, NOT financial advice\n- NEVER recommend a position you wouldn't take to assignment\n- NEVER sell premium against a name you don't want to own\n- IRA / Roth: cash-secured only (no margin)\n- Watch earnings + binary catalyst dates religiously — surprises destroy wheel strategies\n- Realized return on a wheel needs at least 12 cycles to evaluate fairly"
+    },
+    {
+      "id": "iron-condor-builder",
+      "name": "Build a Greek-sized iron condor or credit spread",
+      "category": "Investing",
+      "tags": [
+        "investing"
+      ],
+      "emoji": "🦅",
+      "description": "Build a defined-risk iron condor or credit spread sized to portfolio Greeks. Get strikes, P(profit), and a roll plan.",
+      "works_best_with": {
+        "agent_profile": "finance-agent",
+        "skills": [
+          "concise-planning",
+          "pdf"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Confirm ticker + bias + risk budget",
+        "Fetch chain + IV + expected move",
+        "Construct candidate spreads",
+        "Greek-aware sizing check",
+        "Output entry + management plan"
+      ],
+      "prompt": "Build a defined-risk iron condor or credit spread on a ticker, sized to portfolio Greeks.\n\nInputs:\n- Ticker + my directional bias (neutral / mildly bullish / mildly bearish / volatility selling): [paste]\n- Max risk per trade ($ — typically 1-3% of account): [paste]\n- Current portfolio Greeks (delta, gamma, theta, vega): [paste]\n- Portfolio Greek limits (e.g., max net delta, max negative vega): [paste]\n- Days to expiration target: [default 30-50 DTE]\n- Underlying current price + IV rank + expected move: [paste]\n- Earnings or binary catalyst within DTE window: [paste yes/no + date]\n\nPhase 1 — Confirm trade premise.\n- Why is now the right time (IV rank, technical setup, vol regime)?\n- What would invalidate the thesis (earnings, big news, sector flip)?\n- Iron condor vs single-side credit spread — which fits the bias?\n- If earnings inside DTE, STOP unless explicit earnings-play structure\n\nPhase 2 — Fetch chain + structure candidates.\nFor iron condor:\n- Short call strike (target ~16 delta = ~84% OTM)\n- Long call strike (5-10 wider for defined risk)\n- Short put strike (target ~16 delta)\n- Long put strike (5-10 wider)\n\nFor single-side credit spread:\n- Short strike (target ~25-30 delta for premium / ~16 for higher P(profit))\n- Long strike (defined risk, typically $5 width)\n\nCompute per candidate:\n- Net credit received\n- Max risk = width − credit\n- Max return = credit / max risk\n- Probability of profit\n- Probability of touch\n- Implied move vs strike distance\n\nPhase 3 — Greek-aware sizing.\n- Position delta (net of all 4 legs)\n- Position vega (typically negative for credit structures)\n- Position theta (positive — the payment)\n- Aggregate impact on portfolio Greeks\n- Reject the trade if it pushes any Greek past my limit\n- Suggest contract count that fits both risk budget AND Greek limits\n\nPhase 4 — Entry + management plan.\n- Entry order type (limit at mid, not market)\n- Profit target (typically close at 25-50% of max profit)\n- Stop loss (typically 2x credit received, or test of short strike)\n- Roll criteria (short strike tested + DTE > 21? Roll out or down)\n- Final close criteria (21 DTE or 25% of max profit — whichever first)\n\nPhase 5 — Output.\n- Trade ticket (ready to paste into broker)\n- 1-page trade plan (entry, targets, stops, rolls)\n- Portfolio Greeks before vs after\n- A \"what could go wrong\" risk list with the action for each\n\nFeedback signal:\n- Per closed trade: realized P&L vs expected\n- Win rate vs P(profit) calibration over 20+ trades\n- Greek limit breaches that needed early management — refine sizing\n\nQuality bar:\n- This is analysis, NOT financial advice\n- NEVER hold defined-risk positions through earnings unless that's the explicit thesis\n- NEVER widen wings to \"fix\" a tested side — that increases risk\n- 21 DTE is the management cliff — gamma risk goes parabolic past that\n- Close winners; manage losers; don't pray\n- Track your win rate and average winner/loser separately — high win rate with terrible loser ratio still loses money"
+    },
+    {
+      "id": "crypto-smart-money-tracker",
+      "name": "Track smart-money crypto wallets for early signal",
+      "category": "Investing",
+      "tags": [
+        "investing",
+        "loop"
+      ],
+      "emoji": "🐋",
+      "description": "Track Nansen-labeled smart-money wallets for early accumulation. Get token alerts with score, supporting data, and a follow/fade verdict.",
+      "works_best_with": {
+        "agent_profile": "finance-agent",
+        "skills": [
+          "brave-search",
+          "concise-planning"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Select wallet watchlist",
+        "Detect accumulation events",
+        "Cross-check holder + LP signals",
+        "Score each signal",
+        "Alert with follow/fade verdict"
+      ],
+      "prompt": "Track smart-money wallets and surface early accumulation signals.\n\nInputs:\n- Wallet watchlist (Nansen labels, hand-picked alpha wallets, or Lookonchain feed): [paste]\n- Chains to cover (Ethereum / Solana / Base / Arbitrum / etc.): [paste]\n- Token universe (top 200 by mcap / new tokens / specific sectors): [paste]\n- Minimum signal threshold (number of smart wallets buying / total $ spent): [paste]\n- Alert channel (Telegram / Discord / Email): [paste]\n- My risk tolerance + position size limits: [paste]\n\nPhase 1 — Detect accumulation events.\nFor each tracked wallet:\n- New token positions opened in the last N hours\n- Existing positions added to (>20% increase)\n- Coordinated buying (3+ tracked wallets in same token within 24h)\n- Time-of-day patterns (Asia / EU / US sessions)\n\nPhase 2 — Cross-check supporting signals.\nFor each candidate token:\n- LP depth + 24h volume change\n- Holder count delta (organic vs concentrated)\n- Bubblemaps cluster check (insider concentration risk)\n- Recent contract activity (mint authority, ownership, function calls)\n- Social signal (X / Telegram mentions in the last 24h)\n- Recent CEX listings or pending listings\n\nPhase 3 — Risk filter (avoid the trap).\n- Honeypot check (sell-side simulation)\n- Mint authority not renounced — red flag\n- Top 10 holder concentration > 30% — flag insider risk\n- LP not locked or unlocking soon — flag exit risk\n- Token age < 7 days — flag for extra scrutiny\n\nPhase 4 — Score each signal.\n0-100 composite:\n- Number of smart wallets buying (more = stronger)\n- Total $ spent across smart wallets\n- Time-clustered buying (within hours = stronger)\n- Holder + LP support\n- Risk deductions for any red flags\n\nPhase 5 — Alert + verdict.\nFor each signal above threshold:\n- FOLLOW: high score + low risk + sufficient liquidity to enter\n- INVESTIGATE: medium score, needs human review (specific concerns named)\n- FADE: smart wallet identified but contract or distribution is shady\n- IGNORE: below threshold\n\nOutput per alert:\n- Token + chain + contract\n- Signal summary (which wallets bought, when, how much)\n- Risk flags\n- Suggested entry tier (small probe / medium / pass)\n- Stop-loss + take-profit framework\n\nPhase 6 — Output.\n- Real-time alerts to my channel\n- Daily digest of all signals (followed + faded)\n- Weekly retrospective: signal accuracy + P&L attribution\n\nFeedback signal (closes the loop):\n- Per signal: did the token move? Profitable or not?\n- Wallet labels that consistently predict moves — promote\n- Wallet labels that are noise — demote\n- Risk flags that consistently saved you from rugs — strengthen the rule\n\nQuality bar:\n- This is analysis, NOT financial advice — crypto is highly volatile and lossy\n- NEVER buy a token without verifying the contract address (scams are everywhere)\n- NEVER size up because \"smart money is in\" — they're often wrong too\n- Honeypot + insider checks are MANDATORY before any entry\n- Position sizing on crypto: typically 0.5-2% of account per signal, max\n- Liquidity matters more than alpha — a great signal in an illiquid token can't be exited\n- Smart-money tracking does NOT survive once it's widely automated — bias toward fresh wallets, not the labeled ones everyone follows"
+    },
+    {
+      "id": "token-rugpull-diligence",
+      "name": "Screen a new token for rug-pull and honeypot risk",
+      "category": "Investing",
+      "tags": [
+        "audit",
+        "investing"
+      ],
+      "emoji": "🪤",
+      "description": "Run pre-buy diligence on a new token. Get a 60-second risk audit covering contract, LP, holders, and a go/no-go verdict.",
+      "works_best_with": {
+        "agent_profile": "finance-agent",
+        "skills": [
+          "brave-search",
+          "concise-planning"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Pull contract + LP + holder data",
+        "Run honeypot + transfer simulation",
+        "Check holder concentration + insider clusters",
+        "Score risk per dimension",
+        "Output go/no-go verdict"
+      ],
+      "prompt": "Screen a new token for rug-pull / honeypot risk before I buy.\n\nInputs:\n- Token contract address + chain: [paste]\n- My intended position size: [paste]\n- DEX or CEX where I'd buy: [paste]\n- Source of the signal (Telegram call / X post / wallet tracker / friend): [paste]\n- Time pressure (do I have 60 seconds or 30 minutes to decide?): [paste]\n\nPhase 1 — Contract audit.\n- Verify the contract is verified on Etherscan / Solscan / BSCscan\n- Mint authority: renounced or active?\n- Freeze authority (SPL tokens / Token-2022): present?\n- Transfer fees / taxes: what %?\n- Blacklist function: present?\n- Owner / admin functions still callable: which?\n- Proxy / upgradeable: yes/no? (Yes = ongoing risk)\n- Recent contract changes (last 7 days): any?\n\nPhase 2 — Honeypot + transfer simulation.\n- Simulate a sell of the position size — does it succeed?\n- Hidden transfer fees that only trigger on sell?\n- Slippage required at my position size\n- LP-based sell simulation (will it actually clear?)\n\nPhase 3 — LP + liquidity.\n- Total liquidity in USD\n- LP token: locked, burned, or wallet-held?\n- Lock duration + unlock date\n- LP holder distribution (one wallet vs many)\n- 24h volume + buy/sell ratio\n- Pool age\n\nPhase 4 — Holder distribution + clusters.\n- Top 10 holder concentration (>30% = insider risk)\n- Bubblemaps cluster: connected wallets (sniper bots, dev team holding multi-wallet)\n- New holders in the last 24h (organic growth?)\n- Distribution Gini coefficient\n\nPhase 5 — Off-chain signals.\n- Project team doxxed?\n- Smart contract audit (CertiK, Quantstamp, ZachXBT mention)?\n- Telegram + X account age + follower quality\n- Website + roadmap age\n- CEX listing rumors or scheduled\n\nPhase 6 — Risk score + verdict.\nComposite 0-100 across the dimensions. Verdict tiers:\n- GO (>80, all checks pass): risk-budgeted entry suggested\n- PROBE (60-80, minor concerns): small probe position only, monitor 24h\n- WAIT (40-60, real concerns): wait for resolution (LP lock, audit, dox)\n- NO (<40, red flags): walk away, no position size justifies the risk\n\nPhase 7 — Output.\n- 1-page audit report (top: verdict, body: per-dimension score + evidence)\n- A \"what would make this go from PROBE to GO\" list\n- A \"what to monitor if I do enter\" list (LP changes, owner txns, dump signal)\n- A safe entry plan if GO (slippage limit, position size, stop trigger)\n\nFeedback signal (over time):\n- Per checked token: did the verdict match outcome 7 days later?\n- Which red flag patterns caught actual rugs — promote\n- Which \"GO\" verdicts went to zero anyway — re-examine the methodology\n\nQuality bar:\n- This is analysis, NOT financial advice — crypto rugs are real and frequent\n- A PROBE verdict does NOT mean \"this will pump\" — it means \"the contract isn't actively malicious\"\n- NEVER use real money on a token without the audit running first\n- Mint authority active + LP not locked + dev wallet large = walk away every time\n- Even a perfect verdict doesn't survive a market-wide crash or a coordinated dump\n- Position sizing: probe = 0.25-0.5% of account; go = 1-2% max"
+    },
+    {
+      "id": "cross-dex-arb-detector",
+      "name": "Detect cross-DEX cyclic arbitrage opportunities",
+      "category": "Investing",
+      "tags": [
+        "investing",
+        "loop"
+      ],
+      "emoji": "🌀",
+      "description": "Detect cross-DEX arbitrage cycles (A→B→C→A). Get ranked opportunities with expected profit net of gas + slippage.",
+      "works_best_with": {
+        "agent_profile": "finance-agent",
+        "skills": [
+          "concise-planning"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Define token universe + DEX list",
+        "Pull pool reserves + recent fills",
+        "Find cyclic price disconnects",
+        "Simulate net profit per route",
+        "Output ranked opportunity list"
+      ],
+      "prompt": "Detect cross-DEX cyclic arbitrage opportunities on Solana / Ethereum / Base.\n\nInputs:\n- Chain: [Solana / Ethereum / Base / Arbitrum / Polygon]\n- Token universe (top N by liquidity OR a hand-picked list): [paste]\n- DEX list (Raydium / Orca / Meteora / Jupiter / Uniswap / etc.): [paste]\n- Capital available per cycle: [paste]\n- Gas + priority fee budget per attempt: [paste]\n- Min net profit threshold to alert: [paste — e.g. >$5 net]\n- MEV protection layer (Jito for Solana, Flashbots for ETH): [paste]\n- Alert channel: [Telegram / API webhook]\n\nPhase 1 — Pull pool state.\n- Current reserves + fee tier for each pool in scope\n- Recent fills (last 10-30 sec) to detect imbalanced flow\n- Slippage model per pool (constant product or CLMM-specific)\n\nPhase 2 — Find cyclic disconnects.\n- For each candidate cycle (A → B → C → A) with my token universe:\n- Compute the implied price loop\n- If loop > 1.0 (after fees), surface as a candidate\n- Account for path with 2-hop and 3-hop cycles\n- Filter cycles that cross the same pool twice (no real arb)\n\nPhase 3 — Simulate net profit per route.\n- Input amount sweep (find optimal size — typically the point right before slippage kills it)\n- Total swap fees across the cycle\n- Estimated gas + priority fee\n- MEV / sandwich risk haircut (1-3% buffer)\n- Net P&L = gross spread − fees − gas − MEV haircut\n\nDrop anything with net P&L < threshold.\n\nPhase 4 — Rank surviving routes.\n- Net $ profit\n- Required capital\n- Number of hops (fewer = lower failure rate)\n- Pool depth (more = lower slippage variance)\n- Historic confirmation rate (have similar routes confirmed lately?)\n\nPhase 5 — Alert + simulate before send.\nFor top route:\n- Pre-flight simulation against current pool state (5 sec freshness)\n- If simulation still > threshold: alert + ready-to-send transaction\n- If simulation < threshold: stale data; recompute\n- NEVER auto-send without my approval unless I've explicitly enabled it\n\nPhase 6 — Output.\n- Real-time alerts (route, expected profit, capital required)\n- Daily summary: routes attempted, won, lost, net P&L\n- A leaderboard of profitable cycle patterns\n- A \"killed by MEV\" log to refine the haircut\n\nFeedback signal (closes the loop):\n- Confirmation rate per cycle pattern\n- Realized profit vs simulated — calibrates the MEV haircut\n- Patterns that decay (others discovered them) — rotate to fresher cycles\n\nQuality bar:\n- This is analysis, NOT financial advice — crypto arb is competitive and capital-intensive\n- NEVER auto-execute without simulator confirmation — pool state changes second-to-second\n- Gas wars + MEV bots eat most retail \"arb\" — your edge is in fresh routes, not crowded ones\n- A failed arb costs you gas every time — track failure rate as relentlessly as profit\n- Most cross-DEX arbs on major chains are already captured by professional bots — the alpha is in new pools or unusual cycles\n- If your daily net is negative for 7 days, something in the model is wrong — stop and audit"
+    },
+    {
+      "id": "tax-loss-harvest-sweep",
+      "name": "Run an annual tax-loss harvest sweep",
+      "category": "Finance",
+      "tags": [
+        "audit",
+        "finance",
+        "personal"
+      ],
+      "emoji": "🌾",
+      "description": "Run an annual tax-loss harvest across taxable accounts. Get harvest pairs that avoid wash sale and an estimated tax savings.",
+      "works_best_with": {
+        "agent_profile": "finance-agent",
+        "skills": [
+          "concise-planning",
+          "pdf"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Audit all taxable lots for unrealized losses",
+        "Identify substantially identical replacements",
+        "Check wash-sale across accounts + spouse + IRA",
+        "Estimate tax savings per pair",
+        "Output a Q4 harvest plan"
+      ],
+      "prompt": "Run my annual tax-loss harvest sweep (Q4 prep, before December 31).\n\nInputs:\n- All taxable account statements (Schwab / Fidelity / Robinhood / IBKR — lot-level): [paste or path]\n- Spouse's accounts (for wash-sale rule across spousal accounts): [paste]\n- IRA + Roth + 401k holdings (wash-sale clock applies if substantially identical): [paste]\n- My federal marginal tax bracket + state tax rate: [paste]\n- YTD realized gains (short-term + long-term): [paste]\n- Planned future capital gains or losses I expect to realize: [paste]\n- Risk tolerance for the swap period (sell + buy substantially-NOT-identical replacement): [paste]\n\nPhase 1 — Audit all lots for unrealized losses.\n- For every position in every taxable account, list every lot\n- Per lot: ticker, acquisition date, cost basis, current market value, unrealized loss\n- Sort by largest absolute loss first\n- Flag short-term vs long-term loss (short-term is more valuable for offsetting short-term gains)\n\nPhase 2 — Identify substantially identical replacements.\nFor each loss lot you'd harvest:\n- The replacement security (similar exposure, NOT substantially identical per IRS guidance)\n- Examples: VTI loss → swap to ITOT or SCHB; AAPL loss → swap to QQQ or another tech ETF; SPY loss → swap to VOO with 31-day wait or to IVV with caution\n- The portfolio drift the swap introduces (sector, factor, size, geographic)\n- Whether to \"park\" in cash for 31 days or accept the swap drift\n\nPhase 3 — Wash-sale check (THE critical step).\nFor each candidate harvest:\n- Check ALL taxable accounts (yours + spouse) for the same security in the prior 30 days\n- Check ALL IRA / Roth accounts for the same security (yes, IRA wash-sales triggered by taxable losses are real)\n- Check planned future buys in the next 30 days (auto-invest schedules, dividend reinvestment)\n- Check options positions on the same underlying (puts can be tagged substantially identical)\n- KILL any harvest where any of these conditions exist\n\nPhase 4 — Estimate tax savings.\nFor each surviving harvest:\n- Loss harvested ($)\n- Tax saved at your marginal rate (federal + state)\n- Reduction in YTD realized gains (offset)\n- Carryforward generated (up to $3k/yr against ordinary income; rest carries forward)\n\nPhase 5 — Build the Q4 execution plan.\n- Harvest order (largest tax-saving first)\n- Replacement security buy timing (same day, market close)\n- 31-day calendar for when you can buy back original (if you want to)\n- Auto-invest pause flags + DRIP suspension where needed\n\nPhase 6 — Output.\n- Harvest plan PDF (per-lot detail, executable as broker tickets)\n- Wash-sale risk audit log (all triggers found + how avoided)\n- Estimated tax savings summary (1-page top sheet)\n- A 31-day calendar showing when each replacement holds vs returns\n- Updates needed to auto-invest / DRIP / contribution schedules\n\nFeedback signal (next year):\n- Realized vs estimated tax savings — calibrate\n- Patterns: what harvested well vs what fought wash-sale rules constantly\n- Whether the swap drift hurt portfolio performance — adjust replacement strategy\n\nQuality bar:\n- This is tax planning analysis, NOT tax advice — consult a CPA for complex situations\n- The wash-sale rule is BRUTAL — one missed account triggers full deferral\n- Watch DRIP and auto-invest religiously — they reinvest at year-end and break harvests\n- For substantially identical: VTI and VOO are clearly different (different indices); AAPL and AAPL are not\n- Harvest is most valuable when offsetting short-term gains (taxed as ordinary income)\n- Capital loss carryforward is a real asset — track it across years\n- DON'T harvest at expense of long-term portfolio strategy — the tax tail shouldn't wag the investment dog"
+    },
+    {
+      "id": "fomc-volatility-playbook",
+      "name": "Build a FOMC decision-day volatility playbook",
+      "category": "Investing",
+      "tags": [
+        "investing",
+        "report"
+      ],
+      "emoji": "🦉",
+      "description": "Build an FOMC-day playbook. Get hawkish/neutral/dovish scenarios with strikes, timing, and a 4-stage volatility roadmap.",
+      "works_best_with": {
+        "agent_profile": "finance-agent",
+        "skills": [
+          "brave-search",
+          "concise-planning",
+          "pdf"
+        ],
+        "mcp_servers": [],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Pull market-implied probabilities (Fed Funds Futures)",
+        "Generate hawkish/neutral/dovish scenarios",
+        "Map to the 4-stage vol pattern",
+        "Pick strikes + timing per scenario",
+        "Build the kill switch"
+      ],
+      "prompt": "Build my FOMC decision-day trading playbook.\n\nInputs:\n- FOMC meeting date + time (2:00 PM ET press release, 2:30 PM ET Powell presser): [paste]\n- Current Fed Funds rate + market consensus: [paste]\n- Market-implied probabilities (Fed Funds Futures, CME FedWatch): [paste]\n- Current SPY / QQQ levels + recent technicals: [paste]\n- VIX level + term structure: [paste]\n- My capital allocated to FOMC trade + max loss: [paste]\n- My instrument preference (SPY 0DTE / VIX / sector ETFs): [paste]\n\nPhase 1 — Market-implied probabilities.\n- Hike / hold / cut probabilities (from Fed Funds Futures)\n- Implied terminal rate\n- 2024-2025 dot-plot drift vs current\n- Where consensus is OVER-confident (the actionable edge)\n\nPhase 2 — Generate scenarios.\n\nHawkish (rate higher than consensus, OR consensus rate + hawkish language):\n- SPY directional bias: down\n- VIX bias: spike\n- Bond yields (TLT): down\n- Dollar: up\n- Likely sectors: financials up; growth / tech / housing down\n\nNeutral (consensus rate + balanced language):\n- SPY likely range-bound until presser\n- VIX deflates after release\n- Bonds steady\n\nDovish (rate lower than consensus, OR rate cut signals, OR worse-than-expected projections):\n- SPY: up\n- VIX: deflate hard\n- Bonds: up\n- Dollar: down\n- Likely sectors: growth + small caps lead\n\nFor each scenario: probability estimate + strike selection + risk caps.\n\nPhase 3 — The 4-stage volatility pattern.\nStage 1 — Compression (10:00 AM - 1:55 PM ET):\n- Vol contracts as market awaits\n- Best for theta-positive (premium-selling) structures\n- Avoid directional bets until decision\n\nStage 2 — Decision Spike (2:00 PM - 2:15 PM ET):\n- Maximum volatility on press release\n- 1-3% SPY move within first 15 min is common\n- Best for hedged directional or vol-buying structures\n\nStage 3 — Powell Reversal (2:30 PM - 3:30 PM ET):\n- Press conference often reverses initial move\n- 60% of FOMC days reverse direction in this window\n- Plan around the reversal — don't chase the spike\n\nStage 4 — Resolution (3:30 PM - close):\n- Final positioning, direction confirms\n- Best for closing the trade or letting overnight hold\n\nPhase 4 — Pick strikes + timing per scenario.\n- Conservative play (defined-risk): credit spread or iron condor positioned for compression\n- Directional play: long calls / puts entered AT compression (cheap vol)\n- Vol play: long VIX calls or VIX call spread\n- Reversal play: enter opposite-side position at 2:30 PM if initial spike feels emotional\n\nPhase 5 — Kill switch.\n- Max loss per stage (Stage 2 spike, Stage 3 reversal)\n- Mid-day reassessment trigger (if Stage 2 move > X%, recalibrate)\n- \"Walk away\" rules (if VIX dies after Stage 2, kill long-vol positions immediately)\n\nPhase 6 — Output.\n- Playbook PDF (1 page top-line + 4-stage details + scenario strikes)\n- Pre-market briefing the morning of FOMC (recap of overnight + final probabilities)\n- 2 PM \"decision live\" alert template (script for the reaction)\n- Post-FOMC retrospective (what worked + what didn't + which scenario hit)\n\nFeedback signal (over FOMC meetings):\n- Per scenario: how often did your probability estimates match reality?\n- Per stage: did the timing pattern hold?\n- Per instrument: which gave the best risk-adjusted return on FOMC days?\n\nQuality bar:\n- This is analysis, NOT financial advice — FOMC days are violent and can blow up accounts\n- NEVER size FOMC trades as you would a normal day — assume 2x normal volatility\n- NEVER enter naked options into 2 PM — gamma + vega risk is asymmetric\n- The \"reversal\" pattern is statistical, not guaranteed — manage stops accordingly\n- Consensus probability can be wrong — but trading against consensus needs explicit thesis\n- If you can't articulate the EDGE in your scenario probabilities, don't trade FOMC — just watch"
+    },
+    {
+      "id": "pre-market-daily-briefing",
+      "name": "Run a pre-market daily briefing pipeline",
+      "category": "Investing",
+      "tags": [
+        "investing",
+        "loop",
+        "pipeline",
+        "report"
+      ],
+      "emoji": "🌅",
+      "description": "Run a daily pre-market briefing. Get overnight news, earnings, calendar, top movers, and a positioning sheet by 6 AM.",
+      "works_best_with": {
+        "agent_profile": "finance-agent",
+        "skills": [
+          "brave-search",
+          "firecrawl",
+          "concise-planning"
+        ],
+        "mcp_servers": [
+          "gmail-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Pull overnight global news + futures",
+        "Pull economic calendar + earnings",
+        "Identify top movers + catalysts",
+        "Generate sector heatmap",
+        "Email structured brief by 6 AM"
+      ],
+      "prompt": "Run my pre-market daily briefing pipeline. Schedule daily at 6 AM ET.\n\nInputs:\n- My watchlist (tickers I trade actively): [paste]\n- Sectors I focus on: [paste]\n- Macro indicators to track (DXY, 10Y, VIX, oil, gold, etc.): [paste]\n- Email + Slack destinations: [paste]\n- Time zone + delivery time: [paste]\n- Earnings I'm tracking this week + my positions: [paste]\n- Style: [bulleted-tight / narrative / data-dense]\n\nPhase 1 — Overnight news + futures.\n- Asia + Europe market close summary\n- US futures (ES, NQ, YM, RTY) overnight move + key levels\n- Major news items from overnight (Bloomberg, Reuters, FT, WSJ headlines)\n- Geopolitical events that moved markets (tariffs, war, central bank)\n- Currency moves (DXY, EUR, JPY, CNY)\n- Commodities (oil, gold, copper) overnight\n\nPhase 2 — Economic calendar.\n- Today's releases (time, consensus, prior)\n- Highlight Tier 1 events (CPI, NFP, FOMC, GDP)\n- Implied volatility from STIRs + options around each event\n- \"What would surprise the market\" for each\n\nPhase 3 — Earnings calendar.\n- Companies reporting today (BMO + AMC)\n- Watchlist names reporting\n- Consensus EPS + revenue + key metric\n- Options-implied move (per ATM straddle)\n- Pre-market action if reported BMO\n\nPhase 4 — Top movers + catalysts.\n- Top 20 gainers / losers pre-market (with reason)\n- Watchlist names with notable pre-market move\n- Unusual options activity from overnight (Form 4 sweeps, blocks)\n- Insider buys / sells reported overnight\n- Government / Congress disclosures\n\nPhase 5 — Sector heatmap.\n- Pre-market sector ETFs (XLK, XLF, XLE, XLY, XLI, XLV, XLP, XLU, XLB, XLRE, XLC)\n- Relative strength vs SPY\n- Sectors leading / lagging the morning\n- Rotation signal (if any)\n\nPhase 6 — Positioning sheet.\n- Open positions: any pre-market action on them?\n- Stop levels approaching?\n- Earnings on any open position in the next 3 days?\n- \"If X happens today\" notes for each major holding\n\nPhase 7 — Output.\n- Email at 6 AM ET (subject: \"Pre-Market Brief — [date]\")\n- Slack message with TL;DR + key levels\n- PDF attached with full detail\n- A \"5-minute read\" version (top of email) and a \"20-minute deep dive\" (PDF)\n\nFeedback signal:\n- Which sections I actually read vs skip — promote / demote\n- News items I missed that mattered — refine sources\n- Movers I caught vs missed — adjust pre-market scanning\n- Style preference drift — A/B test bullets vs narrative\n\nQuality bar:\n- This is information aggregation, NOT financial advice\n- NEVER fabricate news — verify with at least one source per claim\n- Cite sources for every non-obvious claim (link to the article)\n- Distinguish official news from rumor — both have signal, but mark them\n- Tier 1 events get top-of-brief treatment, NOT buried in the appendix\n- 6 AM ET means EVERY day — if the pipeline misses a day, I'll lose trust in it\n- Brevity wins for daily — 5 minutes to read, 1 minute to scan"
+    },
+    {
+      "id": "daily-trade-journal",
+      "name": "Run a daily trade journal and EOD review",
+      "category": "Investing",
+      "tags": [
+        "investing",
+        "loop",
+        "report"
+      ],
+      "emoji": "📓",
+      "description": "Run a daily trade journal + end-of-day review. Get P&L attribution, discipline checks, and a weekly pattern report.",
+      "works_best_with": {
+        "agent_profile": "finance-agent",
+        "skills": [
+          "concise-planning",
+          "pdf"
+        ],
+        "mcp_servers": [
+          "notion-mcp"
+        ],
+        "living_ui_apps": []
+      },
+      "steps": [
+        "Ingest broker statement",
+        "Tag each trade by setup",
+        "Compute session R-multiple + win rate",
+        "Flag rule violations",
+        "Output journal entry + weekly retrospective"
+      ],
+      "prompt": "Run my daily trade journal + end-of-day review.\n\nInputs:\n- Today's broker statement / fills (Alpaca / IBKR / TastyTrade / Robinhood export): [paste or path]\n- My setup taxonomy (tag each trade by setup type — momentum, mean reversion, earnings play, swing, etc.): [paste my tags]\n- My trading rules (max risk per trade, max trades per day, no FOMO entries, etc.): [paste]\n- Account size start of day: [paste]\n- Premarket plan I wrote (what I said I'd do): [paste]\n- This week's running stats (win rate, avg R, P&L): [paste]\n\nPhase 1 — Ingest fills + categorize.\nFor each filled trade today:\n- Ticker, entry time, exit time, P&L\n- Tag by setup (from my taxonomy)\n- Tag by quality (planned / opportunistic / FOMO / revenge)\n- Tag by execution (clean fills / chasing / slippage hit)\n- Note any rule violations\n\nPhase 2 — Compute session stats.\n- Number of trades + win rate\n- Average R-multiple won vs lost\n- Largest winner + largest loser\n- P&L attribution by setup tag\n- Time-of-day distribution (am I better at open? midday? close?)\n\nPhase 3 — Discipline check.\n- Did I follow my pre-market plan? (binary yes/no per planned trade)\n- Did I take any unplanned trades? Why?\n- Did I size any position above my rules?\n- Did I hold a stop that I should have honored?\n- Any revenge trade signature (entered another trade right after a loss)?\n\nPhase 4 — Pattern review.\n- The setup that performed best today + why\n- The setup that lost the most + why\n- Surprise patterns (unusual sector, unusual time)\n- Lessons specific to today (a market regime detail to remember)\n\nPhase 5 — Write the journal entry.\nSections:\n1. Headline (1 sentence — was it a good day or a bad day, and what made it that?)\n2. Stats (numbers from Phase 2)\n3. Wins (3 trades that worked + WHY they worked)\n4. Losses (2-3 trades that didn't + WHY they didn't)\n5. Discipline grade (A-F with reasoning)\n6. Tomorrow's plan adjustment (one specific thing to do differently)\n\nPhase 6 — Sunday: weekly retrospective.\n- 7-day stats roll-up\n- Setup leaderboard (which earned, which lost)\n- Win rate by tag, by time of day, by market regime\n- 3 wins to repeat next week\n- 3 losses to NOT repeat next week\n- A \"what would have improved this week's P&L by 20%\" thought experiment\n\nPhase 7 — Output.\n- Daily journal entry (Notion / Obsidian markdown)\n- Weekly retrospective PDF (Sundays)\n- A running setup leaderboard updated daily\n- A monthly P&L attribution by tag\n- An annual \"what I learned\" memo (end-of-year)\n\nFeedback signal (closes the loop):\n- Setups consistently positive over 30+ trades — promote\n- Setups consistently negative over 30+ trades — DROP, not \"try again\"\n- Discipline grade trend — declining = burnout coming\n- The patterns the journal kept surfacing — bake into rules\n\nQuality bar:\n- This is performance analysis, NOT financial advice\n- NEVER fudge the numbers — the journal is for me, not for show\n- Discipline grade is binary truth — don't soften it\n- A losing day with discipline = a good day in the long run\n- A winning day with bad discipline = a bad habit forming\n- Win rate alone is meaningless — average R-multiple is the real edge metric\n- Track the same stats relentlessly — drift kills comparison over months"
+    }
+  ]
+}

--- a/app/ui_layer/adapters/browser_adapter.py
+++ b/app/ui_layer/adapters/browser_adapter.py
@@ -1145,6 +1145,17 @@ A quick Q&A will now begin to understand your objectives to serve you better:"""
             "/api/living-ui/import", self._living_ui_import_handler
         )
 
+        # Agent profile bundle import/export routes
+        self._app.router.add_get(
+            "/api/profile/export", self._profile_export_handler
+        )
+        self._app.router.add_post(
+            "/api/profile/inspect", self._profile_inspect_handler
+        )
+        self._app.router.add_post(
+            "/api/profile/import", self._profile_import_handler
+        )
+
         # Integration bridge routes (Living UI → external APIs)
         from app.living_ui.integration_bridge import IntegrationBridge
 
@@ -2919,6 +2930,123 @@ A quick Q&A will now begin to understand your objectives to serve you better:"""
         except Exception as e:
             logger.error(f"[LIVING_UI] Upload staging error: {e}")
             return web.json_response({"error": str(e)}, status=500)
+
+    # ─────────────────────────────────────────────────────────────────────
+    # Agent profile bundle (.craftbot) — export / inspect / import
+    # ─────────────────────────────────────────────────────────────────────
+
+    async def _profile_export_handler(self, request: "web.Request") -> "web.Response":
+        """Build a .craftbot bundle of the current agent and return it."""
+        from aiohttp import web
+        from app.ui_layer.settings.profile_bundle import export_profile
+        import shutil
+
+        description = request.query.get("description", "")
+        try:
+            result = export_profile(description=description)
+        except Exception as exc:
+            logger.error(f"[PROFILE_BUNDLE] Export failed: {exc}", exc_info=True)
+            return web.json_response({"error": str(exc)}, status=500)
+
+        if not result.get("success"):
+            return web.json_response(
+                {"error": result.get("error", "Export failed")}, status=500
+            )
+
+        bundle_path = Path(result["path"])
+        filename = result["filename"]
+        try:
+            payload = bundle_path.read_bytes()
+        finally:
+            # Clean up the temp file + its parent dir immediately. Bundles are
+            # small enough (no node_modules) to hold in memory briefly.
+            shutil.rmtree(bundle_path.parent, ignore_errors=True)
+
+        return web.Response(
+            body=payload,
+            headers={
+                "Content-Disposition": f'attachment; filename="{filename}"',
+                "Content-Type": "application/octet-stream",
+                "Content-Length": str(len(payload)),
+            },
+        )
+
+    async def _stage_uploaded_bundle(self, request: "web.Request") -> Optional[str]:
+        """Read the multipart upload and save the bundle to a temp file."""
+        import tempfile
+
+        reader = await request.multipart()
+        bundle_path: Optional[str] = None
+        async for part in reader:
+            if part.name == "file":
+                tmp = tempfile.NamedTemporaryFile(
+                    suffix=".craftbot",
+                    prefix="craftbot_profile_in_",
+                    delete=False,
+                )
+                while True:
+                    chunk = await part.read_chunk()
+                    if not chunk:
+                        break
+                    tmp.write(chunk)
+                tmp.close()
+                bundle_path = tmp.name
+        return bundle_path
+
+    async def _profile_inspect_handler(self, request: "web.Request") -> "web.Response":
+        """Read a bundle's manifest so the frontend can render a preview modal."""
+        from aiohttp import web
+        from app.ui_layer.settings.profile_bundle import inspect_bundle
+
+        try:
+            bundle_path = await self._stage_uploaded_bundle(request)
+            if not bundle_path:
+                return web.json_response(
+                    {"error": "No bundle file uploaded"}, status=400
+                )
+            result = inspect_bundle(bundle_path)
+            # Return the temp path so the subsequent /api/profile/import call
+            # can reuse it instead of re-uploading the bundle.
+            result["bundle_path"] = bundle_path
+            return web.json_response(result)
+        except Exception as exc:
+            logger.error(f"[PROFILE_BUNDLE] Inspect failed: {exc}", exc_info=True)
+            return web.json_response({"error": str(exc)}, status=500)
+
+    async def _profile_import_handler(self, request: "web.Request") -> "web.Response":
+        """Apply a previously-inspected bundle to the agent."""
+        from aiohttp import web
+        from app.ui_layer.settings.profile_bundle import import_profile
+
+        try:
+            payload = await request.json()
+        except Exception:
+            return web.json_response(
+                {"error": "Invalid JSON body"}, status=400
+            )
+
+        bundle_path = payload.get("bundle_path") or ""
+        mode = payload.get("mode", "merge")
+        if not bundle_path:
+            return web.json_response(
+                {"error": "bundle_path is required"}, status=400
+            )
+
+        try:
+            result = import_profile(bundle_path, mode=mode)
+        except Exception as exc:
+            logger.error(f"[PROFILE_BUNDLE] Import failed: {exc}", exc_info=True)
+            return web.json_response({"error": str(exc)}, status=500)
+        finally:
+            # Best-effort cleanup of the staged upload.
+            try:
+                p = Path(bundle_path)
+                if p.exists():
+                    p.unlink()
+            except Exception:
+                pass
+
+        return web.json_response(result)
 
     async def _handle_living_ui_state_update(self, data: Dict[str, Any]) -> None:
         """Handle state update from a Living UI for agent awareness."""

--- a/app/ui_layer/adapters/browser_adapter.py
+++ b/app/ui_layer/adapters/browser_adapter.py
@@ -961,13 +961,6 @@ class BrowserAdapter(InterfaceAdapter):
         # Track active OAuth tasks for cancellation support
         self._oauth_tasks: Dict[str, asyncio.Task] = {}
 
-        # Staged bundle path set by the inspect endpoint and consumed by the
-        # import endpoint. Storing it server-side means: (a) the import handler
-        # never trusts a client-supplied filesystem path, and (b) if the user
-        # closes the modal without importing, the next inspect call cleans up
-        # the leftover temp file.
-        self._staged_import_path: Optional[str] = None
-
         # Living UI manager
         template_path = (
             Path(__file__).parent.parent.parent / "data" / "living_ui_template"
@@ -3010,17 +3003,6 @@ A quick Q&A will now begin to understand your objectives to serve you better:"""
         from aiohttp import web
         from app.ui_layer.settings.profile_bundle import inspect_bundle
 
-        # Clean up any leftover staged file from a previous cancelled import.
-        if self._staged_import_path:
-            try:
-                p = Path(self._staged_import_path)
-                if p.exists():
-                    p.unlink()
-            except Exception:
-                pass
-            self._staged_import_path = None
-
-        bundle_path: Optional[str] = None
         try:
             bundle_path = await self._stage_uploaded_bundle(request)
             if not bundle_path:
@@ -3028,23 +3010,13 @@ A quick Q&A will now begin to understand your objectives to serve you better:"""
                     {"error": "No bundle file uploaded"}, status=400
                 )
             result = inspect_bundle(bundle_path)
-            if result.get("success"):
-                # Store server-side so the import handler can use it without
-                # trusting a client-supplied filesystem path.
-                self._staged_import_path = bundle_path
-                bundle_path = None  # ownership transferred — don't clean up below
+            # Return the temp path so the subsequent /api/profile/import call
+            # can reuse it instead of re-uploading the bundle.
+            result["bundle_path"] = bundle_path
             return web.json_response(result)
         except Exception as exc:
             logger.error(f"[PROFILE_BUNDLE] Inspect failed: {exc}", exc_info=True)
             return web.json_response({"error": str(exc)}, status=500)
-        finally:
-            # Clean up the staged file only if inspection failed (success path
-            # transferred ownership to self._staged_import_path above).
-            if bundle_path:
-                try:
-                    Path(bundle_path).unlink(missing_ok=True)
-                except Exception:
-                    pass
 
     async def _profile_import_handler(self, request: "web.Request") -> "web.Response":
         """Apply a previously-inspected bundle to the agent."""
@@ -3058,17 +3030,12 @@ A quick Q&A will now begin to understand your objectives to serve you better:"""
                 {"error": "Invalid JSON body"}, status=400
             )
 
-        # Use the server-side staged path set by the inspect endpoint.
-        # We intentionally ignore any bundle_path from the request body so that
-        # a client cannot point this handler at an arbitrary filesystem path.
-        bundle_path = self._staged_import_path
-        mode = payload.get("mode", "replace")
+        bundle_path = payload.get("bundle_path") or ""
+        mode = payload.get("mode", "merge")
         if not bundle_path:
             return web.json_response(
-                {"error": "No bundle staged. Upload a bundle via /api/profile/inspect first."}, status=400
+                {"error": "bundle_path is required"}, status=400
             )
-
-        self._staged_import_path = None  # clear before import so a failure doesn't leave it set
 
         try:
             # Pass the live LivingUIManager so imported projects land in its
@@ -3085,7 +3052,9 @@ A quick Q&A will now begin to understand your objectives to serve you better:"""
         finally:
             # Best-effort cleanup of the staged upload.
             try:
-                Path(bundle_path).unlink(missing_ok=True)
+                p = Path(bundle_path)
+                if p.exists():
+                    p.unlink()
             except Exception:
                 pass
 

--- a/app/ui_layer/adapters/browser_adapter.py
+++ b/app/ui_layer/adapters/browser_adapter.py
@@ -8,6 +8,7 @@ import json
 import os
 import re
 import shutil
+import sys
 import time
 import uuid
 from datetime import datetime
@@ -17,7 +18,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set
 from aiohttp.client_exceptions import ClientConnectionResetError
 
 from agent_core.utils.logger import logger
-from app.config import AGENT_WORKSPACE_ROOT
+from app.config import AGENT_WORKSPACE_ROOT, APP_DATA_PATH
 from app.ui_layer.adapters.base import InterfaceAdapter
 from app.ui_layer.settings import (
     # General settings
@@ -1832,6 +1833,10 @@ A quick Q&A will now begin to understand your objectives to serve you better:"""
             source = data.get("source", "")
             name = data.get("name", "External App")
             asyncio.create_task(self._handle_living_ui_import(source, name))
+
+        # Playbook catalogue handlers
+        elif msg_type == "playbook_list":
+            await self._handle_playbook_list()
 
         # WhatsApp QR code flow handlers
         elif msg_type == "whatsapp_start_qr":
@@ -6379,6 +6384,66 @@ A quick Q&A will now begin to understand your objectives to serve you better:"""
         await self._broadcast(
             {"type": "living_ui_project_setting_update", "data": result}
         )
+
+    # =====================
+    # Playbook Handlers
+    # =====================
+
+    async def _handle_playbook_list(self) -> None:
+        """Read the bundled playbook catalogue and broadcast it to the client.
+
+        Lookup order mirrors `get_default_picture_path` for read-only bundled
+        assets: APP_DATA_PATH first (source mode + writable per-user dir),
+        then `_MEIPASS/app/data/playbooks` so packaged builds resolve too.
+        """
+        candidates = [APP_DATA_PATH / "playbooks" / "catalogue.json"]
+        meipass = getattr(sys, "_MEIPASS", None)
+        if meipass:
+            candidates.append(
+                Path(meipass) / "app" / "data" / "playbooks" / "catalogue.json"
+            )
+
+        catalogue_path: Optional[Path] = next(
+            (p for p in candidates if p.exists()), None
+        )
+
+        if catalogue_path is None:
+            await self._broadcast(
+                {
+                    "type": "playbook_list",
+                    "data": {
+                        "success": False,
+                        "error": "Playbook catalogue not found.",
+                        "playbooks": [],
+                    },
+                }
+            )
+            return
+
+        try:
+            with open(catalogue_path, "r", encoding="utf-8") as f:
+                catalogue = json.load(f)
+            await self._broadcast(
+                {
+                    "type": "playbook_list",
+                    "data": {
+                        "success": True,
+                        "playbooks": catalogue.get("playbooks", []),
+                    },
+                }
+            )
+        except Exception as e:
+            logger.error(f"[PLAYBOOK] Failed to read catalogue: {e}")
+            await self._broadcast(
+                {
+                    "type": "playbook_list",
+                    "data": {
+                        "success": False,
+                        "error": str(e),
+                        "playbooks": [],
+                    },
+                }
+            )
 
     # =====================
     # Marketplace Handlers

--- a/app/ui_layer/adapters/browser_adapter.py
+++ b/app/ui_layer/adapters/browser_adapter.py
@@ -961,6 +961,9 @@ class BrowserAdapter(InterfaceAdapter):
         # Track active OAuth tasks for cancellation support
         self._oauth_tasks: Dict[str, asyncio.Task] = {}
 
+        # Staged bundle bytes keyed by short-lived token (inspect → import flow)
+        self._staged_bundles: Dict[str, bytes] = {}
+
         # Living UI manager
         template_path = (
             Path(__file__).parent.parent.parent / "data" / "living_ui_template"
@@ -3003,6 +3006,7 @@ A quick Q&A will now begin to understand your objectives to serve you better:"""
         from aiohttp import web
         from app.ui_layer.settings.profile_bundle import inspect_bundle
 
+        bundle_path = None
         try:
             bundle_path = await self._stage_uploaded_bundle(request)
             if not bundle_path:
@@ -3010,13 +3014,22 @@ A quick Q&A will now begin to understand your objectives to serve you better:"""
                     {"error": "No bundle file uploaded"}, status=400
                 )
             result = inspect_bundle(bundle_path)
-            # Return the temp path so the subsequent /api/profile/import call
-            # can reuse it instead of re-uploading the bundle.
-            result["bundle_path"] = bundle_path
+            # Read bytes into memory and delete the temp file immediately so a
+            # cancelled import (user closes modal) never leaks a file to %TEMP%.
+            bundle_bytes = Path(bundle_path).read_bytes()
+            token = str(uuid.uuid4())
+            self._staged_bundles[token] = bundle_bytes
+            result["bundle_token"] = token
             return web.json_response(result)
         except Exception as exc:
             logger.error(f"[PROFILE_BUNDLE] Inspect failed: {exc}", exc_info=True)
             return web.json_response({"error": str(exc)}, status=500)
+        finally:
+            if bundle_path:
+                try:
+                    Path(bundle_path).unlink(missing_ok=True)
+                except Exception:
+                    pass
 
     async def _profile_import_handler(self, request: "web.Request") -> "web.Response":
         """Apply a previously-inspected bundle to the agent."""
@@ -3030,19 +3043,35 @@ A quick Q&A will now begin to understand your objectives to serve you better:"""
                 {"error": "Invalid JSON body"}, status=400
             )
 
-        bundle_path = payload.get("bundle_path") or ""
-        mode = payload.get("mode", "merge")
-        if not bundle_path:
+        token = payload.get("bundle_token") or ""
+        mode = payload.get("mode", "replace")
+        if not token:
             return web.json_response(
-                {"error": "bundle_path is required"}, status=400
+                {"error": "bundle_token is required"}, status=400
             )
 
+        bundle_bytes = self._staged_bundles.get(token)
+        if bundle_bytes is None:
+            return web.json_response(
+                {"error": "bundle_token not found or already used"}, status=400
+            )
+
+        import tempfile
+        tmp_path = None
         try:
+            with tempfile.NamedTemporaryFile(
+                suffix=".craftbot",
+                prefix="craftbot_profile_in_",
+                delete=False,
+            ) as tmp:
+                tmp.write(bundle_bytes)
+                tmp_path = tmp.name
+
             # Pass the live LivingUIManager so imported projects land in its
             # in-memory state. Without this, the manager's stale state will
             # overwrite our file on the next status update / watchdog tick.
             result = import_profile(
-                bundle_path,
+                tmp_path,
                 mode=mode,
                 living_ui_manager=self._living_ui_manager,
             )
@@ -3050,13 +3079,12 @@ A quick Q&A will now begin to understand your objectives to serve you better:"""
             logger.error(f"[PROFILE_BUNDLE] Import failed: {exc}", exc_info=True)
             return web.json_response({"error": str(exc)}, status=500)
         finally:
-            # Best-effort cleanup of the staged upload.
-            try:
-                p = Path(bundle_path)
-                if p.exists():
-                    p.unlink()
-            except Exception:
-                pass
+            self._staged_bundles.pop(token, None)
+            if tmp_path:
+                try:
+                    Path(tmp_path).unlink(missing_ok=True)
+                except Exception:
+                    pass
 
         return web.json_response(result)
 

--- a/app/ui_layer/adapters/browser_adapter.py
+++ b/app/ui_layer/adapters/browser_adapter.py
@@ -961,6 +961,13 @@ class BrowserAdapter(InterfaceAdapter):
         # Track active OAuth tasks for cancellation support
         self._oauth_tasks: Dict[str, asyncio.Task] = {}
 
+        # Staged bundle path set by the inspect endpoint and consumed by the
+        # import endpoint. Storing it server-side means: (a) the import handler
+        # never trusts a client-supplied filesystem path, and (b) if the user
+        # closes the modal without importing, the next inspect call cleans up
+        # the leftover temp file.
+        self._staged_import_path: Optional[str] = None
+
         # Living UI manager
         template_path = (
             Path(__file__).parent.parent.parent / "data" / "living_ui_template"
@@ -3003,6 +3010,17 @@ A quick Q&A will now begin to understand your objectives to serve you better:"""
         from aiohttp import web
         from app.ui_layer.settings.profile_bundle import inspect_bundle
 
+        # Clean up any leftover staged file from a previous cancelled import.
+        if self._staged_import_path:
+            try:
+                p = Path(self._staged_import_path)
+                if p.exists():
+                    p.unlink()
+            except Exception:
+                pass
+            self._staged_import_path = None
+
+        bundle_path: Optional[str] = None
         try:
             bundle_path = await self._stage_uploaded_bundle(request)
             if not bundle_path:
@@ -3010,13 +3028,23 @@ A quick Q&A will now begin to understand your objectives to serve you better:"""
                     {"error": "No bundle file uploaded"}, status=400
                 )
             result = inspect_bundle(bundle_path)
-            # Return the temp path so the subsequent /api/profile/import call
-            # can reuse it instead of re-uploading the bundle.
-            result["bundle_path"] = bundle_path
+            if result.get("success"):
+                # Store server-side so the import handler can use it without
+                # trusting a client-supplied filesystem path.
+                self._staged_import_path = bundle_path
+                bundle_path = None  # ownership transferred — don't clean up below
             return web.json_response(result)
         except Exception as exc:
             logger.error(f"[PROFILE_BUNDLE] Inspect failed: {exc}", exc_info=True)
             return web.json_response({"error": str(exc)}, status=500)
+        finally:
+            # Clean up the staged file only if inspection failed (success path
+            # transferred ownership to self._staged_import_path above).
+            if bundle_path:
+                try:
+                    Path(bundle_path).unlink(missing_ok=True)
+                except Exception:
+                    pass
 
     async def _profile_import_handler(self, request: "web.Request") -> "web.Response":
         """Apply a previously-inspected bundle to the agent."""
@@ -3030,12 +3058,17 @@ A quick Q&A will now begin to understand your objectives to serve you better:"""
                 {"error": "Invalid JSON body"}, status=400
             )
 
-        bundle_path = payload.get("bundle_path") or ""
-        mode = payload.get("mode", "merge")
+        # Use the server-side staged path set by the inspect endpoint.
+        # We intentionally ignore any bundle_path from the request body so that
+        # a client cannot point this handler at an arbitrary filesystem path.
+        bundle_path = self._staged_import_path
+        mode = payload.get("mode", "replace")
         if not bundle_path:
             return web.json_response(
-                {"error": "bundle_path is required"}, status=400
+                {"error": "No bundle staged. Upload a bundle via /api/profile/inspect first."}, status=400
             )
+
+        self._staged_import_path = None  # clear before import so a failure doesn't leave it set
 
         try:
             # Pass the live LivingUIManager so imported projects land in its
@@ -3052,9 +3085,7 @@ A quick Q&A will now begin to understand your objectives to serve you better:"""
         finally:
             # Best-effort cleanup of the staged upload.
             try:
-                p = Path(bundle_path)
-                if p.exists():
-                    p.unlink()
+                Path(bundle_path).unlink(missing_ok=True)
             except Exception:
                 pass
 

--- a/app/ui_layer/adapters/browser_adapter.py
+++ b/app/ui_layer/adapters/browser_adapter.py
@@ -3033,7 +3033,14 @@ A quick Q&A will now begin to understand your objectives to serve you better:"""
             )
 
         try:
-            result = import_profile(bundle_path, mode=mode)
+            # Pass the live LivingUIManager so imported projects land in its
+            # in-memory state. Without this, the manager's stale state will
+            # overwrite our file on the next status update / watchdog tick.
+            result = import_profile(
+                bundle_path,
+                mode=mode,
+                living_ui_manager=self._living_ui_manager,
+            )
         except Exception as exc:
             logger.error(f"[PROFILE_BUNDLE] Import failed: {exc}", exc_info=True)
             return web.json_response({"error": str(exc)}, status=500)

--- a/app/ui_layer/browser/frontend/src/components/Chat/Chat.tsx
+++ b/app/ui_layer/browser/frontend/src/components/Chat/Chat.tsx
@@ -7,6 +7,9 @@ import { Button, IconButton, SlashCommandAutocomplete, StatusIndicator, Attachme
 import type { SlashCommandAutocompleteHandle } from '../ui'
 import { useDerivedAgentStatus } from '../../hooks'
 import { ChatMessageItem } from '../../pages/Chat/ChatMessage'
+import { useAppDispatch, useAppSelector } from '../../store/hooks'
+import { selectPendingPrefill } from '../../store/selectors/chatInput'
+import { clearPendingPrefill } from '../../store/slices/chatInputSlice'
 import styles from './Chat.module.css'
 
 // Pending attachment type
@@ -123,6 +126,8 @@ export function Chat({ livingUIId, placeholder, emptyMessage }: ChatProps) {
   }, [messages])
 
   const [input, setInput] = useState('')
+  const dispatch = useAppDispatch()
+  const pendingPrefill = useAppSelector(selectPendingPrefill)
   const [pendingAttachments, setPendingAttachments] = useState<PendingAttachment[]>([])
   const [attachmentError, setAttachmentError] = useState<string | null>(null)
   const [isDragOver, setIsDragOver] = useState(false)
@@ -273,6 +278,24 @@ export function Chat({ livingUIId, placeholder, emptyMessage }: ChatProps) {
   useLayoutEffect(() => {
     adjustTextareaHeight()
   }, [input, adjustTextareaHeight])
+
+  // Consume a one-shot prefill payload from the chatInput slice (e.g. when the
+  // user picks a playbook). Replaces the current input so the prompt is ready
+  // to send or edit, then clears the payload so it doesn't re-apply.
+  useEffect(() => {
+    if (pendingPrefill === null) return
+    setInput(pendingPrefill)
+    dispatch(clearPendingPrefill())
+    // Focus + move caret to the end after the textarea has updated.
+    setTimeout(() => {
+      const ta = inputRef.current
+      if (ta) {
+        ta.focus()
+        const end = ta.value.length
+        ta.setSelectionRange(end, end)
+      }
+    }, 0)
+  }, [pendingPrefill, dispatch])
 
   const handleChatReply = useCallback((
     sessionId: string | undefined,

--- a/app/ui_layer/browser/frontend/src/components/layout/TopBar.tsx
+++ b/app/ui_layer/browser/frontend/src/components/layout/TopBar.tsx
@@ -1,6 +1,6 @@
-import React from 'react'
-import { Sun, Moon, Github } from 'lucide-react'
-import { IconButton } from '../ui'
+import React, { useState } from 'react'
+import { Sun, Moon, Github, BookOpen } from 'lucide-react'
+import { IconButton, PlaybookModal } from '../ui'
 import { useTheme } from '../../contexts/ThemeContext'
 import { useWebSocket } from '../../contexts/WebSocketContext'
 import { StatusIndicator } from '../ui/StatusIndicator'
@@ -23,6 +23,7 @@ export function TopBar() {
   const { theme, toggleTheme } = useTheme()
   const { connected, actions, messages } = useWebSocket()
   const version = useAppSelector(selectVersion)
+  const [playbookOpen, setPlaybookOpen] = useState(false)
 
   // Derive agent status from actions and messages
   const derivedStatus = useDerivedAgentStatus({
@@ -56,6 +57,12 @@ export function TopBar() {
       <div className={styles.right}>
         {version && <span className={styles.versionBadge}>v{version}</span>}
         <IconButton
+          icon={<BookOpen />}
+          onClick={() => setPlaybookOpen(true)}
+          size="sm"
+          tooltip="Playbooks"
+        />
+        <IconButton
           icon={theme === 'dark' ? <Sun /> : <Moon />}
           onClick={toggleTheme}
           size="sm"
@@ -74,6 +81,7 @@ export function TopBar() {
           onClick={() => window.open('https://discord.gg/bSdZf9HSgq', '_blank')}
         />
       </div>
+      <PlaybookModal isOpen={playbookOpen} onClose={() => setPlaybookOpen(false)} />
     </header>
   )
 }

--- a/app/ui_layer/browser/frontend/src/components/ui/ImportProfileModal.module.css
+++ b/app/ui_layer/browser/frontend/src/components/ui/ImportProfileModal.module.css
@@ -1,0 +1,156 @@
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.centered {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  padding: var(--space-6) 0;
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+}
+
+.error {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  background: rgba(239, 68, 68, 0.08);
+  border: 1px solid rgba(239, 68, 68, 0.25);
+  border-radius: var(--radius-md);
+  color: var(--color-error);
+  font-size: var(--text-sm);
+}
+
+.meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+}
+
+.description {
+  margin: 0;
+  padding: var(--space-2) var(--space-3);
+  background: var(--bg-tertiary);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+  font-style: italic;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.sectionLabel {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.sectionCount {
+  font-weight: 400;
+  opacity: 0.7;
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+}
+
+.chip {
+  padding: 2px 8px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-xs);
+  color: var(--text-primary);
+}
+
+.chipConflict {
+  background: rgba(234, 179, 8, 0.1);
+  border-color: rgba(234, 179, 8, 0.4);
+  color: var(--color-warning, #ca8a04);
+}
+
+.notice {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  background: rgba(234, 179, 8, 0.08);
+  border: 1px solid rgba(234, 179, 8, 0.25);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-xs);
+  color: var(--text-primary);
+}
+
+.modeBlock {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--border-primary);
+}
+
+.modeTitle {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.modeOption {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background var(--transition-fast);
+}
+
+.modeOption:hover {
+  background: var(--bg-tertiary);
+}
+
+.modeOption input[type='radio'] {
+  margin-top: 3px;
+}
+
+.modeName {
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.modeHint {
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+
+.spinning {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/app/ui_layer/browser/frontend/src/components/ui/ImportProfileModal.tsx
+++ b/app/ui_layer/browser/frontend/src/components/ui/ImportProfileModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { Loader2, AlertTriangle, Package, Wrench, Server, Layout, FileText } from 'lucide-react'
 import { Button } from './Button'
 import { Modal, ModalBody, ModalFooter } from './Modal'
@@ -95,6 +95,12 @@ export function ImportProfileModal({
   onApply,
 }: ImportProfileModalProps) {
   const [mode, setMode] = useState<ImportMode>('replace')
+
+  // Always start on the safe default when the modal opens so a previous
+  // 'overwrite' selection can't accidentally persist into the next session.
+  useEffect(() => {
+    if (isOpen) setMode('replace')
+  }, [isOpen])
 
   const contents = manifest?.contents ?? {}
   const skills = contents.skills ?? []

--- a/app/ui_layer/browser/frontend/src/components/ui/ImportProfileModal.tsx
+++ b/app/ui_layer/browser/frontend/src/components/ui/ImportProfileModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { Loader2, AlertTriangle, Package, Wrench, Server, Layout, FileText } from 'lucide-react'
 import { Button } from './Button'
 import { Modal, ModalBody, ModalFooter } from './Modal'
@@ -95,12 +95,6 @@ export function ImportProfileModal({
   onApply,
 }: ImportProfileModalProps) {
   const [mode, setMode] = useState<ImportMode>('replace')
-
-  // Always start on the safe default when the modal opens so a previous
-  // 'overwrite' selection can't accidentally persist into the next session.
-  useEffect(() => {
-    if (isOpen) setMode('replace')
-  }, [isOpen])
 
   const contents = manifest?.contents ?? {}
   const skills = contents.skills ?? []

--- a/app/ui_layer/browser/frontend/src/components/ui/ImportProfileModal.tsx
+++ b/app/ui_layer/browser/frontend/src/components/ui/ImportProfileModal.tsx
@@ -4,7 +4,7 @@ import { Button } from './Button'
 import { Modal, ModalBody, ModalFooter } from './Modal'
 import styles from './ImportProfileModal.module.css'
 
-export type ImportMode = 'merge' | 'replace'
+export type ImportMode = 'replace' | 'overwrite'
 
 export interface ProfileBundleManifest {
   name: string
@@ -94,7 +94,7 @@ export function ImportProfileModal({
   onCancel,
   onApply,
 }: ImportProfileModalProps) {
-  const [mode, setMode] = useState<ImportMode>('merge')
+  const [mode, setMode] = useState<ImportMode>('replace')
 
   const contents = manifest?.contents ?? {}
   const skills = contents.skills ?? []
@@ -185,16 +185,17 @@ export function ImportProfileModal({
                 <input
                   type="radio"
                   name="import-mode"
-                  value="merge"
-                  checked={mode === 'merge'}
-                  onChange={() => setMode('merge')}
+                  value="replace"
+                  checked={mode === 'replace'}
+                  onChange={() => setMode('replace')}
                   disabled={isApplying}
                 />
                 <div>
-                  <div className={styles.modeName}>Merge with my agent (recommended)</div>
+                  <div className={styles.modeName}>Merge and Replace (recommended)</div>
                   <div className={styles.modeHint}>
-                    Adds new skills, MCPs, and apps. Keeps your agent name.
-                    Personality files are appended under a divider. Conflicts are skipped.
+                    Adds new skills, MCPs, and apps. Overwrites personality files
+                    and MCP/skill config on name conflict. Living UI apps with
+                    matching names are imported alongside (never destroyed).
                   </div>
                 </div>
               </label>
@@ -202,16 +203,18 @@ export function ImportProfileModal({
                 <input
                   type="radio"
                   name="import-mode"
-                  value="replace"
-                  checked={mode === 'replace'}
-                  onChange={() => setMode('replace')}
+                  value="overwrite"
+                  checked={mode === 'overwrite'}
+                  onChange={() => setMode('overwrite')}
                   disabled={isApplying}
                 />
                 <div>
-                  <div className={styles.modeName}>Replace</div>
+                  <div className={styles.modeName}>Overwrite</div>
                   <div className={styles.modeHint}>
-                    Overwrites personality files and MCP/skill config on conflict.
-                    Living UI apps with matching names are still imported alongside (never destroyed).
+                    <strong>Destructive.</strong> Wipes <em>all</em> existing
+                    skills, MCP servers, and Living UI apps, then installs only
+                    what's in this bundle. Your agent becomes a copy of the
+                    bundle. Cannot be undone.
                   </div>
                 </div>
               </label>
@@ -224,7 +227,7 @@ export function ImportProfileModal({
           Cancel
         </Button>
         <Button
-          variant="primary"
+          variant={mode === 'overwrite' ? 'danger' : 'primary'}
           onClick={() => onApply(mode)}
           disabled={isApplying || !manifest || !!error}
           icon={
@@ -235,7 +238,11 @@ export function ImportProfileModal({
             )
           }
         >
-          {isApplying ? 'Applying…' : 'Apply Profile'}
+          {isApplying
+            ? 'Applying…'
+            : mode === 'overwrite'
+              ? 'Overwrite Agent'
+              : 'Apply Profile'}
         </Button>
       </ModalFooter>
     </Modal>

--- a/app/ui_layer/browser/frontend/src/components/ui/ImportProfileModal.tsx
+++ b/app/ui_layer/browser/frontend/src/components/ui/ImportProfileModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { Loader2, AlertTriangle, Package, Wrench, Server, Layout, FileText } from 'lucide-react'
 import { Button } from './Button'
 import { Modal, ModalBody, ModalFooter } from './Modal'
@@ -95,6 +95,10 @@ export function ImportProfileModal({
   onApply,
 }: ImportProfileModalProps) {
   const [mode, setMode] = useState<ImportMode>('replace')
+
+  useEffect(() => {
+    if (isOpen) setMode('replace')
+  }, [isOpen])
 
   const contents = manifest?.contents ?? {}
   const skills = contents.skills ?? []

--- a/app/ui_layer/browser/frontend/src/components/ui/ImportProfileModal.tsx
+++ b/app/ui_layer/browser/frontend/src/components/ui/ImportProfileModal.tsx
@@ -1,0 +1,243 @@
+import { useState } from 'react'
+import { Loader2, AlertTriangle, Package, Wrench, Server, Layout, FileText } from 'lucide-react'
+import { Button } from './Button'
+import { Modal, ModalBody, ModalFooter } from './Modal'
+import styles from './ImportProfileModal.module.css'
+
+export type ImportMode = 'merge' | 'replace'
+
+export interface ProfileBundleManifest {
+  name: string
+  description?: string
+  source_app_version?: string
+  created_at?: string
+  contents: {
+    agent_name?: string
+    md_files?: string[]
+    skills?: string[]
+    mcp_servers?: string[]
+    living_ui_apps?: string[]
+  }
+}
+
+export interface ProfileBundlePreview {
+  skills_already_installed: string[]
+  mcp_already_installed: string[]
+  mcp_needs_env: Array<{ name: string; env_keys: string[] }>
+}
+
+export interface ImportProfileModalProps {
+  isOpen: boolean
+  manifest: ProfileBundleManifest | null
+  preview: ProfileBundlePreview | null
+  isApplying: boolean
+  error?: string | null
+  onCancel: () => void
+  onApply: (mode: ImportMode) => void
+}
+
+function formatDate(iso?: string): string {
+  if (!iso) return ''
+  try {
+    const d = new Date(iso)
+    return d.toLocaleDateString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    })
+  } catch {
+    return iso
+  }
+}
+
+function SectionRow({
+  icon,
+  label,
+  items,
+  conflicts,
+}: {
+  icon: React.ReactNode
+  label: string
+  items: string[]
+  conflicts?: string[]
+}) {
+  if (items.length === 0) return null
+  const conflictSet = new Set(conflicts ?? [])
+  return (
+    <div className={styles.section}>
+      <div className={styles.sectionLabel}>
+        {icon}
+        <span>{label}</span>
+        <span className={styles.sectionCount}>({items.length})</span>
+      </div>
+      <div className={styles.chips}>
+        {items.map(name => (
+          <span
+            key={name}
+            className={`${styles.chip} ${conflictSet.has(name) ? styles.chipConflict : ''}`}
+            title={conflictSet.has(name) ? 'Already installed locally' : undefined}
+          >
+            {name}
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export function ImportProfileModal({
+  isOpen,
+  manifest,
+  preview,
+  isApplying,
+  error,
+  onCancel,
+  onApply,
+}: ImportProfileModalProps) {
+  const [mode, setMode] = useState<ImportMode>('merge')
+
+  const contents = manifest?.contents ?? {}
+  const skills = contents.skills ?? []
+  const mcps = contents.mcp_servers ?? []
+  const apps = contents.living_ui_apps ?? []
+  const mds = contents.md_files ?? []
+
+  const title = manifest ? `Import "${manifest.name}"` : 'Import agent profile'
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={isApplying ? () => undefined : onCancel}
+      title={title}
+      size="md"
+      closeOnOverlayClick={!isApplying}
+      closeDisabled={isApplying}
+    >
+      <ModalBody className={styles.body}>
+        {!manifest && !error && (
+          <div className={styles.centered}>
+            <Loader2 size={20} className={styles.spinning} />
+            <span>Reading bundle…</span>
+          </div>
+        )}
+
+        {error && (
+          <div className={styles.error}>
+            <AlertTriangle size={16} />
+            <span>{error}</span>
+          </div>
+        )}
+
+        {manifest && (
+          <>
+            <div className={styles.meta}>
+              {manifest.source_app_version && (
+                <span>Made with CraftBot {manifest.source_app_version}</span>
+              )}
+              {manifest.created_at && <span>· {formatDate(manifest.created_at)}</span>}
+              {contents.agent_name && (
+                <span>· from agent "{contents.agent_name}"</span>
+              )}
+            </div>
+
+            {manifest.description && (
+              <p className={styles.description}>{manifest.description}</p>
+            )}
+
+            <SectionRow
+              icon={<FileText size={14} />}
+              label="Personality files"
+              items={mds}
+            />
+            <SectionRow
+              icon={<Wrench size={14} />}
+              label="Skills"
+              items={skills}
+              conflicts={preview?.skills_already_installed}
+            />
+            <SectionRow
+              icon={<Server size={14} />}
+              label="MCP servers"
+              items={mcps}
+              conflicts={preview?.mcp_already_installed}
+            />
+            <SectionRow
+              icon={<Layout size={14} />}
+              label="Living UI apps"
+              items={apps}
+            />
+
+            {preview && preview.mcp_needs_env.length > 0 && (
+              <div className={styles.notice}>
+                <AlertTriangle size={14} />
+                <div>
+                  After import, fill in API keys for:{' '}
+                  <strong>
+                    {preview.mcp_needs_env.map(m => m.name).join(', ')}
+                  </strong>
+                </div>
+              </div>
+            )}
+
+            <div className={styles.modeBlock}>
+              <div className={styles.modeTitle}>How should I apply this?</div>
+              <label className={styles.modeOption}>
+                <input
+                  type="radio"
+                  name="import-mode"
+                  value="merge"
+                  checked={mode === 'merge'}
+                  onChange={() => setMode('merge')}
+                  disabled={isApplying}
+                />
+                <div>
+                  <div className={styles.modeName}>Merge with my agent (recommended)</div>
+                  <div className={styles.modeHint}>
+                    Adds new skills, MCPs, and apps. Keeps your agent name.
+                    Personality files are appended under a divider. Conflicts are skipped.
+                  </div>
+                </div>
+              </label>
+              <label className={styles.modeOption}>
+                <input
+                  type="radio"
+                  name="import-mode"
+                  value="replace"
+                  checked={mode === 'replace'}
+                  onChange={() => setMode('replace')}
+                  disabled={isApplying}
+                />
+                <div>
+                  <div className={styles.modeName}>Replace</div>
+                  <div className={styles.modeHint}>
+                    Overwrites personality files and MCP/skill config on conflict.
+                    Living UI apps with matching names are still imported alongside (never destroyed).
+                  </div>
+                </div>
+              </label>
+            </div>
+          </>
+        )}
+      </ModalBody>
+      <ModalFooter>
+        <Button variant="secondary" onClick={onCancel} disabled={isApplying}>
+          Cancel
+        </Button>
+        <Button
+          variant="primary"
+          onClick={() => onApply(mode)}
+          disabled={isApplying || !manifest || !!error}
+          icon={
+            isApplying ? (
+              <Loader2 size={14} className={styles.spinning} />
+            ) : (
+              <Package size={14} />
+            )
+          }
+        >
+          {isApplying ? 'Applying…' : 'Apply Profile'}
+        </Button>
+      </ModalFooter>
+    </Modal>
+  )
+}

--- a/app/ui_layer/browser/frontend/src/components/ui/Modal.module.css
+++ b/app/ui_layer/browser/frontend/src/components/ui/Modal.module.css
@@ -23,6 +23,7 @@
   border: 1px solid var(--border-primary);
   border-radius: var(--radius-lg);
   width: 100%;
+  max-height: 92vh;
   overflow: hidden;
   display: flex;
   flex-direction: column;

--- a/app/ui_layer/browser/frontend/src/components/ui/PlaybookModal.module.css
+++ b/app/ui_layer/browser/frontend/src/components/ui/PlaybookModal.module.css
@@ -1,0 +1,389 @@
+/* Title row in the modal header */
+.titleRow {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.titleIcon {
+  color: var(--text-primary);
+}
+
+/* ─── List view ─────────────────────────────────────────────── */
+.listBody {
+  display: flex;
+  flex-direction: column;
+  /* Fixed surface so the modal doesn't resize when filtering — the inner
+     content area scrolls instead. Width pulled in from viewport edges so
+     the modal never overflows on narrower windows. */
+  width: min(1400px, 95vw);
+  height: min(800px, 90vh);
+  min-height: 0;
+}
+
+.toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--border-primary);
+  flex-shrink: 0;
+}
+
+.searchWrapper {
+  position: relative;
+}
+
+.searchIcon {
+  position: absolute;
+  left: var(--space-3);
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--text-muted);
+  pointer-events: none;
+}
+
+.searchInput {
+  width: 100%;
+  padding: var(--space-2) var(--space-3) var(--space-2) calc(var(--space-3) + 20px);
+  font-size: var(--text-sm);
+  font-family: inherit;
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md);
+  transition: border-color var(--transition-fast);
+}
+
+.searchInput:focus {
+  outline: none;
+  border-color: var(--border-hover);
+}
+
+.tagsRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: center;
+}
+
+.tagChip {
+  padding: 4px 10px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-primary);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  font-family: inherit;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  white-space: nowrap;
+}
+
+.tagChip:hover {
+  border-color: var(--text-primary);
+  color: var(--text-primary);
+}
+
+.tagChipActive {
+  background: var(--text-primary);
+  border-color: var(--text-primary);
+  color: var(--bg-primary);
+}
+
+.tagChipActive:hover {
+  color: var(--bg-primary);
+}
+
+.listContent {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-4);
+}
+
+/* Pinterest-style masonry via CSS multi-column layout. column-count is the
+   only reliable knob across browsers — column-width hints get ignored when
+   column-count is also set, which jams columns too narrow. Use media queries
+   keyed to the modal's actual rendered width to step the count down. */
+.grid {
+  column-count: 4;
+  column-gap: var(--space-3);
+}
+
+/* Below ~1000px the modal hits its 90vw cap and 4 columns get cramped. */
+@media (max-width: 1100px) {
+  .grid {
+    column-count: 3;
+  }
+}
+
+@media (max-width: 760px) {
+  .grid {
+    column-count: 2;
+  }
+}
+
+@media (max-width: 500px) {
+  .grid {
+    column-count: 1;
+  }
+}
+
+.card {
+  display: block;
+  width: 100%;
+  margin: 0 0 var(--space-3);
+  padding: var(--space-3);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit;
+  transition: border-color var(--transition-fast), transform var(--transition-fast);
+  break-inside: avoid;
+}
+
+.card:hover {
+  border-color: var(--text-primary);
+  transform: translateY(-2px);
+}
+
+.cardTitleRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
+}
+
+.cardEmoji {
+  font-size: 18px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.cardName {
+  font-weight: var(--font-semibold);
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+}
+
+.cardDesc {
+  margin: 0;
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+  line-height: 1.55;
+}
+
+.cardTags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: var(--space-2);
+}
+
+.cardTag {
+  font-size: 10px;
+  padding: 1px 6px;
+  background: var(--bg-secondary);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+}
+
+/* ─── Detail view ─────────────────────────────────────────────── */
+.detailBody {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  /* Match the list view's fixed footprint so navigating in/out of detail
+     doesn't reshape the modal. */
+  width: min(1400px, 95vw);
+  height: min(800px, 90vh);
+  overflow-y: auto;
+}
+
+.backButton {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  background: none;
+  border: none;
+  font-family: inherit;
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 0;
+}
+
+.backButton:hover {
+  color: var(--text-primary);
+}
+
+.detailHeader {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.detailEmoji {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: var(--radius-md);
+  background: var(--bg-selected);
+  font-size: 28px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.detailName {
+  margin: 0;
+  font-size: var(--text-lg);
+  font-weight: var(--font-semibold);
+  color: var(--text-primary);
+}
+
+.detailCategory {
+  font-size: 10px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-top: 2px;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.sectionLabel {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-size: var(--text-xs);
+  font-weight: var(--font-semibold);
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.sectionHint {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--bg-tertiary);
+  color: var(--text-muted);
+  font-size: 10px;
+  cursor: help;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 8px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-primary);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+}
+
+.chipInstalled {
+  border-color: var(--color-success, #22c55e);
+  color: var(--color-success, #22c55e);
+}
+
+.chipCheck {
+  color: var(--color-success, #22c55e);
+}
+
+.description {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.steps {
+  margin: 0;
+  padding-left: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  color: var(--text-secondary);
+}
+
+.step {
+  font-size: var(--text-sm);
+  line-height: 1.5;
+}
+
+.promptPreview {
+  margin: 0;
+  padding: var(--space-3);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md);
+  font-family: var(--font-mono, monospace);
+  font-size: var(--text-xs);
+  color: var(--text-primary);
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  max-height: 480px;
+  overflow-y: auto;
+}
+
+.detailFooter {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-2);
+  padding-top: var(--space-2);
+}
+
+/* ─── Loading / empty states ─────────────────────────────────────────────── */
+.stateCenter {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: var(--space-6);
+  color: var(--text-muted);
+  min-height: 240px;
+}
+
+.stateIcon {
+  margin-bottom: var(--space-3);
+  opacity: 0.5;
+}
+
+.stateText {
+  margin: 0 0 var(--space-3);
+  font-size: var(--text-sm);
+}
+
+.spinner {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}

--- a/app/ui_layer/browser/frontend/src/components/ui/PlaybookModal.tsx
+++ b/app/ui_layer/browser/frontend/src/components/ui/PlaybookModal.tsx
@@ -1,0 +1,395 @@
+import { useState, useEffect, useMemo, useCallback } from 'react'
+import {
+  ArrowLeft,
+  BookOpen,
+  Check,
+  Layout,
+  Loader2,
+  Search,
+  Server,
+  Sparkles,
+  UserCircle,
+  Wrench,
+  Zap,
+} from 'lucide-react'
+import { Button } from './Button'
+import { Modal } from './Modal'
+import { MarkdownContent } from './MarkdownContent'
+import { useSettingsWebSocket } from '../../pages/Settings/useSettingsWebSocket'
+import { useAppDispatch, useAppSelector } from '../../store/hooks'
+import { setPendingPrefill } from '../../store/slices/chatInputSlice'
+import { selectEnabledSkillNames } from '../../store/selectors/skillsSettings'
+import styles from './PlaybookModal.module.css'
+
+export interface PlaybookModalProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+interface PlaybookWorksBestWith {
+  agent_profile?: string
+  skills?: string[]
+  mcp_servers?: string[]
+  living_ui_apps?: string[]
+}
+
+interface Playbook {
+  id: string
+  name: string
+  category?: string
+  tags?: string[]
+  emoji?: string
+  description?: string
+  works_best_with?: PlaybookWorksBestWith
+  steps?: string[]
+  prompt: string
+}
+
+const DEFAULT_EMOJI = '📖'
+
+export function PlaybookModal({ isOpen, onClose }: PlaybookModalProps) {
+  const { send, onMessage, isConnected } = useSettingsWebSocket()
+  const dispatch = useAppDispatch()
+  const enabledSkills = useAppSelector(selectEnabledSkillNames)
+
+  const [playbooks, setPlaybooks] = useState<Playbook[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [selectedTags, setSelectedTags] = useState<Set<string>>(new Set())
+  const [tagsExpanded, setTagsExpanded] = useState(false)
+  const [selectedPlaybook, setSelectedPlaybook] = useState<Playbook | null>(null)
+
+  const TAG_COLLAPSE_LIMIT = 8
+
+  // Fetch on first open (and whenever the connection comes online while open).
+  useEffect(() => {
+    if (!isOpen || !isConnected) return
+    if (playbooks.length > 0) return
+    setLoading(true)
+    setError(null)
+    send('playbook_list')
+  }, [isOpen, isConnected, playbooks.length, send])
+
+  // Subscribe to playbook_list responses for as long as the modal is mounted.
+  useEffect(() => {
+    return onMessage('playbook_list', (data: unknown) => {
+      const d = data as { success: boolean; playbooks?: Playbook[]; error?: string }
+      setLoading(false)
+      if (d.success && d.playbooks) {
+        setPlaybooks(d.playbooks)
+        setError(null)
+      } else {
+        setError(d.error || 'Failed to load playbooks')
+      }
+    })
+  }, [onMessage])
+
+  // Reset search + detail view whenever the modal closes so reopening starts clean.
+  useEffect(() => {
+    if (!isOpen) {
+      setSearchQuery('')
+      setSelectedTags(new Set())
+      setTagsExpanded(false)
+      setSelectedPlaybook(null)
+    }
+  }, [isOpen])
+
+  const allTags = useMemo(() => {
+    const counts = new Map<string, number>()
+    playbooks.forEach(p => p.tags?.forEach(t => counts.set(t, (counts.get(t) || 0) + 1)))
+    return Array.from(counts.entries())
+      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+      .map(([t]) => t)
+  }, [playbooks])
+
+  const filteredPlaybooks = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase()
+    return playbooks.filter(p => {
+      if (q) {
+        const hay = `${p.name} ${p.description ?? ''} ${(p.tags || []).join(' ')} ${p.category ?? ''}`.toLowerCase()
+        if (!hay.includes(q)) return false
+      }
+      if (selectedTags.size > 0) {
+        const tags = p.tags || []
+        if (!tags.some(t => selectedTags.has(t))) return false
+      }
+      return true
+    })
+  }, [playbooks, searchQuery, selectedTags])
+
+  const toggleTag = useCallback((tag: string) => {
+    setSelectedTags(prev => {
+      const next = new Set(prev)
+      if (next.has(tag)) next.delete(tag)
+      else next.add(tag)
+      return next
+    })
+  }, [])
+
+  const enabledSkillsSet = useMemo(() => new Set(enabledSkills), [enabledSkills])
+
+  const handleUse = useCallback((playbook: Playbook) => {
+    dispatch(setPendingPrefill(playbook.prompt))
+    onClose()
+  }, [dispatch, onClose])
+
+  if (!isOpen) return null
+
+  // Detail view -----------------------------------------------------------
+  if (selectedPlaybook) {
+    const wbw = selectedPlaybook.works_best_with || {}
+
+    return (
+      <Modal
+        isOpen
+        onClose={onClose}
+        size="auto"
+        title={
+          <span className={styles.titleRow}>
+            <BookOpen size={18} className={styles.titleIcon} />
+            Playbook
+          </span>
+        }
+      >
+        <div className={styles.detailBody}>
+          <button
+            type="button"
+            className={styles.backButton}
+            onClick={() => setSelectedPlaybook(null)}
+          >
+            <ArrowLeft size={14} />
+            Back to all playbooks
+          </button>
+
+          <div className={styles.detailHeader}>
+            <span className={styles.detailEmoji} aria-hidden="true">
+              {selectedPlaybook.emoji || DEFAULT_EMOJI}
+            </span>
+            <div>
+              <h2 className={styles.detailName}>{selectedPlaybook.name}</h2>
+              {selectedPlaybook.category && (
+                <div className={styles.detailCategory}>{selectedPlaybook.category}</div>
+              )}
+            </div>
+          </div>
+
+          {(wbw.agent_profile || (wbw.skills && wbw.skills.length) || (wbw.mcp_servers && wbw.mcp_servers.length) || (wbw.living_ui_apps && wbw.living_ui_apps.length)) && (
+            <div className={styles.section}>
+              <div className={styles.sectionLabel}>
+                Works best with
+                <span
+                  className={styles.sectionHint}
+                  title="These are hints — CraftBot can run the prompt without them, and will offer to help install anything missing."
+                >
+                  ?
+                </span>
+              </div>
+              <div className={styles.chips}>
+                {wbw.agent_profile && (
+                  <span className={styles.chip} title="Suggested agent profile">
+                    <UserCircle size={12} />
+                    {wbw.agent_profile}
+                  </span>
+                )}
+                {(wbw.skills || []).map(skill => {
+                  const installed = enabledSkillsSet.has(skill)
+                  return (
+                    <span
+                      key={`skill-${skill}`}
+                      className={`${styles.chip} ${installed ? styles.chipInstalled : ''}`}
+                      title={installed ? 'Skill already enabled' : 'Suggested skill'}
+                    >
+                      <Wrench size={12} />
+                      {skill}
+                      {installed && <Check size={10} className={styles.chipCheck} />}
+                    </span>
+                  )
+                })}
+                {(wbw.mcp_servers || []).map(mcp => (
+                  <span key={`mcp-${mcp}`} className={styles.chip} title="Suggested MCP server">
+                    <Server size={12} />
+                    {mcp}
+                  </span>
+                ))}
+                {(wbw.living_ui_apps || []).map(app => (
+                  <span key={`app-${app}`} className={styles.chip} title="Suggested Living UI app">
+                    <Layout size={12} />
+                    {app}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {selectedPlaybook.description && (
+            <div className={styles.section}>
+              <div className={styles.sectionLabel}>About</div>
+              <MarkdownContent
+                content={selectedPlaybook.description}
+                className={styles.description}
+              />
+            </div>
+          )}
+
+          {selectedPlaybook.steps && selectedPlaybook.steps.length > 0 && (
+            <div className={styles.section}>
+              <div className={styles.sectionLabel}>What CraftBot will do</div>
+              <ol className={styles.steps}>
+                {selectedPlaybook.steps.map((step, idx) => (
+                  <li key={idx} className={styles.step}>
+                    {step}
+                  </li>
+                ))}
+              </ol>
+            </div>
+          )}
+
+          <div className={styles.section}>
+            <div className={styles.sectionLabel}>Prompt preview</div>
+            <pre className={styles.promptPreview}>{selectedPlaybook.prompt}</pre>
+          </div>
+
+          <div className={styles.detailFooter}>
+            <Button variant="secondary" onClick={() => setSelectedPlaybook(null)}>
+              Back
+            </Button>
+            <Button
+              icon={<Zap size={14} />}
+              onClick={() => handleUse(selectedPlaybook)}
+            >
+              Use this playbook
+            </Button>
+          </div>
+        </div>
+      </Modal>
+    )
+  }
+
+  // List view -------------------------------------------------------------
+  return (
+    <Modal
+      isOpen
+      onClose={onClose}
+      size="auto"
+      title={
+        <span className={styles.titleRow}>
+          <BookOpen size={18} className={styles.titleIcon} />
+          Playbooks
+        </span>
+      }
+    >
+      <div className={styles.listBody}>
+        <div className={styles.toolbar}>
+          <div className={styles.searchWrapper}>
+            <Search size={14} className={styles.searchIcon} />
+            <input
+              className={styles.searchInput}
+              placeholder="Search playbooks..."
+              value={searchQuery}
+              onChange={e => setSearchQuery(e.target.value)}
+              autoFocus
+            />
+          </div>
+          {allTags.length > 0 && (() => {
+            const visibleTags = tagsExpanded ? allTags : allTags.slice(0, TAG_COLLAPSE_LIMIT)
+            const hiddenCount = Math.max(0, allTags.length - TAG_COLLAPSE_LIMIT)
+            return (
+              <div className={styles.tagsRow}>
+                <button
+                  type="button"
+                  className={`${styles.tagChip} ${selectedTags.size === 0 ? styles.tagChipActive : ''}`}
+                  onClick={() => setSelectedTags(new Set())}
+                >
+                  All
+                </button>
+                {visibleTags.map(tag => (
+                  <button
+                    key={tag}
+                    type="button"
+                    className={`${styles.tagChip} ${selectedTags.has(tag) ? styles.tagChipActive : ''}`}
+                    onClick={() => toggleTag(tag)}
+                  >
+                    {tag}
+                  </button>
+                ))}
+                {hiddenCount > 0 && (
+                  <button
+                    type="button"
+                    className={styles.tagChip}
+                    onClick={() => setTagsExpanded(v => !v)}
+                  >
+                    {tagsExpanded ? 'Show less' : `+${hiddenCount} more`}
+                  </button>
+                )}
+              </div>
+            )
+          })()}
+        </div>
+
+        <div className={styles.listContent}>
+          {loading ? (
+            <div className={styles.stateCenter}>
+              <Loader2 size={24} className={styles.spinner} />
+            </div>
+          ) : error ? (
+            <div className={styles.stateCenter}>
+              <p className={styles.stateText}>{error}</p>
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={() => {
+                  setLoading(true)
+                  setError(null)
+                  send('playbook_list')
+                }}
+              >
+                Retry
+              </Button>
+            </div>
+          ) : playbooks.length === 0 ? (
+            <div className={styles.stateCenter}>
+              <Sparkles size={32} className={styles.stateIcon} />
+              <p className={styles.stateText}>No playbooks available yet.</p>
+            </div>
+          ) : filteredPlaybooks.length === 0 ? (
+            <div className={styles.stateCenter}>
+              <Search size={32} className={styles.stateIcon} />
+              <p className={styles.stateText}>No playbooks match your filters.</p>
+            </div>
+          ) : (
+            <div className={styles.grid}>
+              {filteredPlaybooks.map(playbook => (
+                <button
+                  key={playbook.id}
+                  type="button"
+                  className={styles.card}
+                  onClick={() => setSelectedPlaybook(playbook)}
+                >
+                  <div className={styles.cardTitleRow}>
+                    <span className={styles.cardEmoji} aria-hidden="true">
+                      {playbook.emoji || DEFAULT_EMOJI}
+                    </span>
+                    <span className={styles.cardName}>{playbook.name}</span>
+                  </div>
+                  {playbook.description && (
+                    <p className={styles.cardDesc}>{playbook.description}</p>
+                  )}
+                  {playbook.tags && playbook.tags.length > 0 && (
+                    <div className={styles.cardTags}>
+                      {playbook.tags.slice(0, 4).map(tag => (
+                        <span key={tag} className={styles.cardTag}>
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </Modal>
+  )
+}

--- a/app/ui_layer/browser/frontend/src/components/ui/index.ts
+++ b/app/ui_layer/browser/frontend/src/components/ui/index.ts
@@ -36,3 +36,6 @@ export type { SkillCreatorModalProps, SkillCreatorMode, SkillCreatorSubmit } fro
 
 export { SlashCommandAutocomplete } from './SlashCommandAutocomplete'
 export type { SlashCommandAutocompleteHandle } from './SlashCommandAutocomplete'
+
+export { PlaybookModal } from './PlaybookModal'
+export type { PlaybookModalProps } from './PlaybookModal'

--- a/app/ui_layer/browser/frontend/src/components/ui/index.ts
+++ b/app/ui_layer/browser/frontend/src/components/ui/index.ts
@@ -23,6 +23,14 @@ export type { ModalProps, ModalSize, ModalSectionProps } from './Modal'
 export { ConfirmModal } from './ConfirmModal'
 export type { ConfirmModalProps } from './ConfirmModal'
 
+export { ImportProfileModal } from './ImportProfileModal'
+export type {
+  ImportProfileModalProps,
+  ImportMode,
+  ProfileBundleManifest,
+  ProfileBundlePreview,
+} from './ImportProfileModal'
+
 export { SkillCreatorModal } from './SkillCreatorModal'
 export type { SkillCreatorModalProps, SkillCreatorMode, SkillCreatorSubmit } from './SkillCreatorModal'
 

--- a/app/ui_layer/browser/frontend/src/pages/Settings/GeneralSettings.tsx
+++ b/app/ui_layer/browser/frontend/src/pages/Settings/GeneralSettings.tsx
@@ -670,7 +670,7 @@ export function GeneralSettings() {
 
       setProfileStatus({
         type: 'success',
-        message: `${verb} ${what}. Restart the agent to apply changes.`,
+        message: `${verb} ${what}.`,
       })
       setShowImportModal(false)
       setImportManifest(null)

--- a/app/ui_layer/browser/frontend/src/pages/Settings/GeneralSettings.tsx
+++ b/app/ui_layer/browser/frontend/src/pages/Settings/GeneralSettings.tsx
@@ -108,7 +108,7 @@ export function GeneralSettings() {
     { type: 'success' | 'error' | 'info'; message: string } | null
   >(null)
   const [showImportModal, setShowImportModal] = useState(false)
-  const [importBundlePath, setImportBundlePath] = useState<string | null>(null)
+  const [importBundleToken, setImportBundleToken] = useState<string | null>(null)
   const [importManifest, setImportManifest] = useState<ProfileBundleManifest | null>(null)
   const [importPreview, setImportPreview] = useState<ProfileBundlePreview | null>(null)
   const [importError, setImportError] = useState<string | null>(null)
@@ -610,7 +610,7 @@ export function GeneralSettings() {
     setImportManifest(null)
     setImportPreview(null)
     setImportError(null)
-    setImportBundlePath(null)
+    setImportBundleToken(null)
     setShowImportModal(true)
 
     try {
@@ -626,7 +626,7 @@ export function GeneralSettings() {
       }
       setImportManifest(data.manifest)
       setImportPreview(data.preview)
-      setImportBundlePath(data.bundle_path)
+      setImportBundleToken(data.bundle_token)
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Could not read bundle'
       setImportError(msg)
@@ -638,18 +638,18 @@ export function GeneralSettings() {
     setImportManifest(null)
     setImportPreview(null)
     setImportError(null)
-    setImportBundlePath(null)
+    setImportBundleToken(null)
   }
 
   const handleImportApply = async (mode: ImportMode) => {
-    if (!importBundlePath) return
+    if (!importBundleToken) return
     setIsApplyingImport(true)
     setImportError(null)
     try {
       const response = await fetch('/api/profile/import', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ bundle_path: importBundlePath, mode }),
+        body: JSON.stringify({ bundle_token: importBundleToken, mode }),
       })
       const data = await response.json()
       if (!response.ok || !data.success) {
@@ -675,7 +675,7 @@ export function GeneralSettings() {
       setShowImportModal(false)
       setImportManifest(null)
       setImportPreview(null)
-      setImportBundlePath(null)
+      setImportBundleToken(null)
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Import failed'
       setImportError(msg)

--- a/app/ui_layer/browser/frontend/src/pages/Settings/GeneralSettings.tsx
+++ b/app/ui_layer/browser/frontend/src/pages/Settings/GeneralSettings.tsx
@@ -13,8 +13,18 @@ import {
   Trash2,
   Eraser,
   ListChecks,
+  Package,
+  PackageOpen,
 } from 'lucide-react'
-import { Button, Badge, ConfirmModal } from '../../components/ui'
+import {
+  Button,
+  Badge,
+  ConfirmModal,
+  ImportProfileModal,
+  type ImportMode,
+  type ProfileBundleManifest,
+  type ProfileBundlePreview,
+} from '../../components/ui'
 import { useTheme } from '../../contexts/ThemeContext'
 import { useWebSocket } from '../../contexts/WebSocketContext'
 import { useConfirmModal } from '../../hooks'
@@ -91,6 +101,19 @@ export function GeneralSettings() {
   const [pictureError, setPictureError] = useState<string | null>(null)
   const [isUploadingPicture, setIsUploadingPicture] = useState(false)
   const pictureInputRef = useRef<HTMLInputElement | null>(null)
+
+  // Agent profile bundle (import/export)
+  const [isExportingProfile, setIsExportingProfile] = useState(false)
+  const [profileStatus, setProfileStatus] = useState<
+    { type: 'success' | 'error' | 'info'; message: string } | null
+  >(null)
+  const [showImportModal, setShowImportModal] = useState(false)
+  const [importBundlePath, setImportBundlePath] = useState<string | null>(null)
+  const [importManifest, setImportManifest] = useState<ProfileBundleManifest | null>(null)
+  const [importPreview, setImportPreview] = useState<ProfileBundlePreview | null>(null)
+  const [importError, setImportError] = useState<string | null>(null)
+  const [isApplyingImport, setIsApplyingImport] = useState(false)
+  const profileImportInputRef = useRef<HTMLInputElement | null>(null)
 
   // Keep local preview in sync with the central context value (e.g. after reconnect)
   useEffect(() => {
@@ -537,6 +560,130 @@ export function GeneralSettings() {
     })
   }
 
+  // ─── Agent profile bundle ───────────────────────────────────────────
+
+  const handleExportProfile = async () => {
+    setIsExportingProfile(true)
+    setProfileStatus(null)
+    try {
+      const response = await fetch('/api/profile/export')
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({}))
+        throw new Error(body.error || `Export failed (${response.status})`)
+      }
+      const blob = await response.blob()
+      const disposition = response.headers.get('Content-Disposition') || ''
+      const match = /filename="([^"]+)"/.exec(disposition)
+      const filename = match ? match[1] : 'agent-profile.craftbot'
+
+      const url = URL.createObjectURL(blob)
+      const link = document.createElement('a')
+      link.href = url
+      link.download = filename
+      document.body.appendChild(link)
+      link.click()
+      link.remove()
+      URL.revokeObjectURL(url)
+
+      setProfileStatus({ type: 'success', message: 'Profile exported' })
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Export failed'
+      setProfileStatus({ type: 'error', message: msg })
+    } finally {
+      setIsExportingProfile(false)
+      setTimeout(() => setProfileStatus(null), 4000)
+    }
+  }
+
+  const handleImportProfileClick = () => {
+    profileImportInputRef.current?.click()
+  }
+
+  const handleProfileFileSelected = async (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const file = e.target.files?.[0]
+    e.target.value = ''
+    if (!file) return
+
+    setProfileStatus(null)
+    setImportManifest(null)
+    setImportPreview(null)
+    setImportError(null)
+    setImportBundlePath(null)
+    setShowImportModal(true)
+
+    try {
+      const form = new FormData()
+      form.append('file', file)
+      const response = await fetch('/api/profile/inspect', {
+        method: 'POST',
+        body: form,
+      })
+      const data = await response.json()
+      if (!response.ok || !data.success) {
+        throw new Error(data.error || 'Could not read bundle')
+      }
+      setImportManifest(data.manifest)
+      setImportPreview(data.preview)
+      setImportBundlePath(data.bundle_path)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Could not read bundle'
+      setImportError(msg)
+    }
+  }
+
+  const handleImportCancel = () => {
+    setShowImportModal(false)
+    setImportManifest(null)
+    setImportPreview(null)
+    setImportError(null)
+    setImportBundlePath(null)
+  }
+
+  const handleImportApply = async (mode: ImportMode) => {
+    if (!importBundlePath) return
+    setIsApplyingImport(true)
+    setImportError(null)
+    try {
+      const response = await fetch('/api/profile/import', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ bundle_path: importBundlePath, mode }),
+      })
+      const data = await response.json()
+      if (!response.ok || !data.success) {
+        throw new Error(data.error || 'Import failed')
+      }
+
+      const summary = data.summary || {}
+      const added = (summary.skills_added?.length || 0) + (summary.mcp_added?.length || 0)
+      const parts: string[] = []
+      if (summary.skills_added?.length) parts.push(`${summary.skills_added.length} skill(s)`)
+      if (summary.mcp_added?.length) parts.push(`${summary.mcp_added.length} MCP server(s)`)
+      if (summary.living_ui_added?.length || summary.living_ui_renamed?.length) {
+        parts.push(
+          `${(summary.living_ui_added?.length || 0) + (summary.living_ui_renamed?.length || 0)} Living UI app(s)`
+        )
+      }
+      const what = parts.length > 0 ? parts.join(', ') : (added > 0 ? 'profile data' : 'profile (nothing new)')
+
+      setProfileStatus({
+        type: 'success',
+        message: `Imported ${what}. Restart the agent to apply changes.`,
+      })
+      setShowImportModal(false)
+      setImportManifest(null)
+      setImportPreview(null)
+      setImportBundlePath(null)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Import failed'
+      setImportError(msg)
+    } finally {
+      setIsApplyingImport(false)
+    }
+  }
+
   return (
     <div className={styles.settingsSection}>
       <div className={styles.sectionHeader}>
@@ -814,6 +961,60 @@ export function GeneralSettings() {
         )}
       </div>
 
+      {/* Agent Profile (import/export) */}
+      <div className={styles.profileSection}>
+        <div className={styles.profileHeader}>
+          <Package size={18} className={styles.profileIcon} />
+          <h4>Agent Profile</h4>
+        </div>
+        <p className={styles.profileDescription}>
+          Share your agent's personality, skills, MCP servers, and Living UI apps
+          as a single <code>.craftbot</code> file. API keys, personal memory, and
+          conversation history are never included.
+        </p>
+        <div className={styles.profileActions}>
+          <input
+            ref={profileImportInputRef}
+            type="file"
+            accept=".craftbot,application/octet-stream,application/zip"
+            onChange={handleProfileFileSelected}
+            style={{ display: 'none' }}
+          />
+          <Button
+            variant="primary"
+            onClick={handleExportProfile}
+            disabled={isExportingProfile}
+            icon={
+              isExportingProfile ? (
+                <Loader2 size={14} className={styles.spinning} />
+              ) : (
+                <Download size={14} />
+              )
+            }
+          >
+            {isExportingProfile ? 'Exporting…' : 'Export Profile'}
+          </Button>
+          <Button
+            variant="secondary"
+            onClick={handleImportProfileClick}
+            disabled={isApplyingImport}
+            icon={<PackageOpen size={14} />}
+          >
+            Import Profile
+          </Button>
+          {profileStatus?.type === 'success' && (
+            <span className={styles.statusSuccess}>
+              <Check size={14} /> {profileStatus.message}
+            </span>
+          )}
+          {profileStatus?.type === 'error' && (
+            <span className={styles.statusError}>
+              <X size={14} /> {profileStatus.message}
+            </span>
+          )}
+        </div>
+      </div>
+
       {/* Advanced Section */}
       <div className={styles.advancedSection}>
         <button
@@ -1030,6 +1231,17 @@ export function GeneralSettings() {
 
       {/* Confirm Modal */}
       <ConfirmModal {...confirmModalProps} />
+
+      {/* Import Profile Modal */}
+      <ImportProfileModal
+        isOpen={showImportModal}
+        manifest={importManifest}
+        preview={importPreview}
+        isApplying={isApplyingImport}
+        error={importError}
+        onCancel={handleImportCancel}
+        onApply={handleImportApply}
+      />
     </div>
   )
 }

--- a/app/ui_layer/browser/frontend/src/pages/Settings/GeneralSettings.tsx
+++ b/app/ui_layer/browser/frontend/src/pages/Settings/GeneralSettings.tsx
@@ -657,7 +657,6 @@ export function GeneralSettings() {
       }
 
       const summary = data.summary || {}
-      const added = (summary.skills_added?.length || 0) + (summary.mcp_added?.length || 0)
       const parts: string[] = []
       if (summary.skills_added?.length) parts.push(`${summary.skills_added.length} skill(s)`)
       if (summary.mcp_added?.length) parts.push(`${summary.mcp_added.length} MCP server(s)`)
@@ -666,11 +665,12 @@ export function GeneralSettings() {
           `${(summary.living_ui_added?.length || 0) + (summary.living_ui_renamed?.length || 0)} Living UI app(s)`
         )
       }
-      const what = parts.length > 0 ? parts.join(', ') : (added > 0 ? 'profile data' : 'profile (nothing new)')
+      const verb = mode === 'overwrite' ? 'Overwrote agent with' : 'Imported'
+      const what = parts.length > 0 ? parts.join(', ') : 'profile'
 
       setProfileStatus({
         type: 'success',
-        message: `Imported ${what}. Restart the agent to apply changes.`,
+        message: `${verb} ${what}. Restart the agent to apply changes.`,
       })
       setShowImportModal(false)
       setImportManifest(null)

--- a/app/ui_layer/browser/frontend/src/pages/Settings/SettingsPage.module.css
+++ b/app/ui_layer/browser/frontend/src/pages/Settings/SettingsPage.module.css
@@ -727,6 +727,55 @@
   line-height: 1.4;
 }
 
+/* Agent Profile (import/export) */
+.profileSection {
+  margin-top: var(--space-6);
+  padding: var(--space-4);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md);
+}
+
+.profileHeader {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
+}
+
+.profileHeader h4 {
+  font-size: var(--text-sm);
+  font-weight: var(--font-semibold);
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.profileIcon {
+  color: var(--text-secondary);
+}
+
+.profileDescription {
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  margin-bottom: var(--space-3);
+  line-height: 1.5;
+}
+
+.profileDescription code {
+  padding: 1px 6px;
+  background: var(--bg-secondary);
+  border-radius: var(--radius-sm);
+  font-size: 0.9em;
+  color: var(--text-primary);
+}
+
+.profileActions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+}
+
 .dangerRowAction {
   display: flex;
   align-items: center;

--- a/app/ui_layer/browser/frontend/src/store/index.ts
+++ b/app/ui_layer/browser/frontend/src/store/index.ts
@@ -17,6 +17,7 @@ import livingUiSettingsReducer from './slices/livingUiSettingsSlice'
 import generalSettingsReducer from './slices/generalSettingsSlice'
 import modelSettingsReducer from './slices/modelSettingsSlice'
 import integrationsSettingsReducer from './slices/integrationsSettingsSlice'
+import chatInputReducer from './slices/chatInputSlice'
 import { socketMiddleware } from './socket/socketMiddleware'
 
 export const store = configureStore({
@@ -39,6 +40,7 @@ export const store = configureStore({
     generalSettings: generalSettingsReducer,
     modelSettings: modelSettingsReducer,
     integrationsSettings: integrationsSettingsReducer,
+    chatInput: chatInputReducer,
   },
   middleware: (getDefault) => getDefault().concat(socketMiddleware),
 })

--- a/app/ui_layer/browser/frontend/src/store/selectors/chatInput.ts
+++ b/app/ui_layer/browser/frontend/src/store/selectors/chatInput.ts
@@ -1,0 +1,3 @@
+import type { RootState } from '../index'
+
+export const selectPendingPrefill = (state: RootState) => state.chatInput.pendingPrefill

--- a/app/ui_layer/browser/frontend/src/store/slices/chatInputSlice.ts
+++ b/app/ui_layer/browser/frontend/src/store/slices/chatInputSlice.ts
@@ -1,0 +1,32 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+
+// Cross-component prefill channel for the chat input.
+//
+// The chat input state itself stays local to Chat.tsx — this slice only
+// carries a one-shot "pendingPrefill" payload that Chat consumes via
+// useEffect and clears immediately. Used by the Playbook modal (and any
+// future feature that needs to drop text into the composer from elsewhere
+// in the app).
+interface ChatInputState {
+  pendingPrefill: string | null
+}
+
+const initialState: ChatInputState = {
+  pendingPrefill: null,
+}
+
+const chatInputSlice = createSlice({
+  name: 'chatInput',
+  initialState,
+  reducers: {
+    setPendingPrefill(state, action: PayloadAction<string>) {
+      state.pendingPrefill = action.payload
+    },
+    clearPendingPrefill(state) {
+      state.pendingPrefill = null
+    },
+  },
+})
+
+export const { setPendingPrefill, clearPendingPrefill } = chatInputSlice.actions
+export default chatInputSlice.reducer

--- a/app/ui_layer/settings/__init__.py
+++ b/app/ui_layer/settings/__init__.py
@@ -56,6 +56,13 @@ from app.ui_layer.settings.general_settings import (
     update_general_settings,
 )
 
+# Agent profile bundle (import/export)
+from app.ui_layer.settings.profile_bundle import (
+    export_profile,
+    inspect_bundle,
+    import_profile,
+)
+
 # Proactive/scheduler settings
 from app.ui_layer.settings.proactive_settings import (
     # Proactive mode control
@@ -146,6 +153,10 @@ __all__ = [
     "reset_agent_state",
     "get_general_settings",
     "update_general_settings",
+    # Agent profile bundle
+    "export_profile",
+    "inspect_bundle",
+    "import_profile",
     # Proactive mode control
     "is_proactive_enabled",
     "get_proactive_mode",

--- a/app/ui_layer/settings/profile_bundle.py
+++ b/app/ui_layer/settings/profile_bundle.py
@@ -21,7 +21,10 @@ import zipfile
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+
+if TYPE_CHECKING:
+    from app.living_ui.manager import LivingUIManager
 
 from app.config import (
     AGENT_FILE_SYSTEM_PATH,
@@ -182,7 +185,12 @@ def _gather_export_contents() -> Dict[str, Any]:
     ]
 
     mcp_config = _load_json(MCP_CONFIG_PATH, {"mcp_servers": []})
-    mcp_servers = mcp_config.get("mcp_servers", [])
+    # Only export enabled MCP servers — the recipient already has the ~157
+    # disabled defaults bundled with CraftBot, and shipping all of them would
+    # leak machine-specific command paths.
+    mcp_servers = [
+        s for s in mcp_config.get("mcp_servers", []) if s.get("enabled", False)
+    ]
 
     md_present = [
         f for f in PROFILE_MD_FILES if (AGENT_FILE_SYSTEM_PATH / f).is_file()
@@ -276,13 +284,14 @@ def export_profile(description: str = "") -> Dict[str, Any]:
             if src.is_dir():
                 _copy_dir_filtered(src, skills_dir / skill_name)
 
-        # mcp/
+        # mcp/ — only enabled servers (the inventory was already filtered)
         mcp_dir = staging / "mcp"
         mcp_dir.mkdir()
         mcp_config = _load_json(MCP_CONFIG_PATH, {"mcp_servers": []})
-        cleaned_servers, _stripped = _strip_mcp_secrets(
-            mcp_config.get("mcp_servers", [])
-        )
+        enabled_mcp = [
+            s for s in mcp_config.get("mcp_servers", []) if s.get("enabled", False)
+        ]
+        cleaned_servers, _stripped = _strip_mcp_secrets(enabled_mcp)
         (mcp_dir / "servers.json").write_text(
             json.dumps({"mcp_servers": cleaned_servers}, indent=2, ensure_ascii=False),
             encoding="utf-8",
@@ -291,11 +300,16 @@ def export_profile(description: str = "") -> Dict[str, Any]:
         # living_ui/
         living_dir = staging / "living_ui"
         living_dir.mkdir()
-        projects = _load_json(LIVING_UI_PROJECTS_FILE, [])
+        projects = _load_json(LIVING_UI_PROJECTS_FILE, {"projects": []})
         if isinstance(projects, dict):
             projects = projects.get("projects", [])
+        # Match the envelope the LivingUIManager uses on disk
+        # ({"projects": [...]}). Writing a flat list would make the manager's
+        # _load_projects() fail silently — and its next startup cleanup pass
+        # would then delete every Living UI folder as "orphaned".
         (living_dir / "projects.json").write_text(
-            json.dumps(projects, indent=2, ensure_ascii=False), encoding="utf-8"
+            json.dumps({"projects": projects}, indent=2, ensure_ascii=False),
+            encoding="utf-8",
         )
         for project in projects:
             project_path_str = project.get("path", "")
@@ -590,8 +604,27 @@ def _apply_mcp(
     return added, skipped, needs_env
 
 
-def _apply_living_ui(src_living_dir: Path) -> Tuple[List[str], List[str]]:
-    """Copy Living UI projects. Always rename on conflict (preserve user data)."""
+def _apply_living_ui(
+    src_living_dir: Path,
+    manager: Optional["LivingUIManager"] = None,
+) -> Tuple[List[str], List[str]]:
+    """Copy Living UI projects and register them with the live manager.
+
+    Always renames on folder/id conflict so we never destroy a user's existing
+    project data.
+
+    When ``manager`` is provided (production path), the imported projects are
+    inserted directly into ``manager.projects`` and persisted via the manager's
+    own ``_save_projects()``. This is CRITICAL: without it, our changes are
+    written to disk but the still-running ``LivingUIManager`` holds a stale
+    in-memory state — any subsequent ``_save_projects()`` call (status update,
+    watchdog tick, port change, etc.) will flush that stale state back to disk
+    and silently erase every imported entry.
+
+    ``manager=None`` is supported for inspection / non-running callers; that
+    path writes the registry file directly and is vulnerable to the race
+    described above, so don't use it from a live agent.
+    """
     added: List[str] = []
     renamed: List[str] = []
 
@@ -602,14 +635,30 @@ def _apply_living_ui(src_living_dir: Path) -> Tuple[List[str], List[str]]:
     if not bundle_projects:
         return added, renamed
 
-    LIVING_UI_DIR.mkdir(parents=True, exist_ok=True)
-    current_projects = _load_json(LIVING_UI_PROJECTS_FILE, [])
-    if isinstance(current_projects, dict):
-        current_projects = current_projects.get("projects", [])
-    current_ids = {p.get("id") for p in current_projects}
-    current_folders = {Path(p.get("path", "")).name for p in current_projects if p.get("path")}
+    # Resolve target dir + existing-state snapshot from the live manager when
+    # available, otherwise fall back to the on-disk file.
+    if manager is not None:
+        target_living_dir = manager.living_ui_dir
+        current_ids = set(manager.projects.keys())
+        current_folders = {
+            Path(p.path).name for p in manager.projects.values() if p.path
+        }
+    else:
+        target_living_dir = LIVING_UI_DIR
+        current_records = _load_json(LIVING_UI_PROJECTS_FILE, {"projects": []})
+        if isinstance(current_records, dict):
+            current_records = current_records.get("projects", [])
+        current_ids = {p.get("id") for p in current_records}
+        current_folders = {
+            Path(p.get("path", "")).name for p in current_records if p.get("path")
+        }
+
+    target_living_dir.mkdir(parents=True, exist_ok=True)
 
     import uuid
+
+    # Collected new entries (manifest dicts) to apply after the loop.
+    new_records: List[Dict[str, Any]] = []
 
     for project in bundle_projects:
         project_path_str = project.get("path", "")
@@ -620,7 +669,6 @@ def _apply_living_ui(src_living_dir: Path) -> Tuple[List[str], List[str]]:
         if not src_folder.is_dir():
             continue
 
-        # Conflict → rename folder + project id
         new_project = dict(project)
         folder_name = original_folder
         if project.get("id") in current_ids or folder_name in current_folders:
@@ -630,10 +678,10 @@ def _apply_living_ui(src_living_dir: Path) -> Tuple[List[str], List[str]]:
             new_project["name"] = f"{base_name} (imported)"
             sanitized = _slugify(base_name).lower()
             folder_name = f"{sanitized}_{new_id}"
-            new_project["path"] = str(LIVING_UI_DIR / folder_name)
+            new_project["path"] = str(target_living_dir / folder_name)
             renamed.append(new_project["name"])
         else:
-            new_project["path"] = str(LIVING_UI_DIR / folder_name)
+            new_project["path"] = str(target_living_dir / folder_name)
             added.append(project.get("name", original_folder))
 
         # Reset transient runtime fields so the imported project starts clean.
@@ -641,24 +689,82 @@ def _apply_living_ui(src_living_dir: Path) -> Tuple[List[str], List[str]]:
         new_project.pop("pid", None)
         new_project.pop("backendPid", None)
 
-        _copy_dir_filtered(src_folder, LIVING_UI_DIR / folder_name)
-        current_projects.append(new_project)
+        _copy_dir_filtered(src_folder, target_living_dir / folder_name)
+        new_records.append(new_project)
         current_ids.add(new_project["id"])
         current_folders.add(folder_name)
 
-    LIVING_UI_PROJECTS_FILE.parent.mkdir(parents=True, exist_ok=True)
-    LIVING_UI_PROJECTS_FILE.write_text(
-        json.dumps(current_projects, indent=2, ensure_ascii=False), encoding="utf-8"
-    )
+    if not new_records:
+        return added, renamed
+
+    if manager is not None:
+        # Register into the live manager so its next _save_projects() flushes
+        # our entries instead of overwriting them. Importing here to keep the
+        # module's top-level import surface light (and avoid a circular).
+        from app.living_ui.manager import LivingUIProject
+
+        for record in new_records:
+            try:
+                created_at_ms = record.get("createdAt")
+                if not isinstance(created_at_ms, (int, float)):
+                    created_at_ms = datetime.now().timestamp() * 1000
+                project_obj = LivingUIProject(
+                    id=record["id"],
+                    name=record["name"],
+                    description=record.get("description", ""),
+                    path=record["path"],
+                    status="stopped",
+                    port=record.get("port"),
+                    backend_port=record.get("backendPort"),
+                    created_at=created_at_ms / 1000,
+                    features=record.get("features", []) or [],
+                    theme=record.get("theme", "system") or "system",
+                    auto_launch=bool(record.get("autoLaunch", False)),
+                    log_cleanup=bool(record.get("logCleanup", True)),
+                    project_type=record.get("projectType", "native") or "native",
+                    app_runtime=record.get("appRuntime"),
+                )
+            except Exception as exc:
+                logger.warning(
+                    f"[PROFILE_BUNDLE] Skipping malformed imported project "
+                    f"{record.get('id', '?')}: {exc}"
+                )
+                continue
+            manager.projects[project_obj.id] = project_obj
+            if project_obj.port:
+                manager._used_ports.add(project_obj.port)
+            if project_obj.backend_port:
+                manager._used_ports.add(project_obj.backend_port)
+        # Manager writes the file in the envelope format the loader expects.
+        manager._save_projects()
+    else:
+        # Fallback path — direct file write. Same envelope format as the
+        # manager uses, see _save_projects().
+        current_records = _load_json(LIVING_UI_PROJECTS_FILE, {"projects": []})
+        if isinstance(current_records, dict):
+            current_records = current_records.get("projects", [])
+        current_records.extend(new_records)
+        LIVING_UI_PROJECTS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        LIVING_UI_PROJECTS_FILE.write_text(
+            json.dumps({"projects": current_records}, indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
+
     return added, renamed
 
 
-def import_profile(bundle_path: str, mode: str = "merge") -> Dict[str, Any]:
+def import_profile(
+    bundle_path: str,
+    mode: str = "merge",
+    living_ui_manager: Optional["LivingUIManager"] = None,
+) -> Dict[str, Any]:
     """Apply a bundle to the current agent.
 
     Args:
         bundle_path: filesystem path to the .craftbot file (already uploaded)
         mode: "merge" (default — additive) or "replace" (overwrite on conflict)
+        living_ui_manager: live LivingUIManager from the adapter. Required for
+            Living UI projects to survive — see _apply_living_ui() for why.
 
     Returns:
         Dict with success flag and ImportSummary contents. The agent will need
@@ -696,7 +802,9 @@ def import_profile(bundle_path: str, mode: str = "merge") -> Dict[str, Any]:
         settings_applied = _apply_settings(work_dir / "profile", mode)
         skills_added, skills_skipped = _apply_skills(work_dir / "skills", mode)
         mcp_added, mcp_skipped, mcp_needs_env = _apply_mcp(work_dir / "mcp", mode)
-        living_added, living_renamed = _apply_living_ui(work_dir / "living_ui")
+        living_added, living_renamed = _apply_living_ui(
+            work_dir / "living_ui", manager=living_ui_manager
+        )
 
         # NOTE: agent_name is intentionally NOT applied — per product decision,
         # users keep their own agent name and just inherit the personality/skills.

--- a/app/ui_layer/settings/profile_bundle.py
+++ b/app/ui_layer/settings/profile_bundle.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 
 from app.config import (
     AGENT_FILE_SYSTEM_PATH,
+    AGENT_FILE_SYSTEM_TEMPLATE_PATH,
     AGENT_WORKSPACE_ROOT,
     APP_CONFIG_PATH,
     PROJECT_ROOT,
@@ -458,27 +459,29 @@ class ImportSummary:
         return asdict(self)
 
 
-def _apply_md_files(
-    src_profile: Path, mode: str, bundle_name: str
-) -> List[str]:
+def _apply_md_files(src_profile: Path, mode: str) -> List[str]:
+    """Write personality MD files from the bundle into the agent file system.
+
+    Both ``replace`` and ``overwrite`` modes write the bundle's content verbatim
+    over the local file. The only difference is what happens to MD files the
+    bundle DIDN'T ship: in ``overwrite`` mode we reset them to their template
+    (so the recipient's agent ends up strictly defined by the bundle); in
+    ``replace`` mode we leave the user's existing file alone.
+    """
     applied: List[str] = []
     AGENT_FILE_SYSTEM_PATH.mkdir(parents=True, exist_ok=True)
     for fname in PROFILE_MD_FILES:
         src = src_profile / fname
-        if not src.is_file():
-            continue
         target = AGENT_FILE_SYSTEM_PATH / fname
         try:
-            incoming = src.read_text(encoding="utf-8")
-            if mode == "replace" or not target.exists():
-                target.write_text(incoming, encoding="utf-8")
-            else:  # merge → append under a divider
-                existing = target.read_text(encoding="utf-8")
-                divider = (
-                    f"\n\n---\n_imported from {bundle_name}_\n\n"
-                )
-                target.write_text(existing.rstrip() + divider + incoming, encoding="utf-8")
-            applied.append(fname)
+            if src.is_file():
+                target.write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+                applied.append(fname)
+            elif mode == "overwrite":
+                tmpl = AGENT_FILE_SYSTEM_TEMPLATE_PATH / fname
+                if tmpl.is_file():
+                    shutil.copy2(tmpl, target)
+                    applied.append(fname)
         except OSError as exc:
             logger.error(f"[PROFILE_BUNDLE] Failed to apply {fname}: {exc}")
     return applied
@@ -487,13 +490,27 @@ def _apply_md_files(
 def _apply_skills(
     src_skills_dir: Path, mode: str
 ) -> Tuple[List[str], List[str]]:
-    """Copy skill folders and update enabled_skills in skills_config.json."""
+    """Install skill folders and update skills_config.json.
+
+    ``replace`` — bundle overwrites local on name collision; new skills added.
+    ``overwrite`` — every existing skill folder under SKILLS_DIR is deleted,
+    then the bundle's skills are installed and become the entire skill set
+    (no disabled defaults left over).
+    """
     added: List[str] = []
     skipped: List[str] = []
     enabled_list_path = src_skills_dir / "enabled.json"
     bundle_enabled = _load_json(enabled_list_path, {}).get("enabled_skills", [])
 
     SKILLS_DIR.mkdir(parents=True, exist_ok=True)
+
+    if mode == "overwrite":
+        # Strict factory reset: wipe every skill folder, then install the
+        # bundle's. The recipient's skill set ends up exactly = bundle's.
+        for child in list(SKILLS_DIR.iterdir()):
+            if child.is_dir():
+                shutil.rmtree(child, ignore_errors=True)
+
     for skill_name in bundle_enabled:
         src = src_skills_dir / skill_name
         if not src.is_dir():
@@ -510,20 +527,31 @@ def _apply_skills(
             _copy_dir_filtered(src, dst)
             added.append(skill_name)
 
-    # Update skills_config.json's enabled list (additive — never disables).
-    config = _load_json(
-        SKILLS_CONFIG_PATH, {"auto_load": True, "enabled_skills": [], "disabled_skills": []}
-    )
-    enabled_set = list(config.get("enabled_skills", []))
-    disabled_set = list(config.get("disabled_skills", []))
-    for skill_name in bundle_enabled:
-        if skill_name in added:
-            if skill_name not in enabled_set:
-                enabled_set.append(skill_name)
-            if skill_name in disabled_set:
-                disabled_set.remove(skill_name)
-    config["enabled_skills"] = enabled_set
-    config["disabled_skills"] = disabled_set
+    if mode == "overwrite":
+        # Authoritative config: bundle's enabled list IS the skill state.
+        config = {
+            "auto_load": True,
+            "enabled_skills": list(bundle_enabled),
+            "disabled_skills": [],
+        }
+    else:
+        # Additive: only flip skills the bundle landed into the enabled list,
+        # never disable anything the user already had.
+        config = _load_json(
+            SKILLS_CONFIG_PATH,
+            {"auto_load": True, "enabled_skills": [], "disabled_skills": []},
+        )
+        enabled_set = list(config.get("enabled_skills", []))
+        disabled_set = list(config.get("disabled_skills", []))
+        for skill_name in bundle_enabled:
+            if skill_name in added:
+                if skill_name not in enabled_set:
+                    enabled_set.append(skill_name)
+                if skill_name in disabled_set:
+                    disabled_set.remove(skill_name)
+        config["enabled_skills"] = enabled_set
+        config["disabled_skills"] = disabled_set
+
     SKILLS_CONFIG_PATH.write_text(
         json.dumps(config, indent=2, ensure_ascii=False), encoding="utf-8"
     )
@@ -533,7 +561,14 @@ def _apply_skills(
 def _apply_mcp(
     src_mcp_dir: Path, mode: str
 ) -> Tuple[List[str], List[str], List[Dict[str, Any]]]:
-    """Merge or replace MCP server configs."""
+    """Install MCP server configs from the bundle.
+
+    ``replace`` — bundle overwrites local on name collision (preserving any
+    env tokens the user already filled in); new servers added.
+    ``overwrite`` — local mcp_config.json is wiped and replaced entirely with
+    the bundle's servers; no env values are preserved (the recipient's MCP
+    state ends up exactly = bundle's).
+    """
     added: List[str] = []
     skipped: List[str] = []
     needs_env: List[Dict[str, Any]] = []
@@ -541,6 +576,24 @@ def _apply_mcp(
     servers_path = src_mcp_dir / "servers.json"
     bundle_servers = _load_json(servers_path, {}).get("mcp_servers", [])
 
+    if mode == "overwrite":
+        cleaned: List[Dict[str, Any]] = []
+        for server in bundle_servers:
+            name = server.get("name", "")
+            if not name:
+                continue
+            missing_env = [k for k, v in (server.get("env") or {}).items() if not v]
+            if missing_env:
+                needs_env.append({"name": name, "env_keys": missing_env})
+            cleaned.append(server)
+            added.append(name)
+        MCP_CONFIG_PATH.write_text(
+            json.dumps({"mcp_servers": cleaned}, indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
+        return added, skipped, needs_env
+
+    # replace mode — additive with overwrite-on-conflict + env preservation
     current = _load_json(MCP_CONFIG_PATH, {"mcp_servers": []})
     existing = current.get("mcp_servers", [])
     by_name = {s.get("name", ""): s for s in existing}
@@ -554,20 +607,17 @@ def _apply_mcp(
             needs_env.append({"name": name, "env_keys": missing_env})
 
         if name in by_name:
-            if mode == "replace":
-                # Keep ANY env values the user had set locally — don't blow
-                # them away on replace, since the user's filled-in tokens are
-                # more valuable than the (empty) tokens from the bundle.
-                preserved_env = by_name[name].get("env", {})
-                merged_env = dict(server.get("env", {}))
-                for k, v in preserved_env.items():
-                    if v and k in merged_env and not merged_env[k]:
-                        merged_env[k] = v
-                server["env"] = merged_env
-                by_name[name] = server
-                added.append(name)
-            else:
-                skipped.append(name)
+            # Keep ANY env values the user had set locally — don't blow
+            # them away, since the user's filled-in tokens are more
+            # valuable than the (empty) tokens from the bundle.
+            preserved_env = by_name[name].get("env", {})
+            merged_env = dict(server.get("env", {}))
+            for k, v in preserved_env.items():
+                if v and k in merged_env and not merged_env[k]:
+                    merged_env[k] = v
+            server["env"] = merged_env
+            by_name[name] = server
+            added.append(name)
         else:
             by_name[name] = server
             added.append(name)
@@ -701,36 +751,84 @@ def _register_living_ui_via_file(records: List[Dict[str, Any]]) -> None:
     )
 
 
+def _wipe_living_ui_state(
+    manager: Optional["LivingUIManager"],
+    target_living_dir: Path,
+) -> None:
+    """Delete every existing Living UI folder + clear the registry.
+
+    Used by overwrite mode so the bundle's projects are the only ones present.
+    When a manager is provided, both its in-memory state and the registry file
+    are cleared (via _save_projects). With no manager, the registry file is
+    truncated to ``{"projects": []}`` directly.
+
+    Best-effort on the folders: one held open by a running process may fail to
+    delete on Windows; the on-startup orphan cleanup will sweep it later.
+    """
+    if manager is not None:
+        manager.projects.clear()
+        manager._used_ports.clear()
+        manager._save_projects()
+    else:
+        LIVING_UI_PROJECTS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        LIVING_UI_PROJECTS_FILE.write_text(
+            json.dumps({"projects": []}, indent=2), encoding="utf-8"
+        )
+    if target_living_dir.exists():
+        for child in list(target_living_dir.iterdir()):
+            if child.is_dir():
+                try:
+                    shutil.rmtree(child)
+                except OSError as exc:
+                    logger.warning(
+                        f"[PROFILE_BUNDLE] Failed to delete {child.name}: {exc}"
+                    )
+
+
 def _apply_living_ui(
     src_living_dir: Path,
+    mode: str,
     manager: Optional["LivingUIManager"] = None,
 ) -> Tuple[List[str], List[str]]:
     """Copy Living UI projects into the workspace and register them.
 
-    Always renames on folder/id conflict so existing user data is never
-    overwritten. When ``manager`` is provided, persistence goes through the
-    live ``LivingUIManager`` (required from a running agent); otherwise it
-    falls back to a direct file write.
+    ``replace`` — renames on folder/id conflict so existing user data is never
+    destroyed; new projects added alongside.
+    ``overwrite`` — every existing Living UI project (folders + registry) is
+    deleted first, then the bundle's projects are installed under their
+    original ids/folder names.
+
+    When ``manager`` is provided, persistence goes through the live
+    ``LivingUIManager`` (required from a running agent); otherwise it falls
+    back to a direct file write.
     """
     bundle_projects = _load_living_ui_projects(src_living_dir / "projects.json")
-    if not bundle_projects:
-        return [], []
+    target_living_dir = (
+        manager.living_ui_dir if manager is not None else LIVING_UI_DIR
+    )
+    target_living_dir.mkdir(parents=True, exist_ok=True)
 
-    if manager is not None:
-        target_living_dir = manager.living_ui_dir
+    if mode == "overwrite":
+        _wipe_living_ui_state(manager, target_living_dir)
+        # Empty starting set, so no conflict-rename happens.
+        current_ids: set = set()
+        current_folders: set = set()
+    elif manager is not None:
         current_ids = set(manager.projects.keys())
         current_folders = {
             Path(p.path).name for p in manager.projects.values() if p.path
         }
     else:
-        target_living_dir = LIVING_UI_DIR
         current = _load_living_ui_projects(LIVING_UI_PROJECTS_FILE)
         current_ids = {p.get("id") for p in current}
         current_folders = {
             Path(p.get("path", "")).name for p in current if p.get("path")
         }
 
-    target_living_dir.mkdir(parents=True, exist_ok=True)
+    if not bundle_projects:
+        # In overwrite mode the empty state was already persisted in
+        # _wipe_living_ui_state(); nothing more to do.
+        return [], []
 
     new_records, added, renamed = _plan_and_copy_living_ui_imports(
         src_living_dir,
@@ -751,16 +849,28 @@ def _apply_living_ui(
     return added, renamed
 
 
+VALID_IMPORT_MODES = ("replace", "overwrite")
+
+
 def import_profile(
     bundle_path: str,
-    mode: str = "merge",
+    mode: str = "replace",
     living_ui_manager: Optional["LivingUIManager"] = None,
 ) -> Dict[str, Any]:
     """Apply a bundle to the current agent.
 
     Args:
         bundle_path: filesystem path to the .craftbot file (already uploaded)
-        mode: "merge" (default — additive) or "replace" (overwrite on conflict)
+        mode:
+            ``"replace"`` (default) — additive; bundle wins on name/id conflict
+            for skills, MCP servers, and personality files; Living UI apps are
+            always copied alongside under a rename. Surfaced in the UI as
+            "Merge and Replace".
+
+            ``"overwrite"`` — strict adoption; wipes the local skills folder,
+            MCP config, and Living UI state, then installs the bundle's
+            content as the entire agent identity. Destructive; the recipient's
+            agent ends up = the bundle's.
         living_ui_manager: live LivingUIManager from the adapter. Required for
             Living UI projects to survive — see _apply_living_ui() for why.
 
@@ -769,7 +879,7 @@ def import_profile(
         a manual restart for the changes to fully take effect; the caller
         surfaces that to the user.
     """
-    if mode not in ("merge", "replace"):
+    if mode not in VALID_IMPORT_MODES:
         return {"success": False, "error": f"Unknown import mode: {mode}"}
 
     path = Path(bundle_path)
@@ -796,11 +906,11 @@ def import_profile(
             }
         bundle_name = manifest.get("name") or "imported profile"
 
-        md_applied = _apply_md_files(work_dir / "profile", mode, bundle_name)
+        md_applied = _apply_md_files(work_dir / "profile", mode)
         skills_added, skills_skipped = _apply_skills(work_dir / "skills", mode)
         mcp_added, mcp_skipped, mcp_needs_env = _apply_mcp(work_dir / "mcp", mode)
         living_added, living_renamed = _apply_living_ui(
-            work_dir / "living_ui", manager=living_ui_manager
+            work_dir / "living_ui", mode, manager=living_ui_manager
         )
 
         # NOTE: agent_name is intentionally NOT applied — per product decision,

--- a/app/ui_layer/settings/profile_bundle.py
+++ b/app/ui_layer/settings/profile_bundle.py
@@ -448,6 +448,7 @@ def inspect_bundle(bundle_path: str) -> Dict[str, Any]:
 class ImportSummary:
     skills_added: List[str]
     skills_skipped: List[str]
+    skills_missing: List[str]
     mcp_added: List[str]
     mcp_skipped: List[str]
     mcp_needs_env: List[Dict[str, Any]]
@@ -489,16 +490,29 @@ def _apply_md_files(src_profile: Path, mode: str) -> List[str]:
 
 def _apply_skills(
     src_skills_dir: Path, mode: str
-) -> Tuple[List[str], List[str]]:
+) -> Tuple[List[str], List[str], List[str]]:
     """Install skill folders and update skills_config.json.
 
     ``replace`` — bundle overwrites local on name collision; new skills added.
     ``overwrite`` — every existing skill folder under SKILLS_DIR is deleted,
     then the bundle's skills are installed and become the entire skill set
     (no disabled defaults left over).
+
+    Bundles produced by agent_bundle/build.py list every skill the agent uses
+    in ``enabled.json`` but only ship folders for the "bundled" ones — the
+    "default" skills are assumed to already exist on the recipient's install.
+    We split bundle_enabled into three buckets accordingly:
+
+    - ``added``: bundle shipped a folder; copied to disk and enabled.
+    - ``already_present``: no folder in bundle, but recipient already has it
+      locally; enabled (replace mode only — overwrite mode wipes local first
+      so this bucket is always empty there).
+    - ``missing``: bundle expected the recipient to already have it but they
+      don't; NOT enabled (would leave a ghost entry pointing at no folder).
     """
     added: List[str] = []
-    skipped: List[str] = []
+    already_present: List[str] = []
+    missing: List[str] = []
     enabled_list_path = src_skills_dir / "enabled.json"
     bundle_enabled = _load_json(enabled_list_path, {}).get("enabled_skills", [])
 
@@ -513,49 +527,57 @@ def _apply_skills(
 
     for skill_name in bundle_enabled:
         src = src_skills_dir / skill_name
-        if not src.is_dir():
-            continue
         dst = SKILLS_DIR / skill_name
-        if dst.exists():
-            if mode == "replace":
-                shutil.rmtree(dst, ignore_errors=True)
-                _copy_dir_filtered(src, dst)
-                added.append(skill_name)
+        if not src.is_dir():
+            # Bundle didn't include a folder for this one — it's a "default"
+            # skill the recipient is expected to have. Keep it enabled only if
+            # the folder actually exists locally; otherwise drop it so the
+            # enabled list never contains ghost entries.
+            if dst.is_dir():
+                already_present.append(skill_name)
             else:
-                skipped.append(skill_name)
-        else:
-            _copy_dir_filtered(src, dst)
-            added.append(skill_name)
+                missing.append(skill_name)
+                logger.warning(
+                    f"[PROFILE_BUNDLE] Bundle expected default skill "
+                    f"'{skill_name}' but no folder exists locally; skipping."
+                )
+            continue
+        if dst.exists():
+            shutil.rmtree(dst, ignore_errors=True)
+        _copy_dir_filtered(src, dst)
+        added.append(skill_name)
+
+    installed_now = added + already_present
 
     if mode == "overwrite":
-        # Authoritative config: bundle's enabled list IS the skill state.
+        # Authoritative config: bundle's enabled list IS the skill state, but
+        # filtered to entries that physically exist on disk after the copy.
         config = {
             "auto_load": True,
-            "enabled_skills": list(bundle_enabled),
+            "enabled_skills": installed_now,
             "disabled_skills": [],
         }
     else:
-        # Additive: only flip skills the bundle landed into the enabled list,
-        # never disable anything the user already had.
+        # Additive: enable everything the bundle wanted that we can back with
+        # a real folder, but never disable anything the user already had.
         config = _load_json(
             SKILLS_CONFIG_PATH,
             {"auto_load": True, "enabled_skills": [], "disabled_skills": []},
         )
         enabled_set = list(config.get("enabled_skills", []))
         disabled_set = list(config.get("disabled_skills", []))
-        for skill_name in bundle_enabled:
-            if skill_name in added:
-                if skill_name not in enabled_set:
-                    enabled_set.append(skill_name)
-                if skill_name in disabled_set:
-                    disabled_set.remove(skill_name)
+        for skill_name in installed_now:
+            if skill_name not in enabled_set:
+                enabled_set.append(skill_name)
+            if skill_name in disabled_set:
+                disabled_set.remove(skill_name)
         config["enabled_skills"] = enabled_set
         config["disabled_skills"] = disabled_set
 
     SKILLS_CONFIG_PATH.write_text(
         json.dumps(config, indent=2, ensure_ascii=False), encoding="utf-8"
     )
-    return added, skipped
+    return added, already_present, missing
 
 
 def _apply_mcp(
@@ -907,7 +929,9 @@ def import_profile(
         bundle_name = manifest.get("name") or "imported profile"
 
         md_applied = _apply_md_files(work_dir / "profile", mode)
-        skills_added, skills_skipped = _apply_skills(work_dir / "skills", mode)
+        skills_added, skills_already_present, skills_missing = _apply_skills(
+            work_dir / "skills", mode
+        )
         mcp_added, mcp_skipped, mcp_needs_env = _apply_mcp(work_dir / "mcp", mode)
         living_added, living_renamed = _apply_living_ui(
             work_dir / "living_ui", mode, manager=living_ui_manager
@@ -918,7 +942,8 @@ def import_profile(
 
         summary = ImportSummary(
             skills_added=skills_added,
-            skills_skipped=skills_skipped,
+            skills_skipped=skills_already_present,
+            skills_missing=skills_missing,
             mcp_added=mcp_added,
             mcp_skipped=mcp_skipped,
             mcp_needs_env=mcp_needs_env,
@@ -931,7 +956,7 @@ def import_profile(
             "mode": mode,
             "bundle_name": bundle_name,
             "summary": summary.to_dict(),
-            "restart_required": True,
+            "restart_required": False,
         }
     except (ValueError, json.JSONDecodeError) as exc:
         return {"success": False, "error": str(exc)}

--- a/app/ui_layer/settings/profile_bundle.py
+++ b/app/ui_layer/settings/profile_bundle.py
@@ -1,0 +1,736 @@
+"""Agent Profile Bundle — export and import the current agent as a portable file.
+
+A profile bundle is a zip-with-extension (`.craftbot`) containing the parts of
+the agent that define its identity and capabilities — personality MD files, the
+enabled skills (with their source folders), the MCP server configs, and the
+Living UI app source. It deliberately does NOT include the user's API keys,
+OAuth secrets, memory, conversation history, or personal data files.
+
+Bundles are designed for one-click sharing: a recipient picks the bundle in
+General Settings and chooses Replace or Merge. Agent name is shown in the
+preview for context but is never applied on import.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+import time
+import zipfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from app.config import (
+    AGENT_FILE_SYSTEM_PATH,
+    AGENT_WORKSPACE_ROOT,
+    APP_CONFIG_PATH,
+    PROJECT_ROOT,
+    get_app_version,
+    get_settings,
+    invalidate_settings_cache,
+    save_settings,
+)
+from app.logger import logger
+
+
+BUNDLE_FORMAT_VERSION = "1.0"
+
+# Agent identity MD files that travel in the bundle.
+# USER.md, MEMORY.md, EVENT*.md, CONVERSATION_HISTORY.md, TASK_HISTORY.md are
+# user-personal or runtime state and are intentionally excluded.
+PROFILE_MD_FILES = ("SOUL.md", "AGENT.md", "PROACTIVE.md", "GLOBAL_LIVING_UI.md")
+
+# Whitelist of settings.json branches that are safe to share. Anything not on
+# this list (api_keys, oauth, endpoints, aws_credentials, cache, browser, etc.)
+# is intentionally omitted — we never want a bundle to leak credentials.
+SAFE_SETTINGS_KEYS = ("model", "proactive", "memory")
+
+# Substrings in MCP env-var NAMES that indicate a secret value. The names are
+# kept (so the importer knows what to fill in) but the VALUES are stripped.
+SECRET_ENV_HINTS = ("KEY", "TOKEN", "SECRET", "PASSWORD", "PASS", "CREDENTIAL")
+
+# Files/directories to skip when copying skill folders or Living UI projects.
+SKIP_DIR_NAMES = {
+    "node_modules",
+    "dist",
+    "build",
+    ".next",
+    ".nuxt",
+    ".cache",
+    ".turbo",
+    ".vite",
+    ".git",
+    "__pycache__",
+}
+SKIP_FILE_SUFFIXES = (".db", ".sqlite", ".sqlite3", ".db-journal", ".pyc")
+
+
+SKILLS_CONFIG_PATH = APP_CONFIG_PATH / "skills_config.json"
+MCP_CONFIG_PATH = APP_CONFIG_PATH / "mcp_config.json"
+SKILLS_DIR = PROJECT_ROOT / "skills"
+LIVING_UI_PROJECTS_FILE = AGENT_WORKSPACE_ROOT / "living_ui_projects.json"
+LIVING_UI_DIR = AGENT_WORKSPACE_ROOT / "living_ui"
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _should_skip_path(path: Path) -> bool:
+    """Skip transient/generated/private files when copying user content."""
+    if path.name in SKIP_DIR_NAMES:
+        return True
+    if path.is_file() and any(
+        path.name.lower().endswith(suffix) for suffix in SKIP_FILE_SUFFIXES
+    ):
+        return True
+    return False
+
+
+def _copy_dir_filtered(src: Path, dst: Path) -> None:
+    """Recursive copy honoring SKIP_DIR_NAMES / SKIP_FILE_SUFFIXES."""
+    if not src.exists():
+        return
+    dst.mkdir(parents=True, exist_ok=True)
+    for entry in src.iterdir():
+        if _should_skip_path(entry):
+            continue
+        target = dst / entry.name
+        if entry.is_dir():
+            _copy_dir_filtered(entry, target)
+        else:
+            try:
+                shutil.copy2(entry, target)
+            except OSError as exc:
+                logger.warning(f"[PROFILE_BUNDLE] Skipping unreadable file {entry}: {exc}")
+
+
+def _agent_name() -> str:
+    """Best-effort current agent name — used only for the manifest/preview."""
+    try:
+        from app.onboarding import onboarding_manager
+
+        name = (onboarding_manager.state.agent_name or "").strip()
+        if name:
+            return name
+    except Exception:
+        pass
+    return (
+        get_settings().get("general", {}).get("agent_name")
+        or "CraftBot"
+    )
+
+
+def _looks_like_secret(env_key: str) -> bool:
+    upper = env_key.upper()
+    return any(hint in upper for hint in SECRET_ENV_HINTS)
+
+
+def _strip_mcp_secrets(servers: List[Dict[str, Any]]) -> Tuple[List[Dict[str, Any]], List[str]]:
+    """Strip env-var values that look like secrets. Returns (cleaned, stripped_names)."""
+    stripped: List[str] = []
+    cleaned: List[Dict[str, Any]] = []
+    for server in servers:
+        s = dict(server)
+        env = dict(s.get("env", {}) or {})
+        for key in list(env.keys()):
+            # Strip every value to be safe — the user will need to refill them
+            # on the recipient machine anyway. Keep the keys so the importer
+            # knows what placeholders to surface in the UI.
+            if env[key]:
+                if _looks_like_secret(key):
+                    stripped.append(f"{s.get('name', '?')}::{key}")
+                env[key] = ""
+        s["env"] = env
+        cleaned.append(s)
+    return cleaned, stripped
+
+
+def _safe_settings_subset(settings: Dict[str, Any]) -> Dict[str, Any]:
+    """Return only the share-safe top-level keys from settings.json."""
+    return {k: settings[k] for k in SAFE_SETTINGS_KEYS if k in settings}
+
+
+def _load_json(path: Path, default: Any) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return default
+
+
+def _slugify(name: str) -> str:
+    safe = "".join(c if c.isalnum() or c in "-_" else "_" for c in name)
+    return safe.strip("_") or "agent"
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Export
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _gather_export_contents() -> Dict[str, Any]:
+    """Pre-flight inventory used by manifest + README."""
+    skills_config = _load_json(SKILLS_CONFIG_PATH, {"enabled_skills": []})
+    enabled_skills = [
+        s
+        for s in skills_config.get("enabled_skills", [])
+        if (SKILLS_DIR / s).is_dir()
+    ]
+
+    mcp_config = _load_json(MCP_CONFIG_PATH, {"mcp_servers": []})
+    mcp_servers = mcp_config.get("mcp_servers", [])
+
+    md_present = [
+        f for f in PROFILE_MD_FILES if (AGENT_FILE_SYSTEM_PATH / f).is_file()
+    ]
+
+    living_ui_projects = _load_json(LIVING_UI_PROJECTS_FILE, [])
+    if isinstance(living_ui_projects, dict):
+        living_ui_projects = living_ui_projects.get("projects", [])
+
+    return {
+        "agent_name": _agent_name(),
+        "md_files": md_present,
+        "skills": enabled_skills,
+        "mcp_servers": [s.get("name", "") for s in mcp_servers],
+        "living_ui_apps": [p.get("name", p.get("id", "")) for p in living_ui_projects],
+    }
+
+
+def _build_manifest(contents: Dict[str, Any], description: str = "") -> Dict[str, Any]:
+    return {
+        "bundle_format_version": BUNDLE_FORMAT_VERSION,
+        "name": contents["agent_name"],
+        "description": description,
+        "source_app_version": get_app_version(),
+        "created_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "contents": contents,
+    }
+
+
+def _build_readme(manifest: Dict[str, Any]) -> str:
+    c = manifest["contents"]
+    skills = "\n".join(f"- {s}" for s in c.get("skills", [])) or "_(none)_"
+    mcps = "\n".join(f"- {s}" for s in c.get("mcp_servers", [])) or "_(none)_"
+    apps = "\n".join(f"- {s}" for s in c.get("living_ui_apps", [])) or "_(none)_"
+    mds = ", ".join(c.get("md_files", [])) or "_(none)_"
+    return (
+        f"# {manifest['name']} — CraftBot agent profile\n\n"
+        f"{manifest['description'] or '_(no description)_'}\n\n"
+        f"Bundle format: `{manifest['bundle_format_version']}`  "
+        f"Source app: `{manifest['source_app_version']}`  "
+        f"Created: `{manifest['created_at']}`\n\n"
+        f"## Personality\n{mds}\n\n"
+        f"## Skills\n{skills}\n\n"
+        f"## MCP servers\n{mcps}\n\n"
+        f"## Living UI apps\n{apps}\n\n"
+        "API keys, OAuth secrets, personal memory, and conversation history\n"
+        "are **not** included in this bundle.\n"
+    )
+
+
+def export_profile(description: str = "") -> Dict[str, Any]:
+    """Build the bundle and return path + filename + summary for download.
+
+    Caller is responsible for serving the file and (after the response is sent)
+    deleting the temp file. Mirrors the Living UI export flow.
+    """
+    contents = _gather_export_contents()
+    manifest = _build_manifest(contents, description=description)
+
+    # Work in a staging dir, then zip into a final file.
+    staging = Path(tempfile.mkdtemp(prefix="craftbot_profile_"))
+    try:
+        # manifest + readme
+        (staging / "manifest.json").write_text(
+            json.dumps(manifest, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+        (staging / "README.md").write_text(_build_readme(manifest), encoding="utf-8")
+
+        # profile/
+        profile_dir = staging / "profile"
+        profile_dir.mkdir()
+        for fname in contents["md_files"]:
+            src = AGENT_FILE_SYSTEM_PATH / fname
+            if src.is_file():
+                shutil.copy2(src, profile_dir / fname)
+
+        safe_settings = _safe_settings_subset(get_settings())
+        (profile_dir / "settings.partial.json").write_text(
+            json.dumps(safe_settings, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+
+        # skills/
+        skills_dir = staging / "skills"
+        skills_dir.mkdir()
+        (skills_dir / "enabled.json").write_text(
+            json.dumps({"enabled_skills": contents["skills"]}, indent=2),
+            encoding="utf-8",
+        )
+        for skill_name in contents["skills"]:
+            src = SKILLS_DIR / skill_name
+            if src.is_dir():
+                _copy_dir_filtered(src, skills_dir / skill_name)
+
+        # mcp/
+        mcp_dir = staging / "mcp"
+        mcp_dir.mkdir()
+        mcp_config = _load_json(MCP_CONFIG_PATH, {"mcp_servers": []})
+        cleaned_servers, _stripped = _strip_mcp_secrets(
+            mcp_config.get("mcp_servers", [])
+        )
+        (mcp_dir / "servers.json").write_text(
+            json.dumps({"mcp_servers": cleaned_servers}, indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
+
+        # living_ui/
+        living_dir = staging / "living_ui"
+        living_dir.mkdir()
+        projects = _load_json(LIVING_UI_PROJECTS_FILE, [])
+        if isinstance(projects, dict):
+            projects = projects.get("projects", [])
+        (living_dir / "projects.json").write_text(
+            json.dumps(projects, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+        for project in projects:
+            project_path_str = project.get("path", "")
+            if not project_path_str:
+                continue
+            project_path = Path(project_path_str)
+            if not project_path.is_absolute():
+                project_path = PROJECT_ROOT / project_path
+            if not project_path.is_dir():
+                continue
+            _copy_dir_filtered(project_path, living_dir / project_path.name)
+
+        # Zip everything up.
+        slug = _slugify(contents["agent_name"]).lower()
+        ts = time.strftime("%Y%m%d")
+        out_dir = Path(tempfile.mkdtemp(prefix="craftbot_profile_out_"))
+        out_path = out_dir / f"craftbot-{slug}-{ts}.craftbot"
+        with zipfile.ZipFile(out_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            for entry in staging.rglob("*"):
+                if entry.is_file():
+                    zf.write(entry, entry.relative_to(staging))
+
+        return {
+            "success": True,
+            "path": str(out_path),
+            "filename": out_path.name,
+            "summary": {
+                "skills": len(contents["skills"]),
+                "mcp_servers": len(contents["mcp_servers"]),
+                "living_ui_apps": len(contents["living_ui_apps"]),
+                "md_files": len(contents["md_files"]),
+            },
+        }
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Inspect (preview before import)
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _open_bundle(bundle_path: Path) -> zipfile.ZipFile:
+    if not bundle_path.exists():
+        raise FileNotFoundError(f"Bundle not found: {bundle_path}")
+    try:
+        return zipfile.ZipFile(bundle_path, "r")
+    except zipfile.BadZipFile as exc:
+        raise ValueError(f"Not a valid .craftbot bundle: {exc}") from exc
+
+
+def _safe_extract(zf: zipfile.ZipFile, dest: Path) -> None:
+    """Extract, refusing absolute paths or paths that escape `dest`."""
+    dest = dest.resolve()
+    for member in zf.infolist():
+        # Refuse absolute or traversal paths — defends against zip-slip.
+        name = member.filename.replace("\\", "/")
+        if name.startswith("/") or ".." in name.split("/"):
+            raise ValueError(f"Unsafe path in bundle: {member.filename}")
+        out_path = (dest / name).resolve()
+        try:
+            out_path.relative_to(dest)
+        except ValueError as exc:
+            raise ValueError(f"Unsafe path in bundle: {member.filename}") from exc
+    zf.extractall(dest)
+
+
+def inspect_bundle(bundle_path: str) -> Dict[str, Any]:
+    """Return the manifest + a preview of what will be applied on import."""
+    path = Path(bundle_path)
+    try:
+        with _open_bundle(path) as zf:
+            try:
+                manifest = json.loads(zf.read("manifest.json").decode("utf-8"))
+            except KeyError:
+                return {"success": False, "error": "Bundle is missing manifest.json"}
+            except json.JSONDecodeError as exc:
+                return {"success": False, "error": f"Invalid manifest.json: {exc}"}
+
+            # Compute "already installed" hints so the UI can call them out.
+            local_skills = (
+                set(p.name for p in SKILLS_DIR.iterdir() if p.is_dir())
+                if SKILLS_DIR.exists()
+                else set()
+            )
+            mcp_local = _load_json(MCP_CONFIG_PATH, {"mcp_servers": []}).get(
+                "mcp_servers", []
+            )
+            local_mcp_names = {s.get("name", "") for s in mcp_local}
+
+            # Detect MCP env vars the user will need to refill.
+            try:
+                mcp_servers_in_bundle = json.loads(
+                    zf.read("mcp/servers.json").decode("utf-8")
+                ).get("mcp_servers", [])
+            except (KeyError, json.JSONDecodeError):
+                mcp_servers_in_bundle = []
+            mcp_needs_env: List[Dict[str, Any]] = []
+            for server in mcp_servers_in_bundle:
+                missing = [k for k in (server.get("env") or {}).keys() if not (server["env"] or {}).get(k)]
+                if missing:
+                    mcp_needs_env.append({"name": server.get("name", ""), "env_keys": missing})
+
+            contents = manifest.get("contents", {})
+            return {
+                "success": True,
+                "manifest": manifest,
+                "preview": {
+                    "skills_already_installed": sorted(
+                        set(contents.get("skills", [])) & local_skills
+                    ),
+                    "mcp_already_installed": sorted(
+                        set(contents.get("mcp_servers", [])) & local_mcp_names
+                    ),
+                    "mcp_needs_env": mcp_needs_env,
+                },
+            }
+    except (ValueError, FileNotFoundError) as exc:
+        return {"success": False, "error": str(exc)}
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Import
+# ─────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class ImportSummary:
+    skills_added: List[str]
+    skills_skipped: List[str]
+    mcp_added: List[str]
+    mcp_skipped: List[str]
+    mcp_needs_env: List[Dict[str, Any]]
+    md_applied: List[str]
+    living_ui_added: List[str]
+    living_ui_renamed: List[str]
+    settings_applied: bool
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "skills_added": self.skills_added,
+            "skills_skipped": self.skills_skipped,
+            "mcp_added": self.mcp_added,
+            "mcp_skipped": self.mcp_skipped,
+            "mcp_needs_env": self.mcp_needs_env,
+            "md_applied": self.md_applied,
+            "living_ui_added": self.living_ui_added,
+            "living_ui_renamed": self.living_ui_renamed,
+            "settings_applied": self.settings_applied,
+        }
+
+
+def _apply_md_files(
+    src_profile: Path, mode: str, bundle_name: str
+) -> List[str]:
+    applied: List[str] = []
+    AGENT_FILE_SYSTEM_PATH.mkdir(parents=True, exist_ok=True)
+    for fname in PROFILE_MD_FILES:
+        src = src_profile / fname
+        if not src.is_file():
+            continue
+        target = AGENT_FILE_SYSTEM_PATH / fname
+        try:
+            incoming = src.read_text(encoding="utf-8")
+            if mode == "replace" or not target.exists():
+                target.write_text(incoming, encoding="utf-8")
+            else:  # merge → append under a divider
+                existing = target.read_text(encoding="utf-8")
+                divider = (
+                    f"\n\n---\n_imported from {bundle_name}_\n\n"
+                )
+                target.write_text(existing.rstrip() + divider + incoming, encoding="utf-8")
+            applied.append(fname)
+        except OSError as exc:
+            logger.error(f"[PROFILE_BUNDLE] Failed to apply {fname}: {exc}")
+    return applied
+
+
+def _apply_settings(src_profile: Path, mode: str) -> bool:
+    """In Replace mode only, apply whitelisted settings branches."""
+    if mode != "replace":
+        return False
+    partial_path = src_profile / "settings.partial.json"
+    if not partial_path.is_file():
+        return False
+    try:
+        partial = json.loads(partial_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning(f"[PROFILE_BUNDLE] Invalid settings.partial.json: {exc}")
+        return False
+    current = get_settings()
+    for key in SAFE_SETTINGS_KEYS:
+        if key in partial:
+            current[key] = partial[key]
+    save_settings(current)
+    invalidate_settings_cache()
+    return True
+
+
+def _apply_skills(
+    src_skills_dir: Path, mode: str
+) -> Tuple[List[str], List[str]]:
+    """Copy skill folders and update enabled_skills in skills_config.json."""
+    added: List[str] = []
+    skipped: List[str] = []
+    enabled_list_path = src_skills_dir / "enabled.json"
+    bundle_enabled = _load_json(enabled_list_path, {}).get("enabled_skills", [])
+
+    SKILLS_DIR.mkdir(parents=True, exist_ok=True)
+    for skill_name in bundle_enabled:
+        src = src_skills_dir / skill_name
+        if not src.is_dir():
+            continue
+        dst = SKILLS_DIR / skill_name
+        if dst.exists():
+            if mode == "replace":
+                shutil.rmtree(dst, ignore_errors=True)
+                _copy_dir_filtered(src, dst)
+                added.append(skill_name)
+            else:
+                skipped.append(skill_name)
+        else:
+            _copy_dir_filtered(src, dst)
+            added.append(skill_name)
+
+    # Update skills_config.json's enabled list (additive — never disables).
+    config = _load_json(
+        SKILLS_CONFIG_PATH, {"auto_load": True, "enabled_skills": [], "disabled_skills": []}
+    )
+    enabled_set = list(config.get("enabled_skills", []))
+    disabled_set = list(config.get("disabled_skills", []))
+    for skill_name in bundle_enabled:
+        if skill_name in added:
+            if skill_name not in enabled_set:
+                enabled_set.append(skill_name)
+            if skill_name in disabled_set:
+                disabled_set.remove(skill_name)
+    config["enabled_skills"] = enabled_set
+    config["disabled_skills"] = disabled_set
+    SKILLS_CONFIG_PATH.write_text(
+        json.dumps(config, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    return added, skipped
+
+
+def _apply_mcp(
+    src_mcp_dir: Path, mode: str
+) -> Tuple[List[str], List[str], List[Dict[str, Any]]]:
+    """Merge or replace MCP server configs."""
+    added: List[str] = []
+    skipped: List[str] = []
+    needs_env: List[Dict[str, Any]] = []
+
+    servers_path = src_mcp_dir / "servers.json"
+    bundle_servers = _load_json(servers_path, {}).get("mcp_servers", [])
+
+    current = _load_json(MCP_CONFIG_PATH, {"mcp_servers": []})
+    existing = current.get("mcp_servers", [])
+    by_name = {s.get("name", ""): s for s in existing}
+
+    for server in bundle_servers:
+        name = server.get("name", "")
+        if not name:
+            continue
+        missing_env = [k for k, v in (server.get("env") or {}).items() if not v]
+        if missing_env:
+            needs_env.append({"name": name, "env_keys": missing_env})
+
+        if name in by_name:
+            if mode == "replace":
+                # Keep ANY env values the user had set locally — don't blow
+                # them away on replace, since the user's filled-in tokens are
+                # more valuable than the (empty) tokens from the bundle.
+                preserved_env = by_name[name].get("env", {})
+                merged_env = dict(server.get("env", {}))
+                for k, v in preserved_env.items():
+                    if v and k in merged_env and not merged_env[k]:
+                        merged_env[k] = v
+                server["env"] = merged_env
+                by_name[name] = server
+                added.append(name)
+            else:
+                skipped.append(name)
+        else:
+            by_name[name] = server
+            added.append(name)
+
+    current["mcp_servers"] = list(by_name.values())
+    MCP_CONFIG_PATH.write_text(
+        json.dumps(current, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    return added, skipped, needs_env
+
+
+def _apply_living_ui(src_living_dir: Path) -> Tuple[List[str], List[str]]:
+    """Copy Living UI projects. Always rename on conflict (preserve user data)."""
+    added: List[str] = []
+    renamed: List[str] = []
+
+    projects_path = src_living_dir / "projects.json"
+    bundle_projects = _load_json(projects_path, [])
+    if isinstance(bundle_projects, dict):
+        bundle_projects = bundle_projects.get("projects", [])
+    if not bundle_projects:
+        return added, renamed
+
+    LIVING_UI_DIR.mkdir(parents=True, exist_ok=True)
+    current_projects = _load_json(LIVING_UI_PROJECTS_FILE, [])
+    if isinstance(current_projects, dict):
+        current_projects = current_projects.get("projects", [])
+    current_ids = {p.get("id") for p in current_projects}
+    current_folders = {Path(p.get("path", "")).name for p in current_projects if p.get("path")}
+
+    import uuid
+
+    for project in bundle_projects:
+        project_path_str = project.get("path", "")
+        if not project_path_str:
+            continue
+        original_folder = Path(project_path_str).name
+        src_folder = src_living_dir / original_folder
+        if not src_folder.is_dir():
+            continue
+
+        # Conflict → rename folder + project id
+        new_project = dict(project)
+        folder_name = original_folder
+        if project.get("id") in current_ids or folder_name in current_folders:
+            new_id = uuid.uuid4().hex[:8]
+            base_name = project.get("name", "imported")
+            new_project["id"] = new_id
+            new_project["name"] = f"{base_name} (imported)"
+            sanitized = _slugify(base_name).lower()
+            folder_name = f"{sanitized}_{new_id}"
+            new_project["path"] = str(LIVING_UI_DIR / folder_name)
+            renamed.append(new_project["name"])
+        else:
+            new_project["path"] = str(LIVING_UI_DIR / folder_name)
+            added.append(project.get("name", original_folder))
+
+        # Reset transient runtime fields so the imported project starts clean.
+        new_project["status"] = "stopped"
+        new_project.pop("pid", None)
+        new_project.pop("backendPid", None)
+
+        _copy_dir_filtered(src_folder, LIVING_UI_DIR / folder_name)
+        current_projects.append(new_project)
+        current_ids.add(new_project["id"])
+        current_folders.add(folder_name)
+
+    LIVING_UI_PROJECTS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    LIVING_UI_PROJECTS_FILE.write_text(
+        json.dumps(current_projects, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    return added, renamed
+
+
+def import_profile(bundle_path: str, mode: str = "merge") -> Dict[str, Any]:
+    """Apply a bundle to the current agent.
+
+    Args:
+        bundle_path: filesystem path to the .craftbot file (already uploaded)
+        mode: "merge" (default — additive) or "replace" (overwrite on conflict)
+
+    Returns:
+        Dict with success flag and ImportSummary contents. The agent will need
+        a manual restart for the changes to fully take effect; the caller
+        surfaces that to the user.
+    """
+    if mode not in ("merge", "replace"):
+        return {"success": False, "error": f"Unknown import mode: {mode}"}
+
+    path = Path(bundle_path)
+    if not path.exists():
+        return {"success": False, "error": f"Bundle file not found: {bundle_path}"}
+
+    work_dir = Path(tempfile.mkdtemp(prefix="craftbot_profile_import_"))
+    try:
+        with _open_bundle(path) as zf:
+            _safe_extract(zf, work_dir)
+
+        manifest_path = work_dir / "manifest.json"
+        if not manifest_path.is_file():
+            return {"success": False, "error": "Bundle is missing manifest.json"}
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        bundle_version = manifest.get("bundle_format_version", "")
+        if bundle_version.split(".")[0] != BUNDLE_FORMAT_VERSION.split(".")[0]:
+            return {
+                "success": False,
+                "error": (
+                    f"Bundle format {bundle_version} is not compatible with this "
+                    f"app (expected {BUNDLE_FORMAT_VERSION}). Update CraftBot."
+                ),
+            }
+        bundle_name = manifest.get("name") or "imported profile"
+
+        md_applied = _apply_md_files(work_dir / "profile", mode, bundle_name)
+        settings_applied = _apply_settings(work_dir / "profile", mode)
+        skills_added, skills_skipped = _apply_skills(work_dir / "skills", mode)
+        mcp_added, mcp_skipped, mcp_needs_env = _apply_mcp(work_dir / "mcp", mode)
+        living_added, living_renamed = _apply_living_ui(work_dir / "living_ui")
+
+        # NOTE: agent_name is intentionally NOT applied — per product decision,
+        # users keep their own agent name and just inherit the personality/skills.
+
+        summary = ImportSummary(
+            skills_added=skills_added,
+            skills_skipped=skills_skipped,
+            mcp_added=mcp_added,
+            mcp_skipped=mcp_skipped,
+            mcp_needs_env=mcp_needs_env,
+            md_applied=md_applied,
+            living_ui_added=living_added,
+            living_ui_renamed=living_renamed,
+            settings_applied=settings_applied,
+        )
+        return {
+            "success": True,
+            "mode": mode,
+            "bundle_name": bundle_name,
+            "summary": summary.to_dict(),
+            "restart_required": True,
+        }
+    except (ValueError, json.JSONDecodeError) as exc:
+        return {"success": False, "error": str(exc)}
+    except Exception as exc:
+        logger.error(f"[PROFILE_BUNDLE] Import failed: {exc}", exc_info=True)
+        return {"success": False, "error": f"Import failed: {exc}"}
+    finally:
+        shutil.rmtree(work_dir, ignore_errors=True)
+
+
+__all__ = [
+    "BUNDLE_FORMAT_VERSION",
+    "export_profile",
+    "inspect_bundle",
+    "import_profile",
+]

--- a/app/ui_layer/settings/profile_bundle.py
+++ b/app/ui_layer/settings/profile_bundle.py
@@ -17,8 +17,9 @@ import json
 import shutil
 import tempfile
 import time
+import uuid
 import zipfile
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
@@ -32,9 +33,6 @@ from app.config import (
     APP_CONFIG_PATH,
     PROJECT_ROOT,
     get_app_version,
-    get_settings,
-    invalidate_settings_cache,
-    save_settings,
 )
 from app.logger import logger
 
@@ -45,11 +43,6 @@ BUNDLE_FORMAT_VERSION = "1.0"
 # USER.md, MEMORY.md, EVENT*.md, CONVERSATION_HISTORY.md, TASK_HISTORY.md are
 # user-personal or runtime state and are intentionally excluded.
 PROFILE_MD_FILES = ("SOUL.md", "AGENT.md", "PROACTIVE.md", "GLOBAL_LIVING_UI.md")
-
-# Whitelist of settings.json branches that are safe to share. Anything not on
-# this list (api_keys, oauth, endpoints, aws_credentials, cache, browser, etc.)
-# is intentionally omitted — we never want a bundle to leak credentials.
-SAFE_SETTINGS_KEYS = ("model", "proactive", "memory")
 
 # Substrings in MCP env-var NAMES that indicate a secret value. The names are
 # kept (so the importer knows what to fill in) but the VALUES are stripped.
@@ -122,10 +115,7 @@ def _agent_name() -> str:
             return name
     except Exception:
         pass
-    return (
-        get_settings().get("general", {}).get("agent_name")
-        or "CraftBot"
-    )
+    return "CraftBot"
 
 
 def _looks_like_secret(env_key: str) -> bool:
@@ -153,16 +143,22 @@ def _strip_mcp_secrets(servers: List[Dict[str, Any]]) -> Tuple[List[Dict[str, An
     return cleaned, stripped
 
 
-def _safe_settings_subset(settings: Dict[str, Any]) -> Dict[str, Any]:
-    """Return only the share-safe top-level keys from settings.json."""
-    return {k: settings[k] for k in SAFE_SETTINGS_KEYS if k in settings}
-
-
 def _load_json(path: Path, default: Any) -> Any:
     try:
         return json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return default
+
+
+def _load_living_ui_projects(path: Path) -> List[Dict[str, Any]]:
+    """Read a Living UI registry, tolerating both the {"projects":[...]} envelope
+    used by the LivingUIManager and a bare list (legacy / hand-written)."""
+    data = _load_json(path, {"projects": []})
+    if isinstance(data, dict):
+        return data.get("projects", []) or []
+    if isinstance(data, list):
+        return data
+    return []
 
 
 def _slugify(name: str) -> str:
@@ -196,9 +192,7 @@ def _gather_export_contents() -> Dict[str, Any]:
         f for f in PROFILE_MD_FILES if (AGENT_FILE_SYSTEM_PATH / f).is_file()
     ]
 
-    living_ui_projects = _load_json(LIVING_UI_PROJECTS_FILE, [])
-    if isinstance(living_ui_projects, dict):
-        living_ui_projects = living_ui_projects.get("projects", [])
+    living_ui_projects = _load_living_ui_projects(LIVING_UI_PROJECTS_FILE)
 
     return {
         "agent_name": _agent_name(),
@@ -241,6 +235,91 @@ def _build_readme(manifest: Dict[str, Any]) -> str:
     )
 
 
+def _write_meta(staging: Path, manifest: Dict[str, Any]) -> None:
+    """Write top-level manifest.json + README.md."""
+    (staging / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    (staging / "README.md").write_text(_build_readme(manifest), encoding="utf-8")
+
+
+def _write_profile_dir(staging: Path, md_files: List[str]) -> None:
+    """Copy personality MD files into profile/."""
+    profile_dir = staging / "profile"
+    profile_dir.mkdir()
+    for fname in md_files:
+        src = AGENT_FILE_SYSTEM_PATH / fname
+        if src.is_file():
+            shutil.copy2(src, profile_dir / fname)
+
+
+def _write_skills_dir(staging: Path, skill_names: List[str]) -> None:
+    """Copy each enabled skill folder and write the enabled-list manifest."""
+    skills_dir = staging / "skills"
+    skills_dir.mkdir()
+    (skills_dir / "enabled.json").write_text(
+        json.dumps({"enabled_skills": skill_names}, indent=2),
+        encoding="utf-8",
+    )
+    for skill_name in skill_names:
+        src = SKILLS_DIR / skill_name
+        if src.is_dir():
+            _copy_dir_filtered(src, skills_dir / skill_name)
+
+
+def _write_mcp_dir(staging: Path) -> None:
+    """Write mcp/servers.json with enabled servers only and secrets stripped."""
+    mcp_dir = staging / "mcp"
+    mcp_dir.mkdir()
+    mcp_config = _load_json(MCP_CONFIG_PATH, {"mcp_servers": []})
+    enabled_mcp = [
+        s for s in mcp_config.get("mcp_servers", []) if s.get("enabled", False)
+    ]
+    cleaned_servers, _stripped = _strip_mcp_secrets(enabled_mcp)
+    (mcp_dir / "servers.json").write_text(
+        json.dumps({"mcp_servers": cleaned_servers}, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
+def _write_living_ui_dir(staging: Path) -> None:
+    """Copy Living UI project source folders + the registry file."""
+    living_dir = staging / "living_ui"
+    living_dir.mkdir()
+    projects = _load_living_ui_projects(LIVING_UI_PROJECTS_FILE)
+    # Match the envelope the LivingUIManager uses on disk
+    # ({"projects": [...]}). Writing a flat list would make the manager's
+    # _load_projects() fail silently — and its next startup cleanup pass
+    # would then delete every Living UI folder as "orphaned".
+    (living_dir / "projects.json").write_text(
+        json.dumps({"projects": projects}, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    for project in projects:
+        project_path_str = project.get("path", "")
+        if not project_path_str:
+            continue
+        project_path = Path(project_path_str)
+        if not project_path.is_absolute():
+            project_path = PROJECT_ROOT / project_path
+        if not project_path.is_dir():
+            continue
+        _copy_dir_filtered(project_path, living_dir / project_path.name)
+
+
+def _zip_staging(staging: Path, agent_name: str) -> Path:
+    """Zip the staging tree into a fresh temp file. Returns the .craftbot path."""
+    slug = _slugify(agent_name).lower()
+    ts = time.strftime("%Y%m%d")
+    out_dir = Path(tempfile.mkdtemp(prefix="craftbot_profile_out_"))
+    out_path = out_dir / f"craftbot-{slug}-{ts}.craftbot"
+    with zipfile.ZipFile(out_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for entry in staging.rglob("*"):
+            if entry.is_file():
+                zf.write(entry, entry.relative_to(staging))
+    return out_path
+
+
 def export_profile(description: str = "") -> Dict[str, Any]:
     """Build the bundle and return path + filename + summary for download.
 
@@ -250,87 +329,14 @@ def export_profile(description: str = "") -> Dict[str, Any]:
     contents = _gather_export_contents()
     manifest = _build_manifest(contents, description=description)
 
-    # Work in a staging dir, then zip into a final file.
     staging = Path(tempfile.mkdtemp(prefix="craftbot_profile_"))
     try:
-        # manifest + readme
-        (staging / "manifest.json").write_text(
-            json.dumps(manifest, indent=2, ensure_ascii=False), encoding="utf-8"
-        )
-        (staging / "README.md").write_text(_build_readme(manifest), encoding="utf-8")
-
-        # profile/
-        profile_dir = staging / "profile"
-        profile_dir.mkdir()
-        for fname in contents["md_files"]:
-            src = AGENT_FILE_SYSTEM_PATH / fname
-            if src.is_file():
-                shutil.copy2(src, profile_dir / fname)
-
-        safe_settings = _safe_settings_subset(get_settings())
-        (profile_dir / "settings.partial.json").write_text(
-            json.dumps(safe_settings, indent=2, ensure_ascii=False), encoding="utf-8"
-        )
-
-        # skills/
-        skills_dir = staging / "skills"
-        skills_dir.mkdir()
-        (skills_dir / "enabled.json").write_text(
-            json.dumps({"enabled_skills": contents["skills"]}, indent=2),
-            encoding="utf-8",
-        )
-        for skill_name in contents["skills"]:
-            src = SKILLS_DIR / skill_name
-            if src.is_dir():
-                _copy_dir_filtered(src, skills_dir / skill_name)
-
-        # mcp/ — only enabled servers (the inventory was already filtered)
-        mcp_dir = staging / "mcp"
-        mcp_dir.mkdir()
-        mcp_config = _load_json(MCP_CONFIG_PATH, {"mcp_servers": []})
-        enabled_mcp = [
-            s for s in mcp_config.get("mcp_servers", []) if s.get("enabled", False)
-        ]
-        cleaned_servers, _stripped = _strip_mcp_secrets(enabled_mcp)
-        (mcp_dir / "servers.json").write_text(
-            json.dumps({"mcp_servers": cleaned_servers}, indent=2, ensure_ascii=False),
-            encoding="utf-8",
-        )
-
-        # living_ui/
-        living_dir = staging / "living_ui"
-        living_dir.mkdir()
-        projects = _load_json(LIVING_UI_PROJECTS_FILE, {"projects": []})
-        if isinstance(projects, dict):
-            projects = projects.get("projects", [])
-        # Match the envelope the LivingUIManager uses on disk
-        # ({"projects": [...]}). Writing a flat list would make the manager's
-        # _load_projects() fail silently — and its next startup cleanup pass
-        # would then delete every Living UI folder as "orphaned".
-        (living_dir / "projects.json").write_text(
-            json.dumps({"projects": projects}, indent=2, ensure_ascii=False),
-            encoding="utf-8",
-        )
-        for project in projects:
-            project_path_str = project.get("path", "")
-            if not project_path_str:
-                continue
-            project_path = Path(project_path_str)
-            if not project_path.is_absolute():
-                project_path = PROJECT_ROOT / project_path
-            if not project_path.is_dir():
-                continue
-            _copy_dir_filtered(project_path, living_dir / project_path.name)
-
-        # Zip everything up.
-        slug = _slugify(contents["agent_name"]).lower()
-        ts = time.strftime("%Y%m%d")
-        out_dir = Path(tempfile.mkdtemp(prefix="craftbot_profile_out_"))
-        out_path = out_dir / f"craftbot-{slug}-{ts}.craftbot"
-        with zipfile.ZipFile(out_path, "w", zipfile.ZIP_DEFLATED) as zf:
-            for entry in staging.rglob("*"):
-                if entry.is_file():
-                    zf.write(entry, entry.relative_to(staging))
+        _write_meta(staging, manifest)
+        _write_profile_dir(staging, contents["md_files"])
+        _write_skills_dir(staging, contents["skills"])
+        _write_mcp_dir(staging)
+        _write_living_ui_dir(staging)
+        out_path = _zip_staging(staging, contents["agent_name"])
 
         return {
             "success": True,
@@ -409,7 +415,8 @@ def inspect_bundle(bundle_path: str) -> Dict[str, Any]:
                 mcp_servers_in_bundle = []
             mcp_needs_env: List[Dict[str, Any]] = []
             for server in mcp_servers_in_bundle:
-                missing = [k for k in (server.get("env") or {}).keys() if not (server["env"] or {}).get(k)]
+                env = server.get("env") or {}
+                missing = [k for k in env if not env.get(k)]
                 if missing:
                     mcp_needs_env.append({"name": server.get("name", ""), "env_keys": missing})
 
@@ -446,20 +453,9 @@ class ImportSummary:
     md_applied: List[str]
     living_ui_added: List[str]
     living_ui_renamed: List[str]
-    settings_applied: bool
 
     def to_dict(self) -> Dict[str, Any]:
-        return {
-            "skills_added": self.skills_added,
-            "skills_skipped": self.skills_skipped,
-            "mcp_added": self.mcp_added,
-            "mcp_skipped": self.mcp_skipped,
-            "mcp_needs_env": self.mcp_needs_env,
-            "md_applied": self.md_applied,
-            "living_ui_added": self.living_ui_added,
-            "living_ui_renamed": self.living_ui_renamed,
-            "settings_applied": self.settings_applied,
-        }
+        return asdict(self)
 
 
 def _apply_md_files(
@@ -486,27 +482,6 @@ def _apply_md_files(
         except OSError as exc:
             logger.error(f"[PROFILE_BUNDLE] Failed to apply {fname}: {exc}")
     return applied
-
-
-def _apply_settings(src_profile: Path, mode: str) -> bool:
-    """In Replace mode only, apply whitelisted settings branches."""
-    if mode != "replace":
-        return False
-    partial_path = src_profile / "settings.partial.json"
-    if not partial_path.is_file():
-        return False
-    try:
-        partial = json.loads(partial_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        logger.warning(f"[PROFILE_BUNDLE] Invalid settings.partial.json: {exc}")
-        return False
-    current = get_settings()
-    for key in SAFE_SETTINGS_KEYS:
-        if key in partial:
-            current[key] = partial[key]
-    save_settings(current)
-    invalidate_settings_cache()
-    return True
 
 
 def _apply_skills(
@@ -604,61 +579,23 @@ def _apply_mcp(
     return added, skipped, needs_env
 
 
-def _apply_living_ui(
+def _plan_and_copy_living_ui_imports(
     src_living_dir: Path,
-    manager: Optional["LivingUIManager"] = None,
-) -> Tuple[List[str], List[str]]:
-    """Copy Living UI projects and register them with the live manager.
+    bundle_projects: List[Dict[str, Any]],
+    target_living_dir: Path,
+    current_ids: set,
+    current_folders: set,
+) -> Tuple[List[Dict[str, Any]], List[str], List[str]]:
+    """Walk the bundle's projects, copy each folder into ``target_living_dir``
+    (renaming on id/folder conflict), and return the new registry records.
 
-    Always renames on folder/id conflict so we never destroy a user's existing
-    project data.
-
-    When ``manager`` is provided (production path), the imported projects are
-    inserted directly into ``manager.projects`` and persisted via the manager's
-    own ``_save_projects()``. This is CRITICAL: without it, our changes are
-    written to disk but the still-running ``LivingUIManager`` holds a stale
-    in-memory state — any subsequent ``_save_projects()`` call (status update,
-    watchdog tick, port change, etc.) will flush that stale state back to disk
-    and silently erase every imported entry.
-
-    ``manager=None`` is supported for inspection / non-running callers; that
-    path writes the registry file directly and is vulnerable to the race
-    described above, so don't use it from a live agent.
+    Returns ``(new_records, added_names, renamed_names)``. ``current_ids`` /
+    ``current_folders`` are mutated as new entries land so per-loop conflict
+    checks see them.
     """
+    new_records: List[Dict[str, Any]] = []
     added: List[str] = []
     renamed: List[str] = []
-
-    projects_path = src_living_dir / "projects.json"
-    bundle_projects = _load_json(projects_path, [])
-    if isinstance(bundle_projects, dict):
-        bundle_projects = bundle_projects.get("projects", [])
-    if not bundle_projects:
-        return added, renamed
-
-    # Resolve target dir + existing-state snapshot from the live manager when
-    # available, otherwise fall back to the on-disk file.
-    if manager is not None:
-        target_living_dir = manager.living_ui_dir
-        current_ids = set(manager.projects.keys())
-        current_folders = {
-            Path(p.path).name for p in manager.projects.values() if p.path
-        }
-    else:
-        target_living_dir = LIVING_UI_DIR
-        current_records = _load_json(LIVING_UI_PROJECTS_FILE, {"projects": []})
-        if isinstance(current_records, dict):
-            current_records = current_records.get("projects", [])
-        current_ids = {p.get("id") for p in current_records}
-        current_folders = {
-            Path(p.get("path", "")).name for p in current_records if p.get("path")
-        }
-
-    target_living_dir.mkdir(parents=True, exist_ok=True)
-
-    import uuid
-
-    # Collected new entries (manifest dicts) to apply after the loop.
-    new_records: List[Dict[str, Any]] = []
 
     for project in bundle_projects:
         project_path_str = project.get("path", "")
@@ -694,61 +631,122 @@ def _apply_living_ui(
         current_ids.add(new_project["id"])
         current_folders.add(folder_name)
 
+    return new_records, added, renamed
+
+
+def _register_living_ui_via_manager(
+    records: List[Dict[str, Any]],
+    manager: "LivingUIManager",
+) -> None:
+    """Insert imported projects into the live manager and persist via its own
+    save path so they survive subsequent in-memory-driven flushes.
+
+    Without this, ``_apply_living_ui`` would write the registry file directly
+    but the still-running ``LivingUIManager`` would hold a stale in-memory
+    state; any later ``_save_projects()`` (status update, watchdog tick, port
+    change, etc.) would flush that stale state back and silently erase every
+    imported entry.
+    """
+    # Local import keeps the module's top-level surface light + dodges any
+    # circular-import risk between the settings and living_ui packages.
+    from app.living_ui.manager import LivingUIProject
+
+    for record in records:
+        try:
+            created_at_ms = record.get("createdAt")
+            if not isinstance(created_at_ms, (int, float)):
+                created_at_ms = datetime.now().timestamp() * 1000
+            project_obj = LivingUIProject(
+                id=record["id"],
+                name=record["name"],
+                description=record.get("description", ""),
+                path=record["path"],
+                status="stopped",
+                port=record.get("port"),
+                backend_port=record.get("backendPort"),
+                created_at=created_at_ms / 1000,
+                features=record.get("features", []) or [],
+                theme=record.get("theme", "system") or "system",
+                auto_launch=bool(record.get("autoLaunch", False)),
+                log_cleanup=bool(record.get("logCleanup", True)),
+                project_type=record.get("projectType", "native") or "native",
+                app_runtime=record.get("appRuntime"),
+            )
+        except Exception as exc:
+            logger.warning(
+                f"[PROFILE_BUNDLE] Skipping malformed imported project "
+                f"{record.get('id', '?')}: {exc}"
+            )
+            continue
+        manager.projects[project_obj.id] = project_obj
+        if project_obj.port:
+            manager._used_ports.add(project_obj.port)
+        if project_obj.backend_port:
+            manager._used_ports.add(project_obj.backend_port)
+    manager._save_projects()
+
+
+def _register_living_ui_via_file(records: List[Dict[str, Any]]) -> None:
+    """Fallback persistence — append records to the on-disk registry file.
+
+    Race-prone when an agent is running (see _register_living_ui_via_manager
+    for why), so reserved for inspection / non-running callers.
+    """
+    current_records = _load_living_ui_projects(LIVING_UI_PROJECTS_FILE)
+    current_records.extend(records)
+    LIVING_UI_PROJECTS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    LIVING_UI_PROJECTS_FILE.write_text(
+        json.dumps({"projects": current_records}, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+
+def _apply_living_ui(
+    src_living_dir: Path,
+    manager: Optional["LivingUIManager"] = None,
+) -> Tuple[List[str], List[str]]:
+    """Copy Living UI projects into the workspace and register them.
+
+    Always renames on folder/id conflict so existing user data is never
+    overwritten. When ``manager`` is provided, persistence goes through the
+    live ``LivingUIManager`` (required from a running agent); otherwise it
+    falls back to a direct file write.
+    """
+    bundle_projects = _load_living_ui_projects(src_living_dir / "projects.json")
+    if not bundle_projects:
+        return [], []
+
+    if manager is not None:
+        target_living_dir = manager.living_ui_dir
+        current_ids = set(manager.projects.keys())
+        current_folders = {
+            Path(p.path).name for p in manager.projects.values() if p.path
+        }
+    else:
+        target_living_dir = LIVING_UI_DIR
+        current = _load_living_ui_projects(LIVING_UI_PROJECTS_FILE)
+        current_ids = {p.get("id") for p in current}
+        current_folders = {
+            Path(p.get("path", "")).name for p in current if p.get("path")
+        }
+
+    target_living_dir.mkdir(parents=True, exist_ok=True)
+
+    new_records, added, renamed = _plan_and_copy_living_ui_imports(
+        src_living_dir,
+        bundle_projects,
+        target_living_dir,
+        current_ids,
+        current_folders,
+    )
+
     if not new_records:
         return added, renamed
 
     if manager is not None:
-        # Register into the live manager so its next _save_projects() flushes
-        # our entries instead of overwriting them. Importing here to keep the
-        # module's top-level import surface light (and avoid a circular).
-        from app.living_ui.manager import LivingUIProject
-
-        for record in new_records:
-            try:
-                created_at_ms = record.get("createdAt")
-                if not isinstance(created_at_ms, (int, float)):
-                    created_at_ms = datetime.now().timestamp() * 1000
-                project_obj = LivingUIProject(
-                    id=record["id"],
-                    name=record["name"],
-                    description=record.get("description", ""),
-                    path=record["path"],
-                    status="stopped",
-                    port=record.get("port"),
-                    backend_port=record.get("backendPort"),
-                    created_at=created_at_ms / 1000,
-                    features=record.get("features", []) or [],
-                    theme=record.get("theme", "system") or "system",
-                    auto_launch=bool(record.get("autoLaunch", False)),
-                    log_cleanup=bool(record.get("logCleanup", True)),
-                    project_type=record.get("projectType", "native") or "native",
-                    app_runtime=record.get("appRuntime"),
-                )
-            except Exception as exc:
-                logger.warning(
-                    f"[PROFILE_BUNDLE] Skipping malformed imported project "
-                    f"{record.get('id', '?')}: {exc}"
-                )
-                continue
-            manager.projects[project_obj.id] = project_obj
-            if project_obj.port:
-                manager._used_ports.add(project_obj.port)
-            if project_obj.backend_port:
-                manager._used_ports.add(project_obj.backend_port)
-        # Manager writes the file in the envelope format the loader expects.
-        manager._save_projects()
+        _register_living_ui_via_manager(new_records, manager)
     else:
-        # Fallback path — direct file write. Same envelope format as the
-        # manager uses, see _save_projects().
-        current_records = _load_json(LIVING_UI_PROJECTS_FILE, {"projects": []})
-        if isinstance(current_records, dict):
-            current_records = current_records.get("projects", [])
-        current_records.extend(new_records)
-        LIVING_UI_PROJECTS_FILE.parent.mkdir(parents=True, exist_ok=True)
-        LIVING_UI_PROJECTS_FILE.write_text(
-            json.dumps({"projects": current_records}, indent=2, ensure_ascii=False),
-            encoding="utf-8",
-        )
+        _register_living_ui_via_file(new_records)
 
     return added, renamed
 
@@ -799,7 +797,6 @@ def import_profile(
         bundle_name = manifest.get("name") or "imported profile"
 
         md_applied = _apply_md_files(work_dir / "profile", mode, bundle_name)
-        settings_applied = _apply_settings(work_dir / "profile", mode)
         skills_added, skills_skipped = _apply_skills(work_dir / "skills", mode)
         mcp_added, mcp_skipped, mcp_needs_env = _apply_mcp(work_dir / "mcp", mode)
         living_added, living_renamed = _apply_living_ui(
@@ -818,7 +815,6 @@ def import_profile(
             md_applied=md_applied,
             living_ui_added=living_added,
             living_ui_renamed=living_renamed,
-            settings_applied=settings_applied,
         )
         return {
             "success": True,


### PR DESCRIPTION
What and why:
User usually don't know what to do when they use CraftBot, so this PR is made to ease that. Ship two user-facing additions that make CraftBot faster to set up and easier to drive. Agent profile lets users export/ save / import / overwrite their full agent setup as a portable bundle, so they can clone a working agent across machines or reset cleanly without losing Living UI work. Playbooks adds a catalog of prewritten prompts users can browse and send to chat in one click.

Features / items added:
1. Agent profile export / import as a bundle (personality files, skills, MCP servers, Living UI apps)
2. New repo for hosting agent bundles (https://github.com/CraftOS-dev/craftbot-agent-bundles)
3. Living-UI-safe reset on import so prior projects aren't destroyed
5. New Playbooks button in the top bar that opens a catalog of platbooks
6. 121 curated playbooks across 19 categories (Sales, Engineering, Marketing, Health, Legal, Investing, Content, Customer Success, etc.) with search + tag filtering (28 canonical tags)
7. One-click "Use this playbook" button that drops the prewritten prompt into the chat input via a new Redux chatInputSlice
