### PR TITLE
Fix find_files slowness with SQLite FindIndex (#354).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ agent_file_system/TASK_HISTORY.md
 docs/LIVING_UI_DEVELOPER_GUIDE.md
 agent_file_system/ACTIONS.md
 agent_bundle/
+**/.craftbot/

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ docs/LIVING_UI_DEVELOPER_GUIDE.md
 agent_file_system/ACTIONS.md
 agent_bundle/
 **/.craftbot/
+app/data/.file_index/

--- a/agent_file_system/AGENT.md
+++ b/agent_file_system/AGENT.md
@@ -1,5 +1,5 @@
 ---
-version: 3
+version: 5
 purpose: agent operations manual
 ---
 
@@ -782,6 +782,8 @@ comfortably within one response's output-token budget.
 ### find_files vs list_folder
 - `list_folder`: top-level listing of a single directory.
 - `find_files`: recursive name pattern search across a tree.
+- Searching for several related name variants (e.g. "craftbot" or "craftos")? Combine them into ONE `find_files` call with `|` or `OR` in `pattern` (e.g. `*craftbot*|*craftos*`) instead of issuing multiple parallel `find_files` calls for the same base_directory.
+- Searching multiple drives/roots (e.g. C: and D:)? Same rule applies: join them with `|` in `base_directory` (e.g. `C:/|D:/`), or pass `all_drives=true` to search every local fixed drive in one call — do not fire one `find_files` call per drive.
 
 ### convert_to_markdown vs read_pdf
 - `read_pdf`: direct PDF reading with page support.

--- a/app/agent_base.py
+++ b/app/agent_base.py
@@ -4015,11 +4015,19 @@ class AgentBase:
 
         def _prewarm() -> None:
             try:
-                for drive in file_index.list_local_drives():
+                drives = file_index.list_local_drives()
+            except Exception as e:
+                logger.warning(f"[FILE_INDEX] Could not enumerate local drives: {e}")
+                return
+
+            for drive in drives:
+                try:
                     file_index.build_index(drive)
                     file_index.start_watcher(drive)
-            except Exception as e:
-                logger.warning(f"[FILE_INDEX] Background pre-warm failed: {e}")
+                except Exception as e:
+                    logger.warning(
+                        f"[FILE_INDEX] Background pre-warm failed for {drive}: {e}"
+                    )
 
         threading.Thread(
             target=_prewarm, daemon=True, name="file-index-prewarm"

--- a/app/agent_base.py
+++ b/app/agent_base.py
@@ -58,6 +58,7 @@ from app.config import (
     TELEGRAM_API_HASH,
     get_api_key,
     get_base_url,
+    is_prewarm_all_drives_enabled,
 )
 from craftos_integrations import (
     configure as _configure_integrations,
@@ -3935,6 +3936,11 @@ class AgentBase:
         self._usage_reporter = get_usage_reporter()
         self._usage_reporter.start_background_flush()
 
+        # Pre-warm the find_files index for all local drives (background,
+        # non-blocking) so the first real search doesn't pay a cold-crawl cost.
+        if is_prewarm_all_drives_enabled():
+            self._start_index_prewarm()
+
         # Configure integrations + start external comms manager
         step(6, 7, "Initializing integrations")
         await self._initialize_external_libraries()
@@ -3994,6 +4000,30 @@ class AgentBase:
 
         # Resume triggers for tasks restored from previous session
         await self._schedule_restored_task_triggers()
+
+    def _start_index_prewarm(self) -> None:
+        """Warm the find_files index for every local drive in a background thread.
+
+        Runs one drive at a time rather than one thread per drive: concurrent
+        full-drive crawls were observed contending with each other for the
+        GIL/disk with no net speedup (see app/utils/file_index.py find_files).
+        Fully non-blocking — boot() does not wait on this.
+        """
+        import threading
+
+        from app.utils import file_index
+
+        def _prewarm() -> None:
+            try:
+                for drive in file_index.list_local_drives():
+                    file_index.build_index(drive)
+                    file_index.start_watcher(drive)
+            except Exception as e:
+                logger.warning(f"[FILE_INDEX] Background pre-warm failed: {e}")
+
+        threading.Thread(
+            target=_prewarm, daemon=True, name="file-index-prewarm"
+        ).start()
 
     async def run(
         self,

--- a/app/config.py
+++ b/app/config.py
@@ -128,6 +128,9 @@ def _get_default_settings() -> Dict[str, Any]:
             "use_omniparser": False,
             "omniparser_url": "http://127.0.0.1:7861",
         },
+        "file_index": {
+            "prewarm_all_drives": True,
+        },
     }
 
 
@@ -385,6 +388,12 @@ def get_web_search_cse_id() -> str:
     """Get Google Custom Search Engine ID."""
     settings = get_settings()
     return settings.get("web_search", {}).get("google_cse_id", "")
+
+
+def is_prewarm_all_drives_enabled() -> bool:
+    """Whether to pre-warm the find_files index for all local drives at startup."""
+    settings = get_settings()
+    return settings.get("file_index", {}).get("prewarm_all_drives", True)
 
 
 def reload_settings() -> Dict[str, Any]:

--- a/app/config/settings.json
+++ b/app/config/settings.json
@@ -70,6 +70,9 @@
     "port": 7926,
     "startup_ui": false
   },
+  "file_index": {
+    "prewarm_all_drives": true
+  },
   "api_keys_configured": {
     "openai": false,
     "anthropic": false,

--- a/app/data/action/find_files.py
+++ b/app/data/action/find_files.py
@@ -28,6 +28,11 @@ from agent_core import action
             "example": False,
             "description": "If true, search every local fixed drive/mount in one call instead of just base_directory (which is then ignored). Use this instead of calling find_files once per drive.",
         },
+        "limit": {
+            "type": "integer",
+            "example": 500,
+            "description": "Optional cap on the total number of matches returned across all searched roots. Useful with all_drives or broad patterns to avoid extremely large result sets. Default: unbounded.",
+        },
     },
     output_schema={
         "status": {"type": "string", "example": "success"},
@@ -57,6 +62,7 @@ def find_file_by_name(input_data: dict) -> dict:
     recursive = bool(input_data.get("recursive", True))
     all_drives = bool(input_data.get("all_drives", False))
     base_directory = (input_data.get("base_directory") or "").strip()
+    limit = input_data.get("limit")
 
     if not pattern:
         return {"status": "error", "matches": [], "message": "Pattern is required."}
@@ -64,32 +70,10 @@ def find_file_by_name(input_data: dict) -> dict:
     if all_drives:
         base_directory = ""
     else:
-        # Default to user's home directory if not provided
-        if not base_directory:
-            base_directory = os.path.expanduser("~")
-
-        # base_directory may hold multiple '|'-joined roots; validate each.
-        roots = [part.strip() for part in base_directory.split("|") if part.strip()]
-        normalized_roots = []
-        for root in roots:
-            root = os.path.normpath(os.path.expanduser(root))
-
-            if not os.path.exists(root):
-                return {
-                    "status": "error",
-                    "matches": [],
-                    "message": f"Base directory does not exist: {root}",
-                }
-
-            if not os.path.isdir(root):
-                return {
-                    "status": "error",
-                    "matches": [],
-                    "message": f"Base directory is not a directory: {root}",
-                }
-
-            normalized_roots.append(root)
-        base_directory = "|".join(normalized_roots)
+        roots, error = file_index.resolve_roots(base_directory, windows=False)
+        if error:
+            return error
+        base_directory = "|".join(roots)
 
     # Normalize the pattern (if user passes a path, only use its basename as the match pattern)
     pattern = os.path.expanduser(pattern)
@@ -100,7 +84,9 @@ def find_file_by_name(input_data: dict) -> dict:
         else pattern
     )
 
-    return file_index.find_files(base_directory, file_pattern, recursive, all_drives)
+    return file_index.find_files(
+        base_directory, file_pattern, recursive, all_drives, limit
+    )
 
 
 @action(
@@ -129,6 +115,11 @@ def find_file_by_name(input_data: dict) -> dict:
             "type": "boolean",
             "example": False,
             "description": "If true, search every local fixed drive in one call instead of just base_directory (which is then ignored). Use this instead of calling find_files once per drive.",
+        },
+        "limit": {
+            "type": "integer",
+            "example": 500,
+            "description": "Optional cap on the total number of matches returned across all searched roots. Useful with all_drives or broad patterns to avoid extremely large result sets. Default: unbounded.",
         },
     },
     output_schema={
@@ -159,6 +150,7 @@ def find_file_by_name_windows(input_data: dict) -> dict:
     recursive = bool(input_data.get("recursive", True))
     all_drives = bool(input_data.get("all_drives", False))
     base_directory = (input_data.get("base_directory") or "").strip()
+    limit = input_data.get("limit")
 
     if not pattern:
         return {"status": "error", "matches": [], "message": "Pattern is required."}
@@ -166,34 +158,10 @@ def find_file_by_name_windows(input_data: dict) -> dict:
     if all_drives:
         base_directory = ""
     else:
-        # Default to user's home directory if not provided
-        if not base_directory:
-            base_directory = os.path.expanduser("~")
-
-        # base_directory may hold multiple '|'-joined roots; validate each.
-        roots = [part.strip() for part in base_directory.split("|") if part.strip()]
-        normalized_roots = []
-        for root in roots:
-            # Windows-friendly normalization
-            root = root.replace("/", "\\")
-            root = os.path.normpath(os.path.expanduser(root))
-
-            if not os.path.exists(root):
-                return {
-                    "status": "error",
-                    "matches": [],
-                    "message": f"Base directory does not exist: {root}",
-                }
-
-            if not os.path.isdir(root):
-                return {
-                    "status": "error",
-                    "matches": [],
-                    "message": f"Base directory is not a directory: {root}",
-                }
-
-            normalized_roots.append(root)
-        base_directory = "|".join(normalized_roots)
+        roots, error = file_index.resolve_roots(base_directory, windows=True)
+        if error:
+            return error
+        base_directory = "|".join(roots)
 
     pattern = pattern.replace("/", "\\")
     pattern = os.path.expanduser(pattern)
@@ -206,4 +174,6 @@ def find_file_by_name_windows(input_data: dict) -> dict:
         else pattern
     )
 
-    return file_index.find_files(base_directory, file_pattern, recursive, all_drives)
+    return file_index.find_files(
+        base_directory, file_pattern, recursive, all_drives, limit
+    )

--- a/app/data/action/find_files.py
+++ b/app/data/action/find_files.py
@@ -2,19 +2,19 @@ from agent_core import action
 
 
 def _find_files_impl(base_directory: str, file_pattern: str, recursive: bool) -> dict:
-    import glob
     import os
 
     from app.utils import file_index
 
+    file_index.start_watcher(base_directory)
+    matches = file_index.search(base_directory, file_pattern)
     if not recursive:
