### PR TITLE
fix/rendering issues for text based files on chat preview and toggle for .md files

### DIFF
--- a/app/ui_layer/browser/frontend/src/components/ui/AttachmentPreviewModal.module.css
+++ b/app/ui_layer/browser/frontend/src/components/ui/AttachmentPreviewModal.module.css
@@ -3,11 +3,43 @@
 }
 
 .metaBar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
   padding: var(--space-2) var(--space-4);
   font-size: var(--text-xs);
   color: var(--text-secondary);
   border-bottom: 1px solid var(--border-primary);
   flex-shrink: 0;
+}
+
+.viewToggle {
+  display: flex;
+  gap: var(--space-1);
+  flex-shrink: 0;
+}
+
+.viewToggleBtn,
+.viewToggleBtnActive {
+  padding: var(--space-1) var(--space-3);
+  border: none;
+  border-radius: var(--radius-sm);
+  background: none;
+  font-size: var(--text-xs);
+  font-family: inherit;
+  cursor: pointer;
+  color: var(--text-secondary);
+}
+
+.viewToggleBtn:hover {
+  color: var(--text-primary);
+}
+
+.viewToggleBtnActive {
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-weight: var(--font-semibold);
 }
 
 /* No fixed dimensions: the viewer hugs whichever content branch renders.
@@ -56,6 +88,15 @@
   background: var(--bg-primary);
   white-space: pre;
   box-sizing: border-box;
+}
+
+.markdownPreview {
+  width: min(1280px, 92vw);
+  height: calc(92vh - 100px);
+  padding: var(--space-4);
+  overflow: auto;
+  box-sizing: border-box;
+  background: var(--bg-primary);
 }
 
 .message {

--- a/app/ui_layer/browser/frontend/src/components/ui/AttachmentPreviewModal.tsx
+++ b/app/ui_layer/browser/frontend/src/components/ui/AttachmentPreviewModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Modal } from './Modal'
+import { MarkdownContent } from './MarkdownContent'
 import styles from './AttachmentPreviewModal.module.css'
 
 // A single shape that covers both pre-send attachments (base64 in memory)
@@ -33,7 +34,8 @@ function classify(att: AttachmentPreviewItem) {
     || TEXT_MIMES.has(att.type)
     || TEXT_EXT_RE.test(att.name)
   )
-  return { isImage, isPdf, isText }
+  const isMarkdown = isText && att.name.toLowerCase().endsWith('.md')
+  return { isImage, isPdf, isText, isMarkdown }
 }
 
 function formatFileSize(bytes: number): string {
@@ -45,7 +47,10 @@ function formatFileSize(bytes: number): string {
 }
 
 export function AttachmentPreviewModal({ isOpen, attachment, onClose }: AttachmentPreviewModalProps) {
-  const kind = attachment ? classify(attachment) : null
+  // Memoized: classify() returns a new object each call, and an unstable
+  // identity here would re-trigger the fetch effect below on every render
+  // it itself causes (infinite fetch/abort loop).
+  const kind = useMemo(() => (attachment ? classify(attachment) : null), [attachment])
 
   const imageSrc = useMemo(() => {
     if (!attachment || !kind?.isImage) return null
@@ -74,8 +79,10 @@ export function AttachmentPreviewModal({ isOpen, attachment, onClose }: Attachme
   const [textContent, setTextContent] = useState<string | null>(null)
   const [textLoading, setTextLoading] = useState(false)
   const [textError, setTextError] = useState<string | null>(null)
+  const [mdView, setMdView] = useState<'preview' | 'source'>('preview')
 
   useEffect(() => {
+    setMdView('preview')
     if (!attachment || !kind?.isText) {
       setTextContent(null)
       setTextLoading(false)
@@ -125,6 +132,7 @@ export function AttachmentPreviewModal({ isOpen, attachment, onClose }: Attachme
       {kind.isText && lineCount > 0 && <> · {lineCount} line{lineCount !== 1 ? 's' : ''}</>}
     </>
   )
+  const showMarkdownToggle = kind.isMarkdown && textContent != null
 
   return (
     <Modal
@@ -134,7 +142,27 @@ export function AttachmentPreviewModal({ isOpen, attachment, onClose }: Attachme
       size="auto"
       contentClassName={styles.modal}
     >
-      <div className={styles.metaBar}>{meta}</div>
+      <div className={styles.metaBar}>
+        {meta}
+        {showMarkdownToggle && (
+          <div className={styles.viewToggle}>
+            <button
+              type="button"
+              className={mdView === 'preview' ? styles.viewToggleBtnActive : styles.viewToggleBtn}
+              onClick={() => setMdView('preview')}
+            >
+              Preview
+            </button>
+            <button
+              type="button"
+              className={mdView === 'source' ? styles.viewToggleBtnActive : styles.viewToggleBtn}
+              onClick={() => setMdView('source')}
+            >
+              Source
+            </button>
+          </div>
+        )}
+      </div>
       <div className={styles.viewer}>
         {kind.isImage && imageSrc && (
           <img src={imageSrc} alt={attachment.name} className={styles.image} />
@@ -148,7 +176,11 @@ export function AttachmentPreviewModal({ isOpen, attachment, onClose }: Attachme
           ) : textError ? (
             <div className={styles.message}>{textError}</div>
           ) : textContent != null ? (
-            <pre className={styles.text}>{textContent}</pre>
+            showMarkdownToggle && mdView === 'preview' ? (
+              <MarkdownContent content={textContent} className={styles.markdownPreview} />
+            ) : (
+              <pre className={styles.text}>{textContent}</pre>
+            )
           ) : null
         )}
         {!kind.isImage && !kind.isPdf && !kind.isText && (


### PR DESCRIPTION
## Summary
- Clicking a generated `.md` (or any URL-backed text) attachment in chat entered a perpetual loading state, with the Network tab showing an endless cascade of aborted/retried requests.
- Adds a Preview/Source toggle for markdown attachments so users can view rendered markdown or raw text.

## Root cause
`AttachmentPreviewModal`'s `kind = classify(attachment)` returned a new object on every render instead of being memoized. The text-loading `useEffect` depended on `kind`, so its own `setTextLoading`/`setTextContent` calls triggered a re-render, which produced a new `kind` reference, which re-fired the effect — aborting and re-issuing the same `fetch` in an infinite loop. This wasn't 
## Summary
- Clicking a generated `.md` (or any URL-backed text) attachment in chat entered a perpetual loading state, with the Network tab showing an endless cascade of aborted/retried requests.
- Adds a Preview/Source toggle for markdown attachments so users can view rendered markdown or raw text.

## Root cause
`AttachmentPreviewModal`'s `kind = classify(attachment)` returned a new object on every render instead of being memoized. The text-loading `useEffect` depended on `kind`, so its own `setTextLoading`/`setTextContent` calls triggered a re-render, which produced a new `kind` reference, which re-fired the effect — aborting and re-issuing the same `fetch` in an infinite loop. This wasn't `.md`-specific; it affected any URL-backed text-classified attachment (agent-generated attachments never carry inline base64 `content`).

Fix: memoize `kind` with `useMemo(() => ..., [attachment])`, matching the pattern already used for `imageSrc`/`pdfBlobUrl` in the same file.

## Feature
- `classify()` now also flags `isMarkdown` (`.md` files only).
- Markdown attachments default to a rendered **Preview** (reusing the existing `MarkdownContent`/`react-markdown` pipeline used in chat bubbles), with a **Source** tab to see raw text.
- Toggle only appears for `.md`; other text types (`.json`, `.csv`, etc.) are unchanged.

## Test plan
- [x] `npx tsc --noEmit` — no new errors introduced (pre-existing CSS-module resolution gap in this project is unrelated, confirmed present before this change too)
- [ ] Manually verify in the app: generate a `.md` file via chat, click to open — preview loads once (no repeated network requests), toggle to Source and back works, non-.md text attachments still preview as raw text.

Closes #369 