### PR TITLE
fix: root pytest failures

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,8 @@
 [pytest]
 markers =
     live: real end-to-end tests that hit live integrations and the real LLM (opt-in: `pytest -m live`)
+testpaths =
+    tests
 
 # By default, skip live tests so plain `pytest` stays fast and offline.
 addopts = -m "not live"

--- a/tests/test_trigger_router_and_parking.py
+++ b/tests/test_trigger_router_and_parking.py
@@ -21,9 +21,13 @@ class FakeLLM:
         self.response = response
         self.calls = 0
 
-    async def generate_response_async(self, system_prompt: str, user_prompt: str):
+    async def generate_response_async(
+        self, system_prompt: str, user_prompt: str, prompt_name=None, **_kwargs
+    ):
         self.calls += 1
+        self.last_system_prompt = system_prompt
         self.last_prompt = user_prompt
+        self.last_prompt_name = prompt_name
         return self.response
 
 
@@ -39,6 +43,7 @@ class TestSessionRouter:
         router = SessionRouter(llm, ROUTING_PROMPT)
         result = run(router.route("message", "continue that task", "sessions"))
         assert result["session_id"] == "abc123"
+        assert llm.last_prompt_name == "ROUTE_TO_SESSION"
         assert llm.calls == 1
 
     def test_new_session_decision(self):


### PR DESCRIPTION
## What
- Limit default root pytest discovery to the maintained `tests/` suite.
- Update the router test fake LLM to accept the current `generate_response_async(..., prompt_name=...)` call shape.
- Assert the session router passes `ROUTE_TO_SESSION` into the LLM call.

## Why
Root `pytest` was collecting generated/template Living UI tests under `app/data`, which are not part of CraftBot's maintained root suite and can fail collection from the repository root. The router tests also had a stale fake LLM signature after router calls started passing `prompt_name` for prompt capture.

This replaces #360 with a clean branch based directly on `dev`; the old PR had the right file diff but included unrelated `main` merge commits in its PR commit list after retargeting.

## How to test
- `/usr/local/bin/python3.10 -m pytest tests/test_trigger_router_and_parking.py -q` -> `9 passed`
- `/usr/local/bin/python3.10 -m pytest --collect-only -q` -> `99/115 tests collected (16 deselected)`
- `/usr/local/bin/python3.10 -m pytest -q` -> `99 passed, 16 deselected`
- Root pytest loop: `20/20` successful runs, each `99 passed, 16 deselected`
- `/usr/local/bin/python3.10 -m pytest app/data/living_ui_template/backend/tests -q` -> `4 passed` when invoked explicitly
- `/usr/local/bin/python3.10 -m ruff format --check .` -> `588 files already formatted`
- `/usr/local/bin/python3.10 -m ruff check .` -> `All checks passed!`
- `/usr/local/bin/python3.10 -m compileall -q app agent_core agents decorators skills` -> passed
- `/usr/local/bin/python3.10 -m py_compile tests/test_trigger_router_and_parking.py` -> passed
- `git diff --check HEAD^..HEAD` -> passed