### PR TITLE
Add: Living UI palette theme button

### DIFF
--- a/app/ui_layer/browser/frontend/src/App.tsx
+++ b/app/ui_layer/browser/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Routes, Route, Navigate } from 'react-router-dom'
+import { Routes, Route, Navigate, useParams } from 'react-router-dom'
 import { Layout } from './components/layout'
 import { ChatPage } from './pages/Chat'
 import { TasksPage } from './pages/Tasks'
@@ -10,6 +10,13 @@ import { SettingsPage } from './pages/Settings'
 import { OnboardingPage } from './pages/Onboarding'
 import { LivingUIPage } from './pages/LivingUI'
 import { useWebSocket } from './contexts/WebSocketContext'
+
+// Forces LivingUIPage to remount per-project so useState initializers
+// (theme, custom colors) always start fresh — not carried over from a previous project.
+function LivingUIPageRoute() {
+  const { projectId } = useParams<{ projectId: string }>()
+  return <LivingUIPage key={projectId} />
+}
 
 function App() {
   const { initReceived, needsHardOnboarding } = useWebSocket()
@@ -64,7 +71,7 @@ function App() {
         <Route path="/screen" element={<ScreenPage />} />
         <Route path="/workspace" element={<WorkspacePage />} />
         <Route path="/settings" element={<SettingsPage />} />
-        <Route path="/living-ui/:projectId" element={<LivingUIPage />} />
+        <Route path="/living-ui/:projectId" element={<LivingUIPageRoute />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </Layout>

--- a/app/ui_layer/browser/frontend/src/pages/LivingUI/LivingUIPage.module.css
+++ b/app/ui_layer/browser/frontend/src/pages/LivingUI/LivingUIPage.module.css
@@ -505,6 +505,136 @@
   border-color: var(--border-hover);
 }
 
+/* ── Theme Picker Modal ──────────────────────────────────────────────────── */
+
+.themeGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
+}
+
+.themeTile {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-2);
+  background: var(--bg-tertiary);
+  border: 2px solid var(--border-primary);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: border-color var(--transition-fast), background var(--transition-fast);
+}
+
+.themeTile:hover {
+  border-color: var(--border-hover);
+  background: var(--bg-hover);
+}
+
+.themeTileActive {
+  border-color: var(--color-primary);
+  background: var(--color-primary-subtle);
+}
+
+.themeTileCheck {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: var(--radius-full);
+  background: var(--color-primary);
+  color: #fff;
+}
+
+.swatchRow {
+  display: flex;
+  gap: 3px;
+}
+
+.swatch {
+  display: block;
+  width: 14px;
+  height: 14px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  flex-shrink: 0;
+}
+
+.themeLabel {
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+  color: var(--text-secondary);
+  text-align: center;
+}
+
+.themeTileActive .themeLabel {
+  color: var(--text-primary);
+}
+
+/* Custom color editor */
+.customColors {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-bottom: var(--space-3);
+  padding: var(--space-3);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-md);
+}
+
+.colorRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  cursor: pointer;
+}
+
+.colorInput {
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  background: none;
+  flex-shrink: 0;
+}
+
+.colorInput::-webkit-color-swatch-wrapper {
+  padding: 2px;
+}
+
+.colorInput::-webkit-color-swatch {
+  border: none;
+  border-radius: 2px;
+}
+
+.colorLabel {
+  flex: 1;
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+}
+
+.colorValue {
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+}
+
+.themeCaption {
+  margin: 0;
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  text-align: center;
+}
+
 /* Not Found */
 .notFound {
   display: flex;

--- a/app/ui_layer/browser/frontend/src/pages/LivingUI/LivingUIPage.tsx
+++ b/app/ui_layer/browser/frontend/src/pages/LivingUI/LivingUIPage.tsx
@@ -11,21 +11,52 @@ import {
   Maximize2,
   Minimize2,
   Loader2,
+  Palette,
 } from 'lucide-react'
 import { CraftBotMascot } from '@mascot'
 import { useWebSocket } from '../../contexts/WebSocketContext'
 import { useFullscreen } from '../../contexts/FullscreenContext'
+import { useTheme } from '../../contexts/ThemeContext'
 import { Button } from '../../components/ui/Button'
 import { IconButton } from '../../components/ui/IconButton'
 import { ConfirmModal } from '../../components/ui/ConfirmModal'
 import { Chat } from '../../components/Chat'
-import { getOrCreateIframe, showIframe, hideIframe, refreshIframe, removeIframe } from './iframePool'
+import { getOrCreateIframe, showIframe, hideIframe, refreshIframe, removeIframe, postMessageToIframe, getIframeWindow } from './iframePool'
 import { CreationProgress } from './CreationProgress'
 import { CreationQuestionForm } from './CreationQuestionForm'
+import { LivingUIThemeModal, DEFAULT_CUSTOM_COLORS } from './LivingUIThemeModal'
+import type { LivingUIThemeId, LivingUICustomColors } from './LivingUIThemeModal'
 import { useAppSelector, useAppDispatch } from '../../store/hooks'
 import { selectLivingUiPendingQuestions } from '../../store/selectors/livingUi'
 import { clearPendingQuestion } from '../../store/slices/livingUiSlice'
 import styles from './LivingUIPage.module.css'
+
+function loadLivingUITheme(projectId: string): LivingUIThemeId {
+  try {
+    const stored = localStorage.getItem(`livingui-theme-${projectId}`)
+    if (stored) return stored as LivingUIThemeId
+  } catch {}
+  return 'craftbot'
+}
+
+function saveLivingUITheme(projectId: string, themeId: LivingUIThemeId) {
+  try { localStorage.setItem(`livingui-theme-${projectId}`, themeId) } catch {}
+}
+
+function loadLivingUICustomColors(projectId: string): LivingUICustomColors {
+  try {
+    const raw = localStorage.getItem(`livingui-custom-colors-${projectId}`)
+    if (raw) {
+      const parsed = JSON.parse(raw)
+      if (parsed.bg && parsed.surface && parsed.text && parsed.accent) return parsed
+    }
+  } catch {}
+  return { ...DEFAULT_CUSTOM_COLORS }
+}
+
+function saveLivingUICustomColors(projectId: string, colors: LivingUICustomColors) {
+  try { localStorage.setItem(`livingui-custom-colors-${projectId}`, JSON.stringify(colors)) } catch {}
+}
 
 export function LivingUIPage() {
   const { projectId } = useParams<{ projectId: string }>()
@@ -40,10 +71,18 @@ export function LivingUIPage() {
     sendMessage,
   } = useWebSocket()
   const { isFullscreen, setFullscreen, toggleFullscreen } = useFullscreen()
+  const { theme: appTheme } = useTheme()
   const dispatch = useAppDispatch()
   const pendingQuestions = useAppSelector(selectLivingUiPendingQuestions)
 
   const [showDeleteModal, setShowDeleteModal] = useState(false)
+  const [showThemeModal, setShowThemeModal] = useState(false)
+  const [livingUITheme, setLivingUITheme] = useState<LivingUIThemeId>(
+    () => (projectId ? loadLivingUITheme(projectId) : 'craftbot')
+  )
+  const [livingUICustomColors, setLivingUICustomColors] = useState<LivingUICustomColors>(
+    () => (projectId ? loadLivingUICustomColors(projectId) : { ...DEFAULT_CUSTOM_COLORS })
+  )
   const [showChat, setShowChat] = useState(true)
   const [panelWidth, setPanelWidth] = useState(350)
   const [mobileChatRatio, setMobileChatRatio] = useState(0.4)
@@ -136,6 +175,45 @@ export function LivingUIPage() {
       if (projectId) hideIframe(projectId)
     }
   }, [projectId, project?.status, project?.url])