-        matches = []
-        for path in glob.glob(os.path.join(base_directory, file_pattern)):
-            if os.path.isfile(path):
-                matches.append(os.path.abspath(path))
-    else:
-        file_index.start_watcher(base_directory)
-        matches = file_index.search(base_directory, file_pattern)
+        base_abs = os.path.abspath(base_directory)
+        matches = [
+            path
+            for path in matches
+            if os.path.normcase(os.path.dirname(path)) == os.path.normcase(base_abs)
+        ]
 
     return {
         "status": "success",

--- a/app/data/action/find_files.py
+++ b/app/data/action/find_files.py
@@ -31,7 +31,7 @@ from agent_core import action
         "limit": {
             "type": "integer",
             "example": 500,
-            "description": "Optional cap on the total number of matches returned across all searched roots. Useful with all_drives or broad patterns to avoid extremely large result sets. Default: unbounded.",
+            "description": "Optional cap on the total number of matches returned across all searched roots. Useful with all_drives or broad patterns to avoid extremely large result sets. Pass 0 or omit for unlimited.",
         },
     },
     output_schema={
@@ -119,7 +119,7 @@ def find_file_by_name(input_data: dict) -> dict:
         "limit": {
             "type": "integer",
             "example": 500,
-            "description": "Optional cap on the total number of matches returned across all searched roots. Useful with all_drives or broad patterns to avoid extremely large result sets. Default: unbounded.",
+            "description": "Optional cap on the total number of matches returned across all searched roots. Useful with all_drives or broad patterns to avoid extremely large result sets. Pass 0 or omit for unlimited.",
         },
     },
     output_schema={

--- a/app/data/action/find_files.py
+++ b/app/data/action/find_files.py
@@ -1,6 +1,30 @@
 from agent_core import action
 
 
+def _find_files_impl(base_directory: str, file_pattern: str, recursive: bool) -> dict:
+    import glob
+    import os
+
+    from app.utils import file_index
+
+    if not recursive:
+        matches = []
+        for path in glob.glob(os.path.join(base_directory, file_pattern)):
+            if os.path.isfile(path):
+                matches.append(os.path.abspath(path))
+    else:
+        file_index.start_watcher(base_directory)
+        matches = file_index.search(base_directory, file_pattern)
+
+    return {
+        "status": "success",
+        "matches": matches,
+        "message": ""
+        if matches
+        else f"No files matching '{file_pattern}' were found in '{base_directory}'.",
+    }
+
+
 @action(
     name="find_files",
     description="Finds files by name or pattern across the system. Supports wildcards and recursive search. Use absolute paths for base_directory.",
@@ -45,7 +69,6 @@ from agent_core import action
 )
 def find_file_by_name(input_data: dict) -> dict:
     import os
-    import fnmatch
 
     pattern = (input_data.get("pattern") or "").strip()
     recursive = bool(input_data.get("recursive", True))
@@ -85,26 +108,7 @@ def find_file_by_name(input_data: dict) -> dict:
         else pattern
     )
 
-    matches = []
-    for root, dirs, files in os.walk(base_directory):
-        try:
-            for name in files:
-                if fnmatch.fnmatch(name, file_pattern):
-                    matches.append(os.path.abspath(os.path.join(root, name)))
-        except PermissionError:
-            # Skip directories we don't have access to
-            continue
-
-        if not recursive:
-            break
-
-    return {
-        "status": "success",
-        "matches": matches,
-        "message": ""
-        if matches
-        else f"No files matching '{file_pattern}' were found in '{base_directory}'.",
-    }
+    return _find_files_impl(base_directory, file_pattern, recursive)
 
 
 @action(
@@ -151,7 +155,6 @@ def find_file_by_name(input_data: dict) -> dict:
 )
 def find_file_by_name_windows(input_data: dict) -> dict:
     import os
-    import fnmatch
 
     pattern = (input_data.get("pattern") or "").strip()
     recursive = bool(input_data.get("recursive", True))
@@ -194,22 +197,4 @@ def find_file_by_name_windows(input_data: dict) -> dict:
         else pattern
     )
 
-    matches = []
-    for root, dirs, files in os.walk(base_directory):
-        try:
-            for name in files:
-                if fnmatch.fnmatch(name, file_pattern):
-                    matches.append(os.path.abspath(os.path.join(root, name)))
-        except PermissionError:
-            continue
-
-        if not recursive:
-            break
-
-    return {
-        "status": "success",
-        "matches": matches,
-        "message": ""
-        if matches
-        else f"No files matching '{file_pattern}' were found in '{base_directory}'.",
-    }
+    return _find_files_impl(base_directory, file_pattern, recursive)

--- a/app/data/action/find_files.py
+++ b/app/data/action/find_files.py
@@ -1,30 +1,6 @@
 from agent_core import action
 
 
