### PR TITLE
Fix: Check isComposing for IME conversion on MacBook

### DIFF
--- a/app/ui_layer/browser/frontend/src/components/Chat/Chat.tsx
+++ b/app/ui_layer/browser/frontend/src/components/Chat/Chat.tsx
@@ -415,6 +415,10 @@ export function Chat({ livingUIId, placeholder, emptyMessage }: ChatProps) {
         return
       }
     }
+    if (e.nativeEvent.isComposing) {
+      e.preventDefault()
+      return
+    }
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault()
       if (autocompleteRef.current?.handleEnter()) {


### PR DESCRIPTION
Quick change to prevent pressing the Enter key to confirm IME language conversion from sending a message to chat prematurely