### PR TITLE
Fix subagent params alias dispatch

### DIFF
--- a/app/subagent/runner.py
+++ b/app/subagent/runner.py
@@ -263,9 +263,7 @@ class SubAgentRunner:
 
     async def _dispatch_action(self, sub: SubAgent, decision: Dict[str, Any]) -> None:
         action_name = decision.get("action_name") or ""
-        parameters = decision.get("parameters") or {}
-        if not isinstance(parameters, dict):
-            parameters = {}
+        parameters = self._extract_parameters(decision)
 
         # Enforce the frozen action list — refuse anything else.
         if action_name not in sub.compiled_actions:
@@ -308,6 +306,22 @@ class SubAgentRunner:
             is_gui_task=False,
             input_data=parameters,
         )
+
+    @staticmethod
+    def _extract_parameters(decision: Dict[str, Any]) -> Dict[str, Any]:
+        """Return action inputs from the accepted decision parameter keys."""
+        parameters = decision.get("parameters")
+        if isinstance(parameters, dict):
+            return parameters
+
+        # The compact action list describes schemas under ``params``. Some
+        # providers mirror that key in their decision even though the required
+        # output shape says ``parameters``.
+        params_alias = decision.get("params")
+        if isinstance(params_alias, dict):
+            return params_alias
+
+        return {}
 
     # ------------------------------------------------------------------
     # Session-cache management

--- a/tests/test_subagent_runner.py
+++ b/tests/test_subagent_runner.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+
+import asyncio
+
+from agent_core.core.action import Action
+from app.subagent.runner import SubAgentRunner
+from app.subagent.types import SubAgent
+
+
+class _FakeActionLibrary:
+    def __init__(self):
+        self.action = Action(
+            name="sub_task_end",
+            description="End sub-agent",
+            action_type="atomic",
+            mode="CLI",
+        )
+
+    def retrieve_action(self, action_name):
+        if action_name == self.action.name:
+            return self.action
+        return None
+
+
+class _FakeActionManager:
+    def __init__(self):
+        self.calls = []
+
+    async def execute_action(self, **kwargs):
+        self.calls.append(kwargs)
+        return {"status": "success"}
+
+
+def _make_runner():
+    action_manager = _FakeActionManager()
+    runner = SubAgentRunner(
+        subagent_manager=None,
+        action_manager=action_manager,
+        action_library=_FakeActionLibrary(),
+        event_stream_manager=None,
+        llm_interface=None,
+    )
+    return runner, action_manager
+
+
+def _make_subagent():
+    return SubAgent(
+        id="sub_test",
+        agent_type="research_agent",
+        parent_task_id="parent_test",
+        query="test query",
+        compiled_actions=["sub_task_end"],
+    )
+
+
+def test_dispatch_action_accepts_params_alias():
+    runner, action_manager = _make_runner()
+    payload = {"status": "completed", "result": "done"}
+
+    asyncio.run(
+        runner._dispatch_action(
+            _make_subagent(),
+            {"action_name": "sub_task_end", "params": payload},
+        )
+    )
+
+    assert action_manager.calls[0]["input_data"] == payload
+    assert action_manager.calls[0]["session_id"] == "sub_test"
+
+
+def test_dispatch_action_prefers_parameters_key():
+    runner, action_manager = _make_runner()
+
+    asyncio.run(
+        runner._dispatch_action(
+            _make_subagent(),
+            {
+                "action_name": "sub_task_end",
+                "parameters": {"status": "failed", "result": "primary"},
+                "params": {"status": "completed", "result": "alias"},
+            },
+        )
+    )
+
+    assert action_manager.calls[0]["input_data"] == {
+        "status": "failed",
+        "result": "primary",
+    }


### PR DESCRIPTION
## Summary

Fixes #355.

Sub-agent action dispatch now accepts `params` as an alias for `parameters`.
Some LLM outputs mirror the compact action schema key `params`, which previously caused the runner to drop the payload before calling `sub_task_end`.
As a result, `sub_task_end` received only `_session_id` and failed with `Invalid status`.

## Changes

- Added parameter extraction helper in `SubAgentRunner`
- Preserves existing `parameters` behavior and gives it precedence over `params`
- Added regression tests for:
  - `params` alias dispatch
  - `parameters` precedence when both keys are present

## Verification

- Direct full reproduction passed
- Focused regression functions passed
- `python -m compileall app\subagent\runner.py tests\test_subagent_runner.py` passed