-def _find_files_impl(base_directory: str, file_pattern: str, recursive: bool) -> dict:
-    import os
-
-    from app.utils import file_index
-
-    file_index.start_watcher(base_directory)
-    matches = file_index.search(base_directory, file_pattern)
-    if not recursive:
-        base_abs = os.path.abspath(base_directory)
-        matches = [
-            path
-            for path in matches
-            if os.path.normcase(os.path.dirname(path)) == os.path.normcase(base_abs)
-        ]
-
-    return {
-        "status": "success",
-        "matches": matches,
-        "message": ""
-        if matches
-        else f"No files matching '{file_pattern}' were found in '{base_directory}'.",
-    }
-
-
 @action(
     name="find_files",
     description="Finds files by name or pattern across the system. Supports wildcards and recursive search. Use absolute paths for base_directory.",
@@ -35,7 +11,7 @@ def _find_files_impl(base_directory: str, file_pattern: str, recursive: bool) ->
         "pattern": {
             "type": "string",
             "example": "*.pdf",
-            "description": "The file name or glob pattern to match. Supports wildcards like * and ?",
+            "description": "The file name or glob pattern to match. Supports wildcards like * and ?. To match any of several patterns in a single call, join them with '|' or ' OR ' instead of calling find_files multiple times, e.g. '*craftbot*|*craftos*' or '*.jpg OR *.png'.",
         },
         "recursive": {
             "type": "boolean",
@@ -45,7 +21,12 @@ def _find_files_impl(base_directory: str, file_pattern: str, recursive: bool) ->
         "base_directory": {
             "type": "string",
             "example": "/home/user/Documents",
-            "description": "Absolute path to the base directory to start searching from. Use full absolute paths (e.g., /home/user/Documents or /Users/name/Desktop).",
+            "description": "Absolute path to the base directory to start searching from. Use full absolute paths (e.g., /home/user/Documents or /Users/name/Desktop). To search multiple roots in one call, join them with '|' (e.g. '/home/user|/mnt/data'). Ignored if all_drives is true.",
+        },
+        "all_drives": {
+            "type": "boolean",
+            "example": False,
+            "description": "If true, search every local fixed drive/mount in one call instead of just base_directory (which is then ignored). Use this instead of calling find_files once per drive.",
         },
     },
     output_schema={
@@ -70,34 +51,45 @@ def _find_files_impl(base_directory: str, file_pattern: str, recursive: bool) ->
 def find_file_by_name(input_data: dict) -> dict:
     import os
 
+    from app.utils import file_index
+
     pattern = (input_data.get("pattern") or "").strip()
     recursive = bool(input_data.get("recursive", True))
+    all_drives = bool(input_data.get("all_drives", False))
     base_directory = (input_data.get("base_directory") or "").strip()
 
     if not pattern:
         return {"status": "error", "matches": [], "message": "Pattern is required."}
 
-    # Default to user's home directory if not provided
-    if not base_directory:
-        base_directory = os.path.expanduser("~")
+    if all_drives:
+        base_directory = ""
+    else:
+        # Default to user's home directory if not provided
+        if not base_directory:
+            base_directory = os.path.expanduser("~")
 
-    # Expand ~ and normalize base directory
-    base_directory = os.path.expanduser(base_directory)
-    base_directory = os.path.normpath(base_directory)
+        # base_directory may hold multiple '|'-joined roots; validate each.
+        roots = [part.strip() for part in base_directory.split("|") if part.strip()]
+        normalized_roots = []
+        for root in roots:
+            root = os.path.normpath(os.path.expanduser(root))
 
-    if not os.path.exists(base_directory):
-        return {
-            "status": "error",
-            "matches": [],
-            "message": f"Base directory does not exist: {base_directory}",
-        }
+            if not os.path.exists(root):
+                return {
+                    "status": "error",
+                    "matches": [],
+                    "message": f"Base directory does not exist: {root}",
+                }
 
-    if not os.path.isdir(base_directory):
-        return {
-            "status": "error",
-            "matches": [],
-            "message": f"Base directory is not a directory: {base_directory}",
-        }
+            if not os.path.isdir(root):
+                return {
+                    "status": "error",
+                    "matches": [],
+                    "message": f"Base directory is not a directory: {root}",
+                }
+
+            normalized_roots.append(root)
+        base_directory = "|".join(normalized_roots)
 
     # Normalize the pattern (if user passes a path, only use its basename as the match pattern)
     pattern = os.path.expanduser(pattern)
@@ -108,7 +100,7 @@ def find_file_by_name(input_data: dict) -> dict:
         else pattern
     )
 
-    return _find_files_impl(base_directory, file_pattern, recursive)
+    return file_index.find_files(base_directory, file_pattern, recursive, all_drives)
 
 
 @action(
@@ -121,7 +113,7 @@ def find_file_by_name(input_data: dict) -> dict:
         "pattern": {
             "type": "string",
             "example": "*.pdf",
-            "description": "The file name or glob pattern to match. Supports wildcards like * and ?",
+            "description": "The file name or glob pattern to match. Supports wildcards like * and ?. To match any of several patterns in a single call, join them with '|' or ' OR ' instead of calling find_files multiple times, e.g. '*craftbot*|*craftos*' or '*.jpg OR *.png'.",
         },
         "recursive": {
             "type": "boolean",
@@ -131,7 +123,12 @@ def find_file_by_name(input_data: dict) -> dict:
         "base_directory": {
             "type": "string",
             "example": "C:/Users/user/Documents",
-            "description": "Absolute path to the base directory to start searching from. Use full absolute paths (e.g., C:/Users/user/Documents or D:/Projects).",
+            "description": "Absolute path to the base directory to start searching from. Use full absolute paths (e.g., C:/Users/user/Documents or D:/Projects). To search multiple drives/roots in one call, join them with '|' (e.g. 'C:/|D:/'). Ignored if all_drives is true.",
+        },
+        "all_drives": {
+            "type": "boolean",
+            "example": False,
+            "description": "If true, search every local fixed drive in one call instead of just base_directory (which is then ignored). Use this instead of calling find_files once per drive.",
         },
     },
     output_schema={
@@ -156,35 +153,47 @@ def find_file_by_name(input_data: dict) -> dict:
 def find_file_by_name_windows(input_data: dict) -> dict:
     import os
 
+    from app.utils import file_index
+
     pattern = (input_data.get("pattern") or "").strip()
     recursive = bool(input_data.get("recursive", True))
+    all_drives = bool(input_data.get("all_drives", False))
     base_directory = (input_data.get("base_directory") or "").strip()
 
     if not pattern:
         return {"status": "error", "matches": [], "message": "Pattern is required."}
 
-    # Default to user's home directory if not provided
-    if not base_directory:
-        base_directory = os.path.expanduser("~")
+    if all_drives:
+        base_directory = ""
+    else:
+        # Default to user's home directory if not provided
+        if not base_directory:
+            base_directory = os.path.expanduser("~")
 
-    # Windows-friendly normalization
-    base_directory = base_directory.replace("/", "\\")
-    base_directory = os.path.expanduser(base_directory)
-    base_directory = os.path.normpath(base_directory)
+        # base_directory may hold multiple '|'-joined roots; validate each.
+        roots = [part.strip() for part in base_directory.split("|") if part.strip()]
+        normalized_roots = []
+        for root in roots:
+            # Windows-friendly normalization
+            root = root.replace("/", "\\")
+            root = os.path.normpath(os.path.expanduser(root))
 
-    if not os.path.exists(base_directory):
-        return {
-            "status": "error",
-            "matches": [],
-            "message": f"Base directory does not exist: {base_directory}",
-        }
+            if not os.path.exists(root):
+                return {
+                    "status": "error",
+                    "matches": [],
+                    "message": f"Base directory does not exist: {root}",
+                }
 
-    if not os.path.isdir(base_directory):
-        return {
-            "status": "error",
-            "matches": [],
-            "message": f"Base directory is not a directory: {base_directory}",
-        }
+            if not os.path.isdir(root):
+                return {
+                    "status": "error",
+                    "matches": [],
+                    "message": f"Base directory is not a directory: {root}",
+                }
+
+            normalized_roots.append(root)
+        base_directory = "|".join(normalized_roots)
 
     pattern = pattern.replace("/", "\\")
     pattern = os.path.expanduser(pattern)
@@ -197,4 +206,4 @@ def find_file_by_name_windows(input_data: dict) -> dict:
         else pattern
     )
 
-    return _find_files_impl(base_directory, file_pattern, recursive)
+    return file_index.find_files(base_directory, file_pattern, recursive, all_drives)

--- a/app/data/agent_file_system_template/AGENT.md
+++ b/app/data/agent_file_system_template/AGENT.md
@@ -1,5 +1,5 @@
 ---
-version: 4
+version: 6
 purpose: agent operations manual
 ---
 
@@ -841,6 +841,8 @@ When you see that, the real content is in the file at `<path>`. Retrieve it the 
 ### find_files vs list_folder
 - `list_folder`: top-level listing of a single directory.
 - `find_files`: recursive name pattern search across a tree.
+- Searching for several related name variants (e.g. "craftbot" or "craftos")? Combine them into ONE `find_files` call with `|` or `OR` in `pattern` (e.g. `*craftbot*|*craftos*`) instead of issuing multiple parallel `find_files` calls for the same base_directory.
+- Searching multiple drives/roots (e.g. C: and D:)? Same rule applies: join them with `|` in `base_directory` (e.g. `C:/|D:/`), or pass `all_drives=true` to search every local fixed drive in one call — do not fire one `find_files` call per drive.
 
 ### convert_to_markdown vs read_pdf
 - `read_pdf`: direct PDF reading with page support. By default it returns just the text/tables (lean, to save context); pass `include_metadata=true` for page count and engine info, or `mode="layout"` when you need per-word positions for a spatial/edit task.

--- a/app/updater.py
+++ b/app/updater.py
@@ -245,12 +245,20 @@ async def _run_git(
     env = os.environ.copy()
     env.setdefault("GIT_TERMINAL_PROMPT", "0")
 
+    kwargs = {}
+    if sys.platform == "win32":
+        # Without this, spawning git.exe from this windowless process makes
+        # Windows flash a new console window per invocation (visible to the
+        # user every time an update check runs, e.g. on Settings page load).
+        kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
+
     proc = await asyncio.create_subprocess_exec(
         *cmd,
         cwd=cwd,
         env=env,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
+        **kwargs,
     )
     try:
         stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)

--- a/app/updater.py
+++ b/app/updater.py
@@ -38,49 +38,128 @@ def is_newer(remote: str, local: str) -> bool:
 # ---------------------------------------------------------------------------
 
 GITHUB_REPO = "CraftOS-dev/CraftBot"
-GITHUB_LATEST_RELEASE_URL = f"https://api.github.com/repos/{GITHUB_REPO}/tags"
+GITHUB_TAGS_URL = f"https://api.github.com/repos/{GITHUB_REPO}/tags"
+GITHUB_LATEST_RELEASE_URL = GITHUB_TAGS_URL
+UPDATE_BRANCH = "main"
+GIT_PROBE_TIMEOUT = 15
 
 
 async def check_for_update() -> Tuple[bool, str, str]:
     """Check whether a newer version is available on the remote repo.
 
-    Fetches the latest git tag from GitHub (e.g. ``v1.2.2``) and compares
-    it against the local version stored in settings.json.
+    Source checkouts can be ahead or behind the update branch while still
+    carrying the same tagged app version. Keep the release tag as the primary
+    version signal, then use a git comparison to catch source-checkout updates
+    when the release tag is unchanged.
 
     Returns:
         (update_available, current_version, latest_version)
     """
     from app.config import get_app_version
 
+    current = get_app_version()
+    project_root = Path(__file__).resolve().parent.parent
+
+    release_update = await _check_release_update(current)
+    if release_update[0]:
+        return release_update
+
+    source_update = await _check_source_update(project_root, current)
+    if source_update is not None:
+        return source_update
+
+    return release_update
+
+
+async def _check_source_update(
+    project_root: Path,
+    current: str,
+    branch: str = UPDATE_BRANCH,
+) -> Optional[Tuple[bool, str, str]]:
+    """Check whether this git checkout is behind the configured update branch.
+
+    Returns ``None`` when the probe is inconclusive so callers can fall back to
+    the release-tag check instead of blocking update checks on git-specific
+    failures.
+    """
+    if getattr(sys, "frozen", False):
+        return None
+
+    try:
+        inside, _ = await _run_git(
+            ["git", "rev-parse", "--is-inside-work-tree"], str(project_root)
+        )
+        if _decode_git_stdout(inside) != "true":
+            return None
+
+        await _run_git(
+            ["git", "fetch", "origin", f"{branch}:refs/remotes/origin/{branch}"],
+            str(project_root),
+        )
+        local_stdout, _ = await _run_git(
+            ["git", "rev-parse", "HEAD"], str(project_root)
+        )
+        remote_stdout, _ = await _run_git(
+            ["git", "rev-parse", f"origin/{branch}"], str(project_root)
+        )
+
+        local_revision = _decode_git_stdout(local_stdout)
+        remote_revision = _decode_git_stdout(remote_stdout)
+        if not local_revision or not remote_revision:
+            return None
+        if local_revision == remote_revision:
+            return False, current, current
+
+        count_stdout, _ = await _run_git(
+            [
+                "git",
+                "rev-list",
+                "--left-right",
+                "--count",
+                f"HEAD...origin/{branch}",
+            ],
+            str(project_root),
+        )
+        _ahead_text, behind_text = _decode_git_stdout(count_stdout).split()
+        behind = int(behind_text)
+        if behind > 0:
+            latest = f"{current}+{branch}.{remote_revision[:7]}"
+            return True, current, latest
+
+        return False, current, current
+    except Exception:
+        return None
+
+
+async def _check_release_update(current: str) -> Tuple[bool, str, str]:
+    """Check GitHub release tags against the local app version."""
     import aiohttp
 
-    current = get_app_version()
     try:
         headers = {"Accept": "application/vnd.github.v3+json"}
         async with aiohttp.ClientSession() as session:
             async with session.get(
-                GITHUB_LATEST_RELEASE_URL,
+                GITHUB_TAGS_URL,
                 headers=headers,
                 timeout=aiohttp.ClientTimeout(total=15),
             ) as resp:
                 tags = await resp.json(content_type=None)
-
-        if not tags or not isinstance(tags, list):
-            return False, current, current
-
-        # Find the highest semver tag (tags are not guaranteed sorted)
-        latest = "0.0.0"
-        for tag in tags:
-            name = tag.get("name", "")
-            try:
-                if parse_version(name) > parse_version(latest):
-                    latest = name.strip().lstrip("vV")
-            except (ValueError, AttributeError):
-                continue
-
     except Exception:
-        # Network error — treat as "no update available"
+        # Network error — treat as "no update available".
         return False, current, current
+
+    if not tags or not isinstance(tags, list):
+        return False, current, current
+
+    # Find the highest semver tag. GitHub tags are not guaranteed sorted.
+    latest = "0.0.0"
+    for tag in tags:
+        name = tag.get("name", "")
+        try:
+            if parse_version(name) > parse_version(latest):
+                latest = name.strip().lstrip("vV")
+        except (ValueError, AttributeError):
+            continue
 
     return is_newer(latest, current), current, latest
 
@@ -95,14 +174,12 @@ RESTART_EXIT_CODE = 42
 async def perform_update(
     progress_callback: Optional[Callable[[str], Awaitable[None]]] = None,
 ) -> None:
-    """Launch the external updater script in a new window, then shut down.
+    """Launch the external updater script, then shut down.
 
-    The updater script (scripts/updater.bat on Windows) runs in its own
-    visible terminal and handles: waiting for us to exit, git pull, install,
-    and relaunch. This keeps the update logic out of the running Python
-    process — no in-process git mutation, no exit-code signalling, no
-    console-visibility hacks. If the updater fails, its window stays open
-    showing the error.
+    The script waits for CraftBot to exit, pulls the update branch, installs
+    dependencies, and relaunches CraftBot. Running that work outside this
+    process avoids in-process git mutation and exit-code signalling. Failures
+    are written to updater.log.
     """
 
     async def emit(msg: str) -> None:
@@ -111,12 +188,8 @@ async def perform_update(
 
     project_root = Path(__file__).resolve().parent.parent
 
-    target_branch = "main"
-
-    if sys.platform == "win32":
-        updater_script = project_root / "scripts" / "updater.bat"
-    else:
-        updater_script = project_root / "scripts" / "updater.sh"
+    target_branch = UPDATE_BRANCH
+    updater_script = _updater_script_path(project_root)
 
     if not updater_script.exists():
         raise RuntimeError(f"Updater script not found: {updater_script}")
@@ -131,14 +204,14 @@ async def perform_update(
         CREATE_NO_WINDOW = 0x08000000
         DETACHED_PROCESS = 0x00000008
         subprocess.Popen(
-            [str(updater_script), target_branch],
+            [str(updater_script), target_branch, sys.executable],
             cwd=str(project_root),
             creationflags=DETACHED_PROCESS | CREATE_NO_WINDOW,
             close_fds=True,
         )
     else:
         subprocess.Popen(
-            ["sh", str(updater_script), target_branch],
+            ["sh", str(updater_script), target_branch, sys.executable],
             cwd=str(project_root),
             start_new_session=True,
         )
@@ -155,15 +228,39 @@ async def perform_update(
 # ---------------------------------------------------------------------------
 
 
-async def _run_git(cmd: list, cwd: str) -> Tuple[bytes, bytes]:
+def _decode_git_stdout(stdout: bytes) -> str:
+    return stdout.decode("utf-8", errors="replace").strip()
+
+
+def _updater_script_path(project_root: Path, platform: str = sys.platform) -> Path:
+    if platform == "win32":
+        return project_root / "scripts" / "updater.bat"
+    return project_root / "scripts" / "updater.sh"
+
+
+async def _run_git(
+    cmd: list, cwd: str, timeout: int = GIT_PROBE_TIMEOUT
+) -> Tuple[bytes, bytes]:
     """Run a git command asynchronously; raise on non-zero exit."""
+    env = os.environ.copy()
+    env.setdefault("GIT_TERMINAL_PROMPT", "0")
+
     proc = await asyncio.create_subprocess_exec(
         *cmd,
         cwd=cwd,
+        env=env,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
-    stdout, stderr = await proc.communicate()
+    try:
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except asyncio.TimeoutError as exc:
+        proc.kill()
+        stdout, stderr = await proc.communicate()
+        raise RuntimeError(
+            f"{' '.join(cmd)} timed out after {timeout} seconds"
+        ) from exc
+
     if proc.returncode != 0:
         err = (
             stderr.decode("utf-8", errors="replace").strip()

--- a/app/utils/file_index.py
+++ b/app/utils/file_index.py
@@ -12,6 +12,7 @@ import fnmatch
 import os
 import re
 import sqlite3
+import stat
 import threading
 import time
 from dataclasses import dataclass
@@ -38,9 +39,19 @@ _SKIP_DIR_NAMES = {
     ".craftbot",
     "node_modules",
     ".git",
+    ".svn",
+    ".hg",
     "__pycache__",
     "venv",
     ".venv",
+    ".env",
+    ".tox",
+    ".mypy_cache",
+    ".pytest_cache",
+    "dist",
+    "build",
+    ".idea",
+    ".vscode",
     "$recycle.bin",
     "system volume information",
 }
@@ -55,8 +66,21 @@ _watchers: dict[str, _RootWatcher] = {}
 # entry means "no known pending changes" (build_index can use the cheap
 # cached-count path). A non-empty entry lets build_index apply just those
 # paths (_apply_targeted_changes) instead of re-walking the entire tree.
+#
+# _needs_full_rewalk holds roots where a directory-level event (rename,
+# move, delete of a whole subtree) was observed. A single directory event
+# doesn't tell us which of its descendants changed, so those roots fall
+# back to one full _incremental_update pass instead of a targeted one.
+#
+# _verified_roots holds roots that have had at least one real check (full
+# crawl or incremental/targeted pass) *in this process*. Without it, a
+# freshly restarted process with an existing, matching, non-empty index
+# and no recorded pending changes would trust that index as fresh even
+# though real changes may have happened while the process was down.
 _pending_changes_lock = threading.Lock()
 _pending_changes: dict[str, set[str]] = {}
+_needs_full_rewalk: set[str] = set()
+_verified_roots: set[str] = set()
 
 
 def _get_build_lock(root: str) -> threading.Lock:
@@ -71,10 +95,16 @@ def _get_build_lock(root: str) -> threading.Lock:
 
 
 def _is_skip_path(path: str) -> bool:
-    """True if *path* has a _SKIP_DIR_NAMES component anywhere in it."""
-    normalized = os.path.normcase(path)
-    parts = normalized.replace("/", os.sep).split(os.sep)
-    return any(part in _SKIP_DIR_NAMES for part in parts)
+    """True if *path* has a _SKIP_DIR_NAMES component anywhere in it.
+
+    Lowercases explicitly rather than relying on os.path.normcase, which is
+    only case-insensitive on Windows (a no-op on POSIX) — this must match
+    _iter_files' always-case-insensitive entry.name.lower() check on every
+    platform, or a mixed-case noise directory would be excluded from the
+    crawl but not from watcher events on Linux/macOS.
+    """
+    parts = path.replace("\\", "/").split("/")
+    return any(part.lower() in _SKIP_DIR_NAMES for part in parts)
 
 
 @dataclass
@@ -213,10 +243,13 @@ def build_index(root: str, force: bool = False) -> IndexStats:
                 and os.path.normcase(stored_root[0]) == os.path.normcase(root)
             )
 
+            key = os.path.normcase(root)
+
             if (
                 not force
                 and has_rows
                 and root_matches_stored
+                and key in _verified_roots
                 and not _peek_has_pending_changes(root)
             ):
                 total = conn.execute("SELECT COUNT(*) FROM files").fetchone()[0]
@@ -231,13 +264,18 @@ def build_index(root: str, force: bool = False) -> IndexStats:
             if not force and has_rows and root_matches_stored:
                 # A non-empty pending set (reported directly by this root's
                 # watcher) lets us apply just those paths — O(changes), not
-                # O(total files indexed). Only fall back to the full re-walk
-                # when we have no such record (e.g. no watcher running yet).
-                pending = _pop_pending_changes(root)
-                if pending:
-                    stats = _apply_targeted_changes(conn, root, pending)
-                else:
+                # O(total files indexed). Fall back to the full re-walk when
+                # a directory-level event was seen (a single event doesn't
+                # tell us which descendants changed) or when this root has
+                # no verified state yet in this process (e.g. right after a
+                # restart, before any watcher has run — an empty pending set
+                # there must not be mistaken for "nothing changed").
+                pending, needs_full = _pop_pending_changes(root)
+                if needs_full or key not in _verified_roots or not pending:
                     stats = _incremental_update(conn, root)
+                else:
+                    stats = _apply_targeted_changes(conn, root, pending)
+                _verified_roots.add(key)
                 conn.execute(
                     "INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)",
                     (_META_BUILT_AT, str(time.time())),
@@ -256,6 +294,7 @@ def build_index(root: str, force: bool = False) -> IndexStats:
             # FTS index in one pass at the end (standard FTS5 external-content
             # bulk-load pattern). _init_schema recreates the triggers after.
             _pop_pending_changes(root)  # full crawl already reflects current state
+            _verified_roots.add(key)
             conn.execute("DROP TRIGGER IF EXISTS files_ai")
             conn.execute("DROP TRIGGER IF EXISTS files_ad")
             conn.execute("DROP TRIGGER IF EXISTS files_au")
@@ -353,20 +392,30 @@ def _incremental_update(
             removed += 1
 
     conn.commit()
-    total = conn.execute("SELECT COUNT(*) FROM files").fetchone()[0]
-    return total, added, updated, removed
+    # files_indexed is discarded by every caller — see _apply_targeted_changes.
+    return -1, added, updated, removed
 
 
 def _peek_has_pending_changes(root: str) -> bool:
     key = os.path.normcase(root)
     with _pending_changes_lock:
-        return bool(_pending_changes.get(key))
+        return bool(_pending_changes.get(key)) or key in _needs_full_rewalk
 
 
-def _pop_pending_changes(root: str) -> set[str]:
+def _pop_pending_changes(root: str) -> tuple[set[str], bool]:
+    """Clear and return (changed_paths, needs_full_rewalk) for *root*."""
     key = os.path.normcase(root)
     with _pending_changes_lock:
-        return _pending_changes.pop(key, set())
+        paths = _pending_changes.pop(key, set())
+        needs_full = key in _needs_full_rewalk
+        _needs_full_rewalk.discard(key)
+        return paths, needs_full
+
+
+def _mark_needs_full_rewalk(root: str) -> None:
+    key = os.path.normcase(root)
+    with _pending_changes_lock:
+        _needs_full_rewalk.add(key)
 
 
 def _apply_targeted_changes(
@@ -381,8 +430,14 @@ def _apply_targeted_changes(
     added = updated = removed = 0
     for path in changed_paths:
         try:
+            # lstat (not following symlinks) so a symlink is never indexed
+            # here as a "file" — matches _iter_files/_full_crawl, which
+            # also never treats symlinks as files. Deriving is_file from
+            # this same stat (rather than a separate os.path.isfile call,
+            # which *does* follow symlinks) keeps the two code paths from
+            # disagreeing about what counts as an indexable file.
             st = os.stat(path, follow_symlinks=False)
-            is_file = os.path.isfile(path)
+            is_file = stat.S_ISREG(st.st_mode)
         except OSError:
             st = None
             is_file = False
@@ -412,8 +467,9 @@ def _apply_targeted_changes(
             updated += 1
 
     conn.commit()
-    total = conn.execute("SELECT COUNT(*) FROM files").fetchone()[0]
-    return total, added, updated, removed
+    # files_indexed is discarded by every caller (search(), _flush()) — skip
+    # the O(total rows) COUNT(*) a real total would cost on every flush.
+    return -1, added, updated, removed
 
 
 def _fts_prefilter_sql(pattern: str) -> tuple[str, list[str]] | None:
@@ -518,11 +574,60 @@ def list_local_drives() -> list[str]:
     return drives
 
 
+def resolve_roots(
+    base_directory: str, windows: bool = False
+) -> tuple[list[str], dict | None]:
+    """Validate and normalize a possibly '|'-joined base_directory string.
+
+    Shared by both find_files action variants (posix/windows) via module
+    import — same reasoning as find_files' docstring below: a same-module
+    sibling helper in the action file itself would not be resolvable under
+    the sandboxed exec model those actions run under.
+
+    Returns (roots, None) on success, or ([], error_dict) if base_directory
+    is empty/only separators/whitespace, or any listed root doesn't exist
+    or isn't a directory.
+    """
+    if not base_directory:
+        base_directory = os.path.expanduser("~")
+
+    raw_roots = [part.strip() for part in base_directory.split("|") if part.strip()]
+    if not raw_roots:
+        return [], {
+            "status": "error",
+            "matches": [],
+            "message": "base_directory must contain at least one non-empty path.",
+        }
+
+    roots = []
+    for root in raw_roots:
+        if windows:
+            root = root.replace("/", "\\")
+        root = os.path.normpath(os.path.expanduser(root))
+
+        if not os.path.exists(root):
+            return [], {
+                "status": "error",
+                "matches": [],
+                "message": f"Base directory does not exist: {root}",
+            }
+        if not os.path.isdir(root):
+            return [], {
+                "status": "error",
+                "matches": [],
+                "message": f"Base directory is not a directory: {root}",
+            }
+        roots.append(root)
+
+    return roots, None
+
+
 def find_files(
     base_directory: str,
     file_pattern: str,
     recursive: bool,
     all_drives: bool = False,
+    limit: int | None = None,
 ) -> dict:
     """Search one or more roots for basenames matching *file_pattern*.
 
@@ -534,7 +639,8 @@ def find_files(
 
     *base_directory* may contain multiple absolute paths joined by '|' to
     search several roots in one call. If *all_drives* is True, *base_directory*
-    is ignored and every local fixed drive is searched instead.
+    is ignored and every local fixed drive is searched instead. *limit*, if
+    given, caps the total number of matches across all roots combined.
     """
     if all_drives:
         roots = list_local_drives()
@@ -563,6 +669,10 @@ def find_files(
             if path not in seen:
                 seen.add(path)
                 matches.append(path)
+                if limit is not None and len(matches) >= limit:
+                    break
+        if limit is not None and len(matches) >= limit:
+            break
 
     scope = ", ".join(roots) if roots else base_directory
     return {
@@ -617,12 +727,19 @@ class _RootWatcher:
         self._is_running = True
         return True
 
-    def _on_change(self, path: str, _event_type: str) -> None:
+    def _on_change(self, path: str, event_type: str) -> None:
         if _is_skip_path(path):
             return
-        key = os.path.normcase(self.root)
-        with _pending_changes_lock:
-            _pending_changes.setdefault(key, set()).add(path)
+        if event_type == "dir_changed":
+            # A single directory-level event (rename/move/delete of a whole
+            # subtree) doesn't tell us which descendants changed — the next
+            # build_index() pass does one full re-walk for this root instead
+            # of trusting an incomplete targeted-changes set.
+            _mark_needs_full_rewalk(self.root)
+        else:
+            key = os.path.normcase(self.root)
+            with _pending_changes_lock:
+                _pending_changes.setdefault(key, set()).add(path)
         with self._lock:
             self._pending = True
             if self._debounce_timer:
@@ -645,19 +762,36 @@ class _IndexEventHandler(FileSystemEventHandler):
         self._callback = callback
 
     def on_created(self, event) -> None:
+        # A newly created directory has no stale descendants to reconcile —
+        # files created inside it later fire their own normal per-path
+        # events — so this isn't treated as a structural "dir_changed"
+        # event. Only a directory *move/rename* gets that treatment (see
+        # on_moved): that's the one case with no per-descendant events.
         if not event.is_directory:
             self._callback(event.src_path, "created")
 
     def on_modified(self, event) -> None:
+        # Directory "modified" events don't reliably signal an added/removed
+        # descendant (they can fire for metadata-only changes too), so they
+        # aren't treated as structural — only a directory move/rename is.
         if not event.is_directory:
             self._callback(event.src_path, "modified")
 
     def on_deleted(self, event) -> None:
+        # A deleted directory's contents already generate their own
+        # per-file delete events in the common case (recursive delete, or
+        # Explorer moving it to $RECYCLE.BIN as an on_moved) — the
+        # directory-level event itself adds no new information, so it's
+        # not treated as structural here either.
         if not event.is_directory:
             self._callback(event.src_path, "deleted")
 
     def on_moved(self, event) -> None:
         if event.is_directory:
+            # The one case that genuinely needs whole-subtree reconciliation:
+            # a rename/move doesn't generate per-descendant events, so we
+            # can't know what changed underneath without a real re-walk.
+            self._callback(event.src_path, "dir_changed")
             return
         self._callback(event.src_path, "deleted")
         if event.dest_path:

--- a/app/utils/file_index.py
+++ b/app/utils/file_index.py
@@ -9,6 +9,7 @@ directories (VCS metadata, dependency/build caches, OS reserved folders).
 from __future__ import annotations
 
 import fnmatch
+import hashlib
 import os
 import re
 import sqlite3
@@ -16,6 +17,8 @@ import stat
 import threading
 import time
 from dataclasses import dataclass
+
+from app.config import APP_DATA_PATH
 
 try:
     from watchdog.events import FileSystemEventHandler
@@ -54,6 +57,9 @@ _SKIP_DIR_NAMES = {
     ".vscode",
     "$recycle.bin",
     "system volume information",
+    ".trash",
+    ".trashes",
+    "lost+found",
 }
 
 _build_locks_registry_lock = threading.Lock()
@@ -116,8 +122,30 @@ class IndexStats:
     duration_seconds: float
 
 
+_INDEX_STORAGE_ROOT = os.path.join(str(APP_DATA_PATH), ".file_index")
+
+
 def _index_dir(root: str) -> str:
-    return os.path.join(os.path.abspath(root), ".craftbot")
+    """Per-root index directory, centralized under CraftBot's own app-data
+    directory rather than inside the searched root itself.
+
+    Keeping index storage out of the searched tree matters for two reasons:
+    it stays out of the way of arbitrary/mounted directories that get
+    searched (e.g. a Docker bind-mounted workspace volume), and it makes
+    "delete CraftBot's data" a single well-known location instead of
+    scattered .craftbot folders wherever a search happened to run.
+
+    Keyed by a deterministic hash of the normalized root path (same
+    sha256(...)[:16] convention used elsewhere in the codebase, e.g.
+    activity_log.make_idem_key) so re-indexing the same root reuses its
+    existing db. A short sanitized slug is prefixed purely so a developer
+    browsing the storage directory can tell folders apart at a glance —
+    the hash alone guarantees uniqueness.
+    """
+    normalized = os.path.normcase(os.path.abspath(root))
+    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:16]
+    slug = re.sub(r"[^a-zA-Z0-9]+", "_", normalized).strip("_")[:40]
+    return os.path.join(_INDEX_STORAGE_ROOT, f"{slug}_{digest}")
 
 
 def _db_path(root: str) -> str:
@@ -195,7 +223,21 @@ def _split_or_patterns(pattern: str) -> list[str]:
 
 
 def _iter_files(root: str):
-    """Recursive file iterator mirroring os.walk (skips _SKIP_DIR_NAMES, no symlink follow)."""
+    """Recursive file iterator mirroring os.walk (skips _SKIP_DIR_NAMES, stays
+    on one filesystem, no symlink follow).
+
+    The filesystem-boundary check (mirrors `find -xdev`) matters most on
+    macOS/Linux, where "/" is the root of everything — without it, indexing
+    "/" would recurse into /proc, /sys, other mounted volumes under
+    /Volumes, network shares, etc. On Windows this is effectively a no-op
+    since crossing from one drive to another isn't reachable via plain
+    recursion anyway.
+    """
+    try:
+        root_dev = os.stat(root).st_dev
+    except OSError:
+        return
+
     stack = [root]
     while stack:
         dir_path = stack.pop()
@@ -205,6 +247,18 @@ def _iter_files(root: str):
                     try:
                         if entry.is_dir(follow_symlinks=False):
                             if entry.name.lower() in _SKIP_DIR_NAMES:
+                                continue
+                            try:
+                                # os.stat(entry.path, ...), NOT entry.stat(...):
+                                # on Windows, DirEntry.stat() is served from
+                                # scandir's cached WIN32_FIND_DATA, which has
+                                # no device info and always reports st_dev=0
+                                # — comparing that against the real root_dev
+                                # would treat every subdirectory as a
+                                # different filesystem and skip it entirely.
+                                if os.stat(entry.path, follow_symlinks=False).st_dev != root_dev:
+                                    continue
+                            except OSError:
                                 continue
                             stack.append(entry.path)
                         elif entry.is_file(follow_symlinks=False):
@@ -640,8 +694,15 @@ def find_files(
     *base_directory* may contain multiple absolute paths joined by '|' to
     search several roots in one call. If *all_drives* is True, *base_directory*
     is ignored and every local fixed drive is searched instead. *limit*, if
-    given, caps the total number of matches across all roots combined.
+    given and positive, caps the total number of matches across all roots
+    combined. 0 (or any non-positive value) means unlimited, matching the
+    common "0 = no limit" convention — without this, a literal 0 would stop
+    the search after exactly one match, since `len(matches) >= 0` is true
+    the instant the first match is found.
     """
+    if limit is not None and limit <= 0:
+        limit = None
+
     if all_drives:
         roots = list_local_drives()
         if not roots:

--- a/app/utils/file_index.py
+++ b/app/utils/file_index.py
@@ -173,7 +173,7 @@ def build_index(root: str, force: bool = False) -> IndexStats:
                 not force
                 and has_rows
                 and stored_root
-                and stored_root[0] == root
+                and os.path.normcase(stored_root[0]) == os.path.normcase(root)
                 and not _needs_incremental.get(root, False)
             ):
                 total = conn.execute("SELECT COUNT(*) FROM files").fetchone()[0]
@@ -302,13 +302,19 @@ def _fts_prefilter_sql(pattern: str) -> tuple[str, list[str]] | None:
         return ("f.basename = ?", [pattern])
 
     if pattern.startswith("*"):
+        remainder = pattern[1:]
+        next_star = remainder.find("*")
+        literal = remainder[:next_star] if next_star >= 0 else remainder
+        if len(literal) >= 2 and "?" not in literal and "[" not in literal:
+            return ("files_fts.basename MATCH ?", [literal])
         return None
 
     star = pattern.find("*")
     if star > 0:
         literal = pattern[:star]
-        if len(literal) >= 2 and literal.replace("_", "").isalnum():
-            return ("files_fts.basename MATCH ?", [literal])
+        if len(literal) >= 2 and "?" not in literal and "[" not in literal:
+            quoted = '"' + literal.replace('"', '""') + '"'
+            return ("files_fts.basename MATCH ?", [quoted])
     return None
 
 

--- a/app/utils/file_index.py
+++ b/app/utils/file_index.py
@@ -1,0 +1,459 @@
+"""
+CraftBot FindIndex — SQLite FTS5 trigram filename index with watchdog updates.
+
+Replaces live os.walk retrieval for find_files (issue #354).
+Full crawl under the resolved base_directory — no directory skip list.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import os
+import re
+import sqlite3
+import threading
+import time
+from dataclasses import dataclass
+
+try:
+    from watchdog.events import FileSystemEventHandler
+    from watchdog.observers import Observer
+
+    WATCHDOG_AVAILABLE = True
+except ImportError:
+    WATCHDOG_AVAILABLE = False
+
+    class FileSystemEventHandler:  # type: ignore[no-redef]
+        pass
+
+    Observer = None  # type: ignore[misc, assignment]
+
+_DEBOUNCE_SECONDS = 5.0
+_DB_NAME = "findindex.db"
+_META_ROOT = "indexed_root"
+_META_BUILT_AT = "built_at"
+
+_build_lock = threading.Lock()
+_watcher_lock = threading.Lock()
+_watchers: dict[str, _RootWatcher] = {}
+_needs_incremental: dict[str, bool] = {}
+
+
+@dataclass
+class IndexStats:
+    files_indexed: int
+    files_added: int
+    files_updated: int
+    files_removed: int
+    duration_seconds: float
+
+
+def _index_dir(root: str) -> str:
+    return os.path.join(os.path.abspath(root), ".craftbot")
+
+
+def _db_path(root: str) -> str:
+    return os.path.join(_index_dir(root), _DB_NAME)
+
+
+def _connect(root: str) -> sqlite3.Connection:
+    os.makedirs(_index_dir(root), exist_ok=True)
+    conn = sqlite3.connect(_db_path(root), check_same_thread=False)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA busy_timeout=30000")
+    return conn
+
+
+def _init_schema(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS meta (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS files (
+            rowid INTEGER PRIMARY KEY,
+            path TEXT NOT NULL UNIQUE,
+            basename TEXT NOT NULL,
+            mtime REAL NOT NULL,
+            size INTEGER NOT NULL
+        );
+
+        CREATE VIRTUAL TABLE IF NOT EXISTS files_fts USING fts5(
+            basename,
+            content='files',
+            content_rowid='rowid',
+            tokenize='trigram'
+        );
+
+        CREATE TRIGGER IF NOT EXISTS files_ai AFTER INSERT ON files BEGIN
+            INSERT INTO files_fts(rowid, basename) VALUES (new.rowid, new.basename);
+        END;
+
+        CREATE TRIGGER IF NOT EXISTS files_ad AFTER DELETE ON files BEGIN
+            INSERT INTO files_fts(files_fts, rowid, basename)
+            VALUES ('delete', old.rowid, old.basename);
+        END;
+
+        CREATE TRIGGER IF NOT EXISTS files_au AFTER UPDATE ON files BEGIN
+            INSERT INTO files_fts(files_fts, rowid, basename)
+            VALUES ('delete', old.rowid, old.basename);
+            INSERT INTO files_fts(rowid, basename) VALUES (new.rowid, new.basename);
+        END;
+        """
+    )
+    conn.commit()
+
+
+def _normalize_glob_part(part: str) -> str:
+    if any(ch in part for ch in "*?[]"):
+        return part
+    return f"{part}*"
+
+
+def _split_or_patterns(pattern: str) -> list[str]:
+    if "|" in pattern:
+        parts = [part.strip() for part in pattern.split("|") if part.strip()]
+    elif re.search(r"\s+OR\s+", pattern, re.IGNORECASE):
+        parts = [
+            part.strip()
+            for part in re.split(r"\s+OR\s+", pattern, flags=re.IGNORECASE)
+            if part.strip()
+        ]
+    else:
+        parts = [pattern]
+    return [_normalize_glob_part(part) for part in parts]
+
+
+def _iter_files(root: str):
+    """Recursive file iterator mirroring os.walk (no skip list, no symlink follow)."""
+    stack = [root]
+    while stack:
+        dir_path = stack.pop()
+        try:
+            with os.scandir(dir_path) as entries:
+                for entry in entries:
+                    try:
+                        if entry.is_dir(follow_symlinks=False):
+                            stack.append(entry.path)
+                        elif entry.is_file(follow_symlinks=False):
+                            yield entry
+                    except OSError:
+                        continue
+        except OSError:
+            continue
+
+
+def _file_stat(entry: os.DirEntry) -> tuple[float, int] | None:
+    try:
+        st = entry.stat(follow_symlinks=False)
+        return (st.st_mtime, st.st_size)
+    except OSError:
+        return None
+
+
+def build_index(root: str, force: bool = False) -> IndexStats:
+    """Build or incrementally refresh the filename index for *root*."""
+    root = os.path.abspath(root)
+    started = time.perf_counter()
+
+    with _build_lock:
+        conn = _connect(root)
+        try:
+            _init_schema(conn)
+            stored_root = conn.execute(
+                "SELECT value FROM meta WHERE key = ?", (_META_ROOT,)
+            ).fetchone()
+            has_rows = (
+                conn.execute("SELECT 1 FROM files LIMIT 1").fetchone() is not None
+            )
+
+            if (
+                not force
+                and has_rows
+                and stored_root
+                and stored_root[0] == root
+                and not _needs_incremental.get(root, False)
+            ):
+                total = conn.execute("SELECT COUNT(*) FROM files").fetchone()[0]
+                return IndexStats(
+                    files_indexed=total,
+                    files_added=0,
+                    files_updated=0,
+                    files_removed=0,
+                    duration_seconds=time.perf_counter() - started,
+                )
+
+            if not force and has_rows and stored_root and stored_root[0] == root:
+                stats = _incremental_update(conn, root)
+                _needs_incremental[root] = False
+                conn.execute(
+                    "INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)",
+                    (_META_BUILT_AT, str(time.time())),
+                )
+                conn.commit()
+                return IndexStats(
+                    files_indexed=stats[0],
+                    files_added=stats[1],
+                    files_updated=stats[2],
+                    files_removed=stats[3],
+                    duration_seconds=time.perf_counter() - started,
+                )
+
+            conn.execute("DELETE FROM files")
+            conn.commit()
+            count = _full_crawl(conn, root)
+            conn.execute(
+                "INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)",
+                (_META_ROOT, root),
+            )
+            conn.execute(
+                "INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)",
+                (_META_BUILT_AT, str(time.time())),
+            )
+            conn.commit()
+            return IndexStats(
+                files_indexed=count,
+                files_added=count,
+                files_updated=0,
+                files_removed=0,
+                duration_seconds=time.perf_counter() - started,
+            )
+        finally:
+            conn.close()
+
+
+def _full_crawl(conn: sqlite3.Connection, root: str) -> int:
+    count = 0
+    batch: list[tuple[str, str, float, int]] = []
+    for entry in _iter_files(root):
+        stat = _file_stat(entry)
+        if stat is None:
+            continue
+        mtime, size = stat
+        batch.append((entry.path, entry.name, mtime, size))
+        if len(batch) >= 5000:
+            conn.executemany(
+                "INSERT INTO files(path, basename, mtime, size) VALUES (?, ?, ?, ?)",
+                batch,
+            )
+            count += len(batch)
+            batch.clear()
+    if batch:
+        conn.executemany(
+            "INSERT INTO files(path, basename, mtime, size) VALUES (?, ?, ?, ?)",
+            batch,
+        )
+        count += len(batch)
+    conn.commit()
+    return count
+
+
+def _incremental_update(
+    conn: sqlite3.Connection, root: str
+) -> tuple[int, int, int, int]:
+    seen: set[str] = set()
+    added = updated = 0
+    prefix = root if root.endswith(os.sep) else root + os.sep
+
+    for entry in _iter_files(root):
+        stat = _file_stat(entry)
+        if stat is None:
+            continue
+        path = entry.path
+        seen.add(path)
+        mtime, size = stat
+        row = conn.execute(
+            "SELECT mtime, size FROM files WHERE path = ?", (path,)
+        ).fetchone()
+        if row is None:
+            conn.execute(
+                "INSERT INTO files(path, basename, mtime, size) VALUES (?, ?, ?, ?)",
+                (path, entry.name, mtime, size),
+            )
+            added += 1
+        elif row[0] != mtime or row[1] != size:
+            conn.execute(
+                "UPDATE files SET basename = ?, mtime = ?, size = ? WHERE path = ?",
+                (entry.name, mtime, size, path),
+            )
+            updated += 1
+
+    removed = 0
+    for (path,) in conn.execute("SELECT path FROM files"):
+        if path == root:
+            continue
+        if not path.startswith(prefix):
+            conn.execute("DELETE FROM files WHERE path = ?", (path,))
+            removed += 1
+            continue
+        if path not in seen:
+            conn.execute("DELETE FROM files WHERE path = ?", (path,))
+            removed += 1
+
+    conn.commit()
+    total = conn.execute("SELECT COUNT(*) FROM files").fetchone()[0]
+    return total, added, updated, removed
+
+
+def _fts_prefilter_sql(pattern: str) -> tuple[str, list[str]] | None:
+    if "*" not in pattern and "?" not in pattern and "[" not in pattern:
+        return ("f.basename = ?", [pattern])
+
+    if pattern.startswith("*"):
+        return None
+
+    star = pattern.find("*")
+    if star > 0:
+        literal = pattern[:star]
+        if len(literal) >= 2 and literal.replace("_", "").isalnum():
+            return ("files_fts.basename MATCH ?", [literal])
+    return None
+
+
+def _search_single(
+    conn: sqlite3.Connection,
+    root: str,
+    pattern: str,
+    limit: int | None,
+) -> list[str]:
+    root_prefix = root if root.endswith(os.sep) else root + os.sep
+    prefilter = _fts_prefilter_sql(pattern)
+    matches: list[str] = []
+
+    if prefilter:
+        sql_fragment, params = prefilter
+        if "files_fts" in sql_fragment:
+            query = f"""
+                SELECT f.path, f.basename
+                FROM files f
+                INNER JOIN files_fts ON files_fts.rowid = f.rowid
+                WHERE f.path LIKE ? AND {sql_fragment}
+            """
+        else:
+            query = f"""
+                SELECT f.path, f.basename
+                FROM files f
+                WHERE f.path LIKE ? AND {sql_fragment}
+            """
+        rows = conn.execute(query, (root_prefix + "%", *params))
+    else:
+        rows = conn.execute(
+            "SELECT path, basename FROM files WHERE path LIKE ?",
+            (root_prefix + "%",),
+        )
+
+    for path, basename in rows:
+        if fnmatch.fnmatch(basename, pattern):
+            matches.append(os.path.abspath(path))
+            if limit is not None and len(matches) >= limit:
+                break
+    return matches
+
+
+def search(root: str, pattern: str, limit: int | None = None) -> list[str]:
+    """Return all paths under *root* whose basename matches *pattern*."""
+    root = os.path.abspath(root)
+    build_index(root, force=False)
+
+    patterns = _split_or_patterns(pattern)
+    conn = _connect(root)
+    try:
+        seen: set[str] = set()
+        results: list[str] = []
+        for part in patterns:
+            for path in _search_single(conn, root, part, limit):
+                if path not in seen:
+                    seen.add(path)
+                    results.append(path)
+                    if limit is not None and len(results) >= limit:
+                        return results
+        return results
+    finally:
+        conn.close()
+
+
+def start_watcher(root: str) -> bool:
+    """Start a debounced watchdog observer for *root* (once per root)."""
+    if not WATCHDOG_AVAILABLE:
+        return False
+
+    root = os.path.abspath(root)
+    with _watcher_lock:
+        if root in _watchers and _watchers[root].is_running:
+            return True
+        watcher = _RootWatcher(root, _DEBOUNCE_SECONDS)
+        if not watcher.start():
+            return False
+        _watchers[root] = watcher
+        return True
+
+
+class _RootWatcher:
+    def __init__(self, root: str, debounce_seconds: float) -> None:
+        self.root = root
+        self.debounce_seconds = debounce_seconds
+        self._observer: Observer | None = None
+        self._is_running = False
+        self._lock = threading.Lock()
+        self._debounce_timer: threading.Timer | None = None
+        self._pending = False
+
+    @property
+    def is_running(self) -> bool:
+        return self._is_running
+
+    def start(self) -> bool:
+        if not WATCHDOG_AVAILABLE or Observer is None:
+            return False
+        if not os.path.isdir(self.root):
+            return False
+        self._observer = Observer()
+        handler = _IndexEventHandler(self._on_change)
+        self._observer.schedule(handler, self.root, recursive=True)
+        self._observer.start()
+        self._is_running = True
+        return True
+
+    def _on_change(self, _path: str, _event_type: str) -> None:
+        _needs_incremental[self.root] = True
+        with self._lock:
+            self._pending = True
+            if self._debounce_timer:
+                self._debounce_timer.cancel()
+            self._debounce_timer = threading.Timer(self.debounce_seconds, self._flush)
+            self._debounce_timer.start()
+
+    def _flush(self) -> None:
+        with self._lock:
+            if not self._pending:
+                return
+            self._pending = False
+            self._debounce_timer = None
+        build_index(self.root, force=False)
+
+
+class _IndexEventHandler(FileSystemEventHandler):
+    def __init__(self, callback) -> None:
+        super().__init__()
+        self._callback = callback
+
+    def on_created(self, event) -> None:
+        if not event.is_directory:
+            self._callback(event.src_path, "created")
+
+    def on_modified(self, event) -> None:
+        if not event.is_directory:
+            self._callback(event.src_path, "modified")
+
+    def on_deleted(self, event) -> None:
+        if not event.is_directory:
+            self._callback(event.src_path, "deleted")
+
+    def on_moved(self, event) -> None:
+        if event.is_directory:
+            return
+        self._callback(event.src_path, "deleted")
+        if event.dest_path:
+            self._callback(event.dest_path, "created")

--- a/app/utils/file_index.py
+++ b/app/utils/file_index.py
@@ -2,7 +2,8 @@
 CraftBot FindIndex — SQLite FTS5 trigram filename index with watchdog updates.
 
 Replaces live os.walk retrieval for find_files (issue #354).
-Full crawl under the resolved base_directory — no directory skip list.
+Full crawl under the resolved base_directory, skipping known noise
+directories (VCS metadata, dependency/build caches, OS reserved folders).
 """
 
 from __future__ import annotations
@@ -33,10 +34,47 @@ _DB_NAME = "findindex.db"
 _META_ROOT = "indexed_root"
 _META_BUILT_AT = "built_at"
 
-_build_lock = threading.Lock()
+_SKIP_DIR_NAMES = {
+    ".craftbot",
+    "node_modules",
+    ".git",
+    "__pycache__",
+    "venv",
+    ".venv",
+    "$recycle.bin",
+    "system volume information",
+}
+
+_build_locks_registry_lock = threading.Lock()
+_build_locks: dict[str, threading.Lock] = {}
 _watcher_lock = threading.Lock()
 _watchers: dict[str, _RootWatcher] = {}
-_needs_incremental: dict[str, bool] = {}
+
+# normcased root -> set of changed absolute paths reported by that root's
+# watcher since the last build_index() pass consumed them. An empty/missing
+# entry means "no known pending changes" (build_index can use the cheap
+# cached-count path). A non-empty entry lets build_index apply just those
+# paths (_apply_targeted_changes) instead of re-walking the entire tree.
+_pending_changes_lock = threading.Lock()
+_pending_changes: dict[str, set[str]] = {}
+
+
+def _get_build_lock(root: str) -> threading.Lock:
+    """Per-root build lock so unrelated roots never block each other."""
+    key = os.path.normcase(root)
+    with _build_locks_registry_lock:
+        lock = _build_locks.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _build_locks[key] = lock
+        return lock
+
+
+def _is_skip_path(path: str) -> bool:
+    """True if *path* has a _SKIP_DIR_NAMES component anywhere in it."""
+    normalized = os.path.normcase(path)
+    parts = normalized.replace("/", os.sep).split(os.sep)
+    return any(part in _SKIP_DIR_NAMES for part in parts)
 
 
 @dataclass
@@ -127,7 +165,7 @@ def _split_or_patterns(pattern: str) -> list[str]:
 
 
 def _iter_files(root: str):
-    """Recursive file iterator mirroring os.walk (no skip list, no symlink follow)."""
+    """Recursive file iterator mirroring os.walk (skips _SKIP_DIR_NAMES, no symlink follow)."""
     stack = [root]
     while stack:
         dir_path = stack.pop()
@@ -136,6 +174,8 @@ def _iter_files(root: str):
                 for entry in entries:
                     try:
                         if entry.is_dir(follow_symlinks=False):
+                            if entry.name.lower() in _SKIP_DIR_NAMES:
+                                continue
                             stack.append(entry.path)
                         elif entry.is_file(follow_symlinks=False):
                             yield entry
@@ -158,7 +198,7 @@ def build_index(root: str, force: bool = False) -> IndexStats:
     root = os.path.abspath(root)
     started = time.perf_counter()
 
-    with _build_lock:
+    with _get_build_lock(root):
         conn = _connect(root)
         try:
             _init_schema(conn)
@@ -168,13 +208,16 @@ def build_index(root: str, force: bool = False) -> IndexStats:
             has_rows = (
                 conn.execute("SELECT 1 FROM files LIMIT 1").fetchone() is not None
             )
+            root_matches_stored = bool(
+                stored_root
+                and os.path.normcase(stored_root[0]) == os.path.normcase(root)
+            )
 
             if (
                 not force
                 and has_rows
-                and stored_root
-                and os.path.normcase(stored_root[0]) == os.path.normcase(root)
-                and not _needs_incremental.get(root, False)
+                and root_matches_stored
+                and not _peek_has_pending_changes(root)
             ):
                 total = conn.execute("SELECT COUNT(*) FROM files").fetchone()[0]
                 return IndexStats(
@@ -185,9 +228,16 @@ def build_index(root: str, force: bool = False) -> IndexStats:
                     duration_seconds=time.perf_counter() - started,
                 )
 
-            if not force and has_rows and stored_root and stored_root[0] == root:
-                stats = _incremental_update(conn, root)
-                _needs_incremental[root] = False
+            if not force and has_rows and root_matches_stored:
+                # A non-empty pending set (reported directly by this root's
+                # watcher) lets us apply just those paths — O(changes), not
+                # O(total files indexed). Only fall back to the full re-walk
+                # when we have no such record (e.g. no watcher running yet).
+                pending = _pop_pending_changes(root)
+                if pending:
+                    stats = _apply_targeted_changes(conn, root, pending)
+                else:
+                    stats = _incremental_update(conn, root)
                 conn.execute(
                     "INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)",
                     (_META_BUILT_AT, str(time.time())),
@@ -201,9 +251,18 @@ def build_index(root: str, force: bool = False) -> IndexStats:
                     duration_seconds=time.perf_counter() - started,
                 )
 
+            # Bulk (re)build: drop the per-row FTS sync triggers so the crawl's
+            # inserts don't each pay a trigram-index write, then rebuild the
+            # FTS index in one pass at the end (standard FTS5 external-content
+            # bulk-load pattern). _init_schema recreates the triggers after.
+            _pop_pending_changes(root)  # full crawl already reflects current state
+            conn.execute("DROP TRIGGER IF EXISTS files_ai")
+            conn.execute("DROP TRIGGER IF EXISTS files_ad")
+            conn.execute("DROP TRIGGER IF EXISTS files_au")
             conn.execute("DELETE FROM files")
-            conn.commit()
             count = _full_crawl(conn, root)
+            conn.execute("INSERT INTO files_fts(files_fts) VALUES ('rebuild')")
+            _init_schema(conn)
             conn.execute(
                 "INSERT OR REPLACE INTO meta(key, value) VALUES (?, ?)",
                 (_META_ROOT, root),
@@ -281,16 +340,76 @@ def _incremental_update(
             updated += 1
 
     removed = 0
+    normcased_prefix = os.path.normcase(prefix)
     for (path,) in conn.execute("SELECT path FROM files"):
         if path == root:
             continue
-        if not path.startswith(prefix):
+        if not os.path.normcase(path).startswith(normcased_prefix):
             conn.execute("DELETE FROM files WHERE path = ?", (path,))
             removed += 1
             continue
         if path not in seen:
             conn.execute("DELETE FROM files WHERE path = ?", (path,))
             removed += 1
+
+    conn.commit()
+    total = conn.execute("SELECT COUNT(*) FROM files").fetchone()[0]
+    return total, added, updated, removed
+
+
+def _peek_has_pending_changes(root: str) -> bool:
+    key = os.path.normcase(root)
+    with _pending_changes_lock:
+        return bool(_pending_changes.get(key))
+
+
+def _pop_pending_changes(root: str) -> set[str]:
+    key = os.path.normcase(root)
+    with _pending_changes_lock:
+        return _pending_changes.pop(key, set())
+
+
+def _apply_targeted_changes(
+    conn: sqlite3.Connection, root: str, changed_paths: set[str]
+) -> tuple[int, int, int, int]:
+    """Apply exactly the given changed paths to the index — no tree walk.
+
+    Cost is O(len(changed_paths)), not O(total files indexed), which is what
+    keeps watcher-driven updates cheap even on huge, highly active roots
+    (unlike _incremental_update, which re-walks everything every time).
+    """
+    added = updated = removed = 0
+    for path in changed_paths:
+        try:
+            st = os.stat(path, follow_symlinks=False)
+            is_file = os.path.isfile(path)
+        except OSError:
+            st = None
+            is_file = False
+
+        row = conn.execute(
+            "SELECT mtime, size FROM files WHERE path = ?", (path,)
+        ).fetchone()
+
+        if st is None or not is_file:
+            if row is not None:
+                conn.execute("DELETE FROM files WHERE path = ?", (path,))
+                removed += 1
+            continue
+
+        basename = os.path.basename(path)
+        if row is None:
+            conn.execute(
+                "INSERT INTO files(path, basename, mtime, size) VALUES (?, ?, ?, ?)",
+                (path, basename, st.st_mtime, st.st_size),
+            )
+            added += 1
+        elif row[0] != st.st_mtime or row[1] != st.st_size:
+            conn.execute(
+                "UPDATE files SET basename = ?, mtime = ?, size = ? WHERE path = ?",
+                (basename, st.st_mtime, st.st_size, path),
+            )
+            updated += 1
 
     conn.commit()
     total = conn.execute("SELECT COUNT(*) FROM files").fetchone()[0]
@@ -306,7 +425,8 @@ def _fts_prefilter_sql(pattern: str) -> tuple[str, list[str]] | None:
         next_star = remainder.find("*")
         literal = remainder[:next_star] if next_star >= 0 else remainder
         if len(literal) >= 2 and "?" not in literal and "[" not in literal:
-            return ("files_fts.basename MATCH ?", [literal])
+            quoted = '"' + literal.replace('"', '""') + '"'
+            return ("files_fts.basename MATCH ?", [quoted])
         return None
 
     star = pattern.find("*")
@@ -380,19 +500,94 @@ def search(root: str, pattern: str, limit: int | None = None) -> list[str]:
         conn.close()
 
 
+def list_local_drives() -> list[str]:
+    """Return mount points of local fixed drives (cross-platform).
+
+    Used both for boot-time index pre-warming and for the find_files
+    ``all_drives`` option, so "search everywhere" means the same set of
+    roots in both places.
+    """
+    import psutil
+
+    drives = []
+    for part in psutil.disk_partitions(all=False):
+        opts = part.opts.lower().split(",")
+        if os.name == "nt" and "fixed" not in opts:
+            continue
+        drives.append(part.mountpoint)
+    return drives
+
+
+def find_files(
+    base_directory: str,
+    file_pattern: str,
+    recursive: bool,
+    all_drives: bool = False,
+) -> dict:
+    """Search one or more roots for basenames matching *file_pattern*.
+
+    Shared implementation for the find_files action. Kept here (rather than
+    as a helper in the action module) because "internal" actions are
+    executed by extracting and exec'ing only the single decorated function's
+    own source — a call to a same-module sibling function is not resolvable
+    at that point, while an attribute access on an imported module is.
+
+    *base_directory* may contain multiple absolute paths joined by '|' to
+    search several roots in one call. If *all_drives* is True, *base_directory*
+    is ignored and every local fixed drive is searched instead.
+    """
+    if all_drives:
+        roots = list_local_drives()
+        if not roots:
+            return {
+                "status": "error",
+                "matches": [],
+                "message": "Could not determine local drives for all_drives search.",
+            }
+    else:
+        roots = [part.strip() for part in base_directory.split("|") if part.strip()]
+
+    seen: set[str] = set()
+    matches: list[str] = []
+    for root in roots:
+        start_watcher(root)
+        root_matches = search(root, file_pattern)
+        if not recursive:
+            root_abs = os.path.abspath(root)
+            root_matches = [
+                path
+                for path in root_matches
+                if os.path.normcase(os.path.dirname(path)) == os.path.normcase(root_abs)
+            ]
+        for path in root_matches:
+            if path not in seen:
+                seen.add(path)
+                matches.append(path)
+
+    scope = ", ".join(roots) if roots else base_directory
+    return {
+        "status": "success",
+        "matches": matches,
+        "message": ""
+        if matches
+        else f"No files matching '{file_pattern}' were found in '{scope}'.",
+    }
+
+
 def start_watcher(root: str) -> bool:
     """Start a debounced watchdog observer for *root* (once per root)."""
     if not WATCHDOG_AVAILABLE:
         return False
 
     root = os.path.abspath(root)
+    key = os.path.normcase(root)
     with _watcher_lock:
-        if root in _watchers and _watchers[root].is_running:
+        if key in _watchers and _watchers[key].is_running:
             return True
         watcher = _RootWatcher(root, _DEBOUNCE_SECONDS)
         if not watcher.start():
             return False
-        _watchers[root] = watcher
+        _watchers[key] = watcher
         return True
 
 
@@ -422,8 +617,12 @@ class _RootWatcher:
         self._is_running = True
         return True
 
-    def _on_change(self, _path: str, _event_type: str) -> None:
-        _needs_incremental[self.root] = True
+    def _on_change(self, path: str, _event_type: str) -> None:
+        if _is_skip_path(path):
+            return
+        key = os.path.normcase(self.root)
+        with _pending_changes_lock:
+            _pending_changes.setdefault(key, set()).add(path)
         with self._lock:
             self._pending = True
             if self._debounce_timer:

--- a/scripts/updater.bat
+++ b/scripts/updater.bat
@@ -2,43 +2,48 @@
 setlocal
 
 rem Argument 1 is the git branch to pull (default: main).
-set BRANCH=%1
+set "BRANCH=%~1"
 if "%BRANCH%"=="" set BRANCH=main
+
+rem Argument 2 is the Python executable that launched CraftBot.
+set "PYTHON_BIN=%~2"
+if "%PYTHON_BIN%"=="" set PYTHON_BIN=python
 
 rem Project root is the parent of scripts/
 cd /d "%~dp0.."
 
 rem Log everything to updater.log so failures are debuggable (we run headlessly).
-set LOG=%~dp0..\updater.log
+set "LOG=%~dp0..\updater.log"
 echo. >> "%LOG%"
 echo ============================================ >> "%LOG%"
 echo %DATE% %TIME% - Updater start (branch=%BRANCH%) >> "%LOG%"
 echo CWD=%CD% >> "%LOG%"
+echo Python=%PYTHON_BIN% >> "%LOG%"
 
 rem Wait for current CraftBot to fully terminate.
 timeout /t 3 /nobreak > nul
 
 echo --- git fetch --- >> "%LOG%"
-git fetch origin %BRANCH% >> "%LOG%" 2>&1
+git fetch origin "%BRANCH%" >> "%LOG%" 2>&1
 if errorlevel 1 goto :fail
 
 echo --- git checkout --- >> "%LOG%"
-git checkout %BRANCH% >> "%LOG%" 2>&1
+git checkout "%BRANCH%" >> "%LOG%" 2>&1
 if errorlevel 1 goto :fail
 
 echo --- git pull --- >> "%LOG%"
-git pull origin %BRANCH% >> "%LOG%" 2>&1
+git pull --ff-only origin "%BRANCH%" >> "%LOG%" 2>&1
 if errorlevel 1 goto :fail
 
 if exist install.py (
     echo --- install.py --- >> "%LOG%"
-    python install.py >> "%LOG%" 2>&1
+    "%PYTHON_BIN%" install.py >> "%LOG%" 2>&1
     if errorlevel 1 goto :fail
 )
 
 echo --- relaunching CraftBot --- >> "%LOG%"
 rem Launch the new CraftBot. This bat process exits and the new run.py takes over.
-start "CraftBot" python run.py --conda
+start "CraftBot" "%PYTHON_BIN%" run.py --conda
 echo %DATE% %TIME% - Updater done, relaunched CraftBot >> "%LOG%"
 exit /b 0
 

--- a/scripts/updater.sh
+++ b/scripts/updater.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+set -u
+
+# Argument 1 is the git branch to pull (default: main).
+BRANCH="${1:-main}"
+
+# Argument 2 is the Python executable that launched CraftBot. Reusing it keeps
+# updates on the same interpreter and avoids python/python3 mismatches.
+PYTHON_BIN="${2:-${PYTHON:-python3}}"
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+ROOT_DIR=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+LOG="$ROOT_DIR/updater.log"
+
+log() {
+    printf '%s\n' "$*" >> "$LOG"
+}
+
+fail() {
+    log "$(date) - UPDATE FAILED: $*"
+    exit 1
+}
+
+{
+    printf '\n'
+    printf '============================================\n'
+    printf '%s - Updater start (branch=%s)\n' "$(date)" "$BRANCH"
+    printf 'CWD=%s\n' "$ROOT_DIR"
+    printf 'Python=%s\n' "$PYTHON_BIN"
+} >> "$LOG"
+
+cd "$ROOT_DIR" || fail "could not cd to $ROOT_DIR"
+
+# Wait for current CraftBot to fully terminate.
+sleep 3
+
+log "--- git fetch ---"
+git fetch origin "$BRANCH" >> "$LOG" 2>&1 || fail "git fetch failed"
+
+log "--- git checkout ---"
+git checkout "$BRANCH" >> "$LOG" 2>&1 || fail "git checkout failed"
+
+log "--- git pull ---"
+git pull --ff-only origin "$BRANCH" >> "$LOG" 2>&1 || fail "git pull failed"
+
+if [ -f install.py ]; then
+    log "--- install.py ---"
+    "$PYTHON_BIN" install.py >> "$LOG" 2>&1 || fail "install.py failed"
+fi
+
+log "--- relaunching CraftBot ---"
+nohup "$PYTHON_BIN" run.py --conda >> "$LOG" 2>&1 &
+log "$(date) - Updater done, relaunched CraftBot"
+exit 0

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1,0 +1,189 @@
+# -*- coding: utf-8 -*-
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from app import updater
+
+
+INSIDE_WORK_TREE = ("git", "rev-parse", "--is-inside-work-tree")
+FETCH_MAIN = ("git", "fetch", "origin", "main:refs/remotes/origin/main")
+HEAD = ("git", "rev-parse", "HEAD")
+ORIGIN_MAIN = ("git", "rev-parse", "origin/main")
+COUNT_MAIN = ("git", "rev-list", "--left-right", "--count", "HEAD...origin/main")
+
+LOCAL_REVISION = b"1111111111111111111111111111111111111111\n"
+REMOTE_REVISION = b"2222222222222222222222222222222222222222\n"
+LOCAL_AHEAD_REVISION = b"3333333333333333333333333333333333333333\n"
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def stub_git(monkeypatch, responses):
+    calls = []
+
+    async def fake_run_git(cmd, cwd):
+        key = tuple(cmd)
+        calls.append(key)
+        if key not in responses:
+            raise AssertionError(f"unexpected git command: {cmd}")
+        return responses[key], b""
+
+    monkeypatch.setattr(updater, "_run_git", fake_run_git)
+    return calls
+
+
+def test_source_update_detects_remote_main_ahead(monkeypatch, tmp_path):
+    calls = stub_git(
+        monkeypatch,
+        {
+            INSIDE_WORK_TREE: b"true\n",
+            FETCH_MAIN: b"",
+            HEAD: LOCAL_REVISION,
+            ORIGIN_MAIN: REMOTE_REVISION,
+            COUNT_MAIN: b"0\t3\n",
+        },
+    )
+
+    result = run(updater._check_source_update(tmp_path, "1.3.4", branch="main"))
+
+    assert result == (True, "1.3.4", "1.3.4+main.2222222")
+    assert FETCH_MAIN in calls
+
+
+@pytest.mark.parametrize(
+    ("local_revision", "remote_revision", "count_output"),
+    [
+        (LOCAL_REVISION, LOCAL_REVISION, None),
+        (LOCAL_AHEAD_REVISION, REMOTE_REVISION, b"2\t0\n"),
+    ],
+)
+def test_source_update_reports_no_update_without_remote_commits(
+    monkeypatch, tmp_path, local_revision, remote_revision, count_output
+):
+    responses = {
+        INSIDE_WORK_TREE: b"true\n",
+        FETCH_MAIN: b"",
+        HEAD: local_revision,
+        ORIGIN_MAIN: remote_revision,
+    }
+    if count_output is not None:
+        responses[COUNT_MAIN] = count_output
+    stub_git(monkeypatch, responses)
+
+    assert run(updater._check_source_update(tmp_path, "1.3.4", branch="main")) == (
+        False,
+        "1.3.4",
+        "1.3.4",
+    )
+
+
+def test_source_update_returns_none_outside_git_checkout(monkeypatch, tmp_path):
+    async def fake_run_git(cmd, cwd):
+        raise RuntimeError("not a git checkout")
+
+    monkeypatch.setattr(updater, "_run_git", fake_run_git)
+
+    assert run(updater._check_source_update(tmp_path, "1.3.4", branch="main")) is None
+
+
+def test_check_for_update_prefers_release_tag_when_semver_is_newer(monkeypatch):
+    async def fail_source_update(project_root, current, branch=updater.UPDATE_BRANCH):
+        raise AssertionError("source check should not run when release is newer")
+
+    async def newer_release_check(current):
+        return True, current, "1.3.5"
+
+    monkeypatch.setattr("app.config.get_app_version", lambda: "1.3.4")
+    monkeypatch.setattr(updater, "_check_source_update", fail_source_update)
+    monkeypatch.setattr(updater, "_check_release_update", newer_release_check)
+
+    assert run(updater.check_for_update()) == (True, "1.3.4", "1.3.5")
+
+
+def test_check_for_update_uses_source_checkout_when_release_tag_is_current(monkeypatch):
+    async def fake_source_update(project_root, current, branch=updater.UPDATE_BRANCH):
+        return True, current, "1.3.4+main.2222222"
+
+    async def current_release_check(current):
+        return False, current, current
+
+    monkeypatch.setattr("app.config.get_app_version", lambda: "1.3.4")
+    monkeypatch.setattr(updater, "_check_source_update", fake_source_update)
+    monkeypatch.setattr(updater, "_check_release_update", current_release_check)
+
+    assert run(updater.check_for_update()) == (
+        True,
+        "1.3.4",
+        "1.3.4+main.2222222",
+    )
+
+
+def test_check_for_update_falls_back_to_release_tags(monkeypatch):
+    async def no_source_update(project_root, current, branch=updater.UPDATE_BRANCH):
+        return None
+
+    async def fake_release_check(current):
+        return False, current, "1.3.4"
+
+    monkeypatch.setattr("app.config.get_app_version", lambda: "1.3.4")
+    monkeypatch.setattr(updater, "_check_source_update", no_source_update)
+    monkeypatch.setattr(updater, "_check_release_update", fake_release_check)
+
+    assert run(updater.check_for_update()) == (False, "1.3.4", "1.3.4")
+
+
+def test_perform_update_launches_posix_script_with_current_python(monkeypatch):
+    class ExitCalled(Exception):
+        def __init__(self, code):
+            self.code = code
+            super().__init__(code)
+
+    launched = {}
+
+    def fake_popen(args, **kwargs):
+        launched["args"] = args
+        launched["kwargs"] = kwargs
+
+    async def no_sleep(delay):
+        return None
+
+    def fake_exit(code):
+        raise ExitCalled(code)
+
+    project_root = Path(__file__).resolve().parent.parent
+    updater_script = project_root / "scripts" / "updater.sh"
+
+    monkeypatch.setattr(updater.sys, "platform", "linux")
+    monkeypatch.setattr(updater.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(updater.asyncio, "sleep", no_sleep)
+    monkeypatch.setattr(updater.os, "_exit", fake_exit)
+
+    with pytest.raises(ExitCalled) as exc_info:
+        run(updater.perform_update())
+
+    assert exc_info.value.code == 0
+    assert launched["args"] == [
+        "sh",
+        str(updater_script),
+        updater.UPDATE_BRANCH,
+        updater.sys.executable,
+    ]
+    assert launched["kwargs"]["cwd"] == str(project_root)
+    assert launched["kwargs"]["start_new_session"] is True
+
+
+@pytest.mark.parametrize(
+    ("platform", "expected"),
+    [("win32", "updater.bat"), ("darwin", "updater.sh"), ("linux", "updater.sh")],
+)
+def test_updater_script_path_is_platform_specific(platform, expected):
+    assert updater._updater_script_path(Path("/repo"), platform).name == expected
+
+
+def test_posix_updater_script_is_versioned():
+    assert (Path(__file__).resolve().parent.parent / "scripts" / "updater.sh").is_file()


### PR DESCRIPTION
Fixes #354

So basically I added a new file, `app/utils/file_index.py`, that builds a SQLite index of filenames (FTS5 trigram on the basename). It lives at `{base_directory}/.craftbot/findindex.db`.

From the outside, `find_files` behaves the same:
- empty `base_directory` still goes to home
- the agent can still search wherever it wants
- we still crawl everything, including stuff like `$Recycle.Bin`
- the response is still just `status`, `matches`, and `message` - all matches, no `head_limit`

The difference is recursive searches hit the index instead of running `os.walk` every single time. Non recursive is unchanged - still just a top level glob.

After the first build, `watchdog` keeps the index updated with a 5 second debounce.

Also added `**/.craftbot/` to `.gitignore` so those runtime DB files don't get committed.