+
+  // Send the selected Living UI theme + current app mode to the iframe
+  useEffect(() => {
+    if (!projectId || project?.status !== 'running') return
+    postMessageToIframe(projectId, {
+      type: 'livingui-theme',
+      themeId: livingUITheme,
+      mode: appTheme,
+      customColors: livingUICustomColors,
+    })
+  }, [livingUITheme, livingUICustomColors, appTheme, projectId, project?.status])
+
+  // When the iframe finishes loading it sends 'craftbot-theme-request'. Reply
+  // with the saved per-project theme so the palette persists across refreshes.
+  useEffect(() => {
+    if (!projectId) return
+    const onIframeReady = (e: MessageEvent) => {
+      if (e.data?.type !== 'craftbot-theme-request' || !e.source) return
+      if (e.source !== getIframeWindow(projectId)) return
+      ;(e.source as Window).postMessage({
+        type: 'livingui-theme',
+        themeId: livingUITheme,
+        mode: appTheme,
+        customColors: livingUICustomColors,
+      }, '*')
+    }
+    window.addEventListener('message', onIframeReady)
+    return () => window.removeEventListener('message', onIframeReady)
+  }, [projectId, livingUITheme, livingUICustomColors, appTheme])
+
+  const handleThemeSelect = (themeId: LivingUIThemeId, colors?: LivingUICustomColors) => {
+    if (!projectId) return
+    setLivingUITheme(themeId)
+    saveLivingUITheme(projectId, themeId)
+    if (colors) {
+      setLivingUICustomColors(colors)
+      saveLivingUICustomColors(projectId, colors)
+    }
+  }
 
   const handleLaunch = () => {
     if (projectId) {
@@ -261,6 +339,12 @@ export function LivingUIPage() {
           ) : null}
           <IconButton
             size="sm"
+            icon={<Palette size={14} />}
+            tooltip="Theme"
+            onClick={() => setShowThemeModal(true)}
+          />
+          <IconButton
+            size="sm"
             icon={<MessageSquare size={14} />}
             tooltip={showChat ? 'Hide Chat' : 'Show Chat'}
             onClick={() => setShowChat(prev => !prev)}
@@ -365,6 +449,15 @@ export function LivingUIPage() {
       {/* Resize overlay — covers the Living UI iframe while dragging so the
           iframe doesn't swallow pointer events and abort the drag. */}
       {isResizing && <div className={styles.resizeOverlay} aria-hidden="true" />}
+
+      {/* Theme Picker Modal */}
+      <LivingUIThemeModal
+        isOpen={showThemeModal}
+        activeTheme={livingUITheme}
+        customColors={livingUICustomColors}
+        onSelect={handleThemeSelect}
+        onClose={() => setShowThemeModal(false)}
+      />
 
       {/* Delete Confirmation Modal */}
       <ConfirmModal

--- a/app/ui_layer/browser/frontend/src/pages/LivingUI/LivingUIThemeModal.tsx
+++ b/app/ui_layer/browser/frontend/src/pages/LivingUI/LivingUIThemeModal.tsx
@@ -1,0 +1,140 @@
+import React, { useState } from 'react'
+import { Check } from 'lucide-react'
+import { Modal, ModalBody } from '../../components/ui/Modal'
+import styles from './LivingUIPage.module.css'
+
+export type LivingUIThemeId = 'craftbot' | 'normal' | 'ocean' | 'forest' | 'pastel' | 'custom'
+
+export interface LivingUICustomColors {
+  bg: string
+  surface: string
+  text: string
+  accent: string
+}
+
+export const DEFAULT_CUSTOM_COLORS: LivingUICustomColors = {
+  bg: '#191919',
+  surface: '#202020',
+  text: '#E6E6E4',
+  accent: '#FF4F18',
+}
+
+const PRESET_THEMES: { id: Exclude<LivingUIThemeId, 'custom'>; label: string; swatches: [string, string, string, string] }[] = [
+  { id: 'craftbot', label: 'CraftBot', swatches: ['#191919', '#202020', '#E6E6E4', '#FF4F18'] },
+  { id: 'normal',   label: 'Normal',   swatches: ['#0A0A0A', '#181818', '#FFFFFF', '#3B82F6'] },
+  { id: 'ocean',    label: 'Ocean',    swatches: ['#0F172A', '#1E293B', '#F8FAFC', '#38BDF8'] },
+  { id: 'forest',   label: 'Forest',   swatches: ['#0F1A14', '#1B2A21', '#F3F6F4', '#22C55E'] },
+  { id: 'pastel',   label: 'Pastel',   swatches: ['#1A1023', '#231530', '#F3E8FF', '#C084FC'] },
+]
+
+interface Props {
+  isOpen: boolean
+  activeTheme: LivingUIThemeId
+  customColors: LivingUICustomColors
+  onSelect: (themeId: LivingUIThemeId, customColors?: LivingUICustomColors) => void
+  onClose: () => void
+}
+
+export function LivingUIThemeModal({ isOpen, activeTheme, customColors, onSelect, onClose }: Props) {
+  const [localColors, setLocalColors] = useState<LivingUICustomColors>(customColors)
+
+  const handlePresetClick = (id: Exclude<LivingUIThemeId, 'custom'>) => {
+    onSelect(id)
+  }
+
+  const handleCustomClick = () => {
+    onSelect('custom', localColors)
+  }
+
+  const handleColorChange = (key: keyof LivingUICustomColors, value: string) => {
+    const updated = { ...localColors, [key]: value }
+    setLocalColors(updated)
+    // Live-preview: if custom is already active, apply immediately
+    if (activeTheme === 'custom') {
+      onSelect('custom', updated)
+    }
+  }
+
+  const customSwatches: [string, string, string, string] = [
+    localColors.bg, localColors.surface, localColors.text, localColors.accent,
+  ]
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Choose Theme" size="sm">
+      <ModalBody>
+        <div className={styles.themeGrid}>
+          {PRESET_THEMES.map(({ id, label, swatches }) => (
+            <button
+              key={id}
+              type="button"
+              className={`${styles.themeTile} ${activeTheme === id ? styles.themeTileActive : ''}`}
+              onClick={() => handlePresetClick(id)}
+            >
+              <SwatchRow swatches={swatches} />
+              <span className={styles.themeLabel}>{label}</span>
+              {activeTheme === id && (
+                <span className={styles.themeTileCheck}>
+                  <Check size={10} />
+                </span>
+              )}
+            </button>
+          ))}
+
+          {/* Custom tile */}
+          <button
+            type="button"
+            className={`${styles.themeTile} ${activeTheme === 'custom' ? styles.themeTileActive : ''}`}
+            onClick={handleCustomClick}
+          >
+            <SwatchRow swatches={customSwatches} />
+            <span className={styles.themeLabel}>Custom</span>
+            {activeTheme === 'custom' && (
+              <span className={styles.themeTileCheck}>
+                <Check size={10} />
+              </span>
+            )}
+          </button>
+        </div>
+
+        {/* Custom color editor — shown when custom is active */}
+        {activeTheme === 'custom' && (
+          <div className={styles.customColors}>
+            {(
+              [
+                { key: 'bg',      label: 'Background' },
+                { key: 'surface', label: 'Surface'    },
+                { key: 'text',    label: 'Text'       },
+                { key: 'accent',  label: 'Accent'     },
+              ] as { key: keyof LivingUICustomColors; label: string }[]
+            ).map(({ key, label }) => (
+              <label key={key} className={styles.colorRow}>
+                <input
+                  type="color"
+                  value={localColors[key]}
+                  onChange={e => handleColorChange(key, e.target.value)}
+                  className={styles.colorInput}
+                />
+                <span className={styles.colorLabel}>{label}</span>
+                <span className={styles.colorValue}>{localColors[key]}</span>
+              </label>
+            ))}
+          </div>
+        )}
+
+        <p className={styles.themeCaption}>
+          Themes adapt to light/dark mode &middot; Custom stays fixed
+        </p>
+      </ModalBody>
+    </Modal>
+  )
+}
+
+function SwatchRow({ swatches }: { swatches: [string, string, string, string] }) {
+  return (
+    <div className={styles.swatchRow}>
+      {swatches.map((color, i) => (
+        <span key={i} className={styles.swatch} style={{ background: color }} />
+      ))}
+    </div>
+  )
+}

--- a/app/ui_layer/browser/frontend/src/pages/LivingUI/iframePool.ts
+++ b/app/ui_layer/browser/frontend/src/pages/LivingUI/iframePool.ts
@@ -105,6 +105,10 @@ export function hasIframe(id: string): boolean {
   return pool.has(id)
 }
 
+export function getIframeWindow(id: string): Window | null {
+  return pool.get(id)?.contentWindow ?? null
+}
+
 export function broadcastThemeToIframes(theme: string, cssVars: Record<string, string>) {
   const message = { type: 'craftbot-theme', theme, cssVars }
   pool.forEach(iframe => {
@@ -119,5 +123,13 @@ export function sendThemeToIframe(id: string, theme: string, cssVars: Record<str
   if (!iframe) return
   try {
     iframe.contentWindow?.postMessage({ type: 'craftbot-theme', theme, cssVars }, '*')
+  } catch (e) {}
+}
+
+export function postMessageToIframe(id: string, data: unknown) {
+  const iframe = pool.get(id)
+  if (!iframe) return
+  try {
+    iframe.contentWindow?.postMessage(data, '*')
   } catch (e) {}
 }


### PR DESCRIPTION
## Note: This PR additionally requires approval of another PR in the Living UI marketplace repo: https://github.com/CraftOS-dev/living-ui-marketplace/pull/18

## What
- Add "Palette Button" between "Stop" and "Hide Chat" buttons on Living UI tabs
- Add selectable preset themes and a custom theme option to all Living UIs
- Modified `LIVING_UI_GUIDE.md` and `_template/` for adding themes to future Living UI creations

## Why
The previous implementation of Living UIs had standardized, boring UIs. This theme update allows better customization and design for users while also allowing a better showcase of Livign UI as a product.

## How to test
- Add and install a Living UI from the marketplace (ensure you're in the `theme-update` branch, which may require modifying links inside `browser_adapter.py` and `manager.py` in CraftBot)
- Test Living UI themes by selecting the paint board icon in the top right of the Living UI tab nestled between the "Stop" and "Hide Chat" buttons
- Create new Living UIs using CraftBot or another agent to ensure theme creation works

## Screenshots
<img width="642" height="413" alt="image" src="https://github.com/user-attachments/assets/ef138a7b-0e0f-4fbd-9cd3-9d99c3e3ce4b" />
<img width="209" height="58" alt="image" src="https://github.com/user-attachments/assets/4819795e-0595-4b71-99ef-b5055d478a49" />
