### PR TITLE
fix #340: guard flush when worker stdout is None

### DIFF
--- a/agent_core/core/impl/action/executor.py
+++ b/agent_core/core/impl/action/executor.py
@@ -292,8 +292,10 @@ def _suppress_worker_stdio():
 
     Returns (saved_stdout_fd, saved_stderr_fd) for later restoration.
     """
-    sys.stdout.flush()
-    sys.stderr.flush()
+    if sys.stdout is not None:
+        sys.stdout.flush()
+    if sys.stderr is not None:
+        sys.stderr.flush()
     devnull_fd = os.open(os.devnull, os.O_WRONLY)
     saved_stdout = os.dup(1)
     saved_stderr = os.dup(2)


### PR DESCRIPTION
## What
- Guard `sys.stdout`/`sys.stderr` flush in `_suppress_worker_stdio()` when streams are `None`

## Why
Closes #340. Sandboxed `run_python` runs in a ProcessPool worker; on Windows `sys.stdout` can be `None`, so `.flush()` crashed before user code ran.

## How to test
1. `python -m compileall -q agent_core`
2. `ruff check agent_core/core/impl/action/executor.py`
3. Run CraftBot and trigger `run_python` with `print('hello')` - should return success with stdout, not an internal AttributeError