### PR TITLE
Feature/tokens command and calculation

### DIFF
--- a/agent_core/core/impl/llm/interface.py
+++ b/agent_core/core/impl/llm/interface.py
@@ -2774,7 +2774,6 @@ class LLMInterface:
             usage = response.get("usage", {}) or {}
             token_count_input = int(usage.get("inputTokens", 0) or 0)
             token_count_output = int(usage.get("outputTokens", 0) or 0)
-            total_tokens = token_count_input + token_count_output
 
             if self._bedrock_model_supports_caching():
                 # Official Converse response uses `cacheReadInputTokens` /
@@ -2791,7 +2790,13 @@ class LLMInterface:
                     or usage.get("cacheWriteInputTokenCount")
                     or 0
                 )
-                cached_tokens = cache_read + cache_write
+                # Bedrock's `inputTokens` EXCLUDES cache activity, unlike the
+                # Anthropic API where input covers the full prompt. Normalize
+                # to the Anthropic shape — input = full prompt, cached = reads
+                # only — so downstream `input - cached` display math holds for
+                # every provider.
+                token_count_input += cache_read + cache_write
+                cached_tokens = cache_read
 
                 metrics = get_cache_metrics()
                 if cache_read > 0:
@@ -2817,6 +2822,8 @@ class LLMInterface:
                     metrics.record_miss(
                         "bedrock", cache_type, total_tokens=token_count_input
                     )
+
+            total_tokens = token_count_input + token_count_output
 
             status = "success"
 

--- a/agent_core/core/impl/vlm/interface.py
+++ b/agent_core/core/impl/vlm/interface.py
@@ -922,7 +922,6 @@ class VLMInterface:
         usage = response.get("usage", {}) or {}
         token_count_input = int(usage.get("inputTokens", 0) or 0)
         token_count_output = int(usage.get("outputTokens", 0) or 0)
-        total_tokens = token_count_input + token_count_output
         cached_tokens = 0
 
         if self._bedrock_model_supports_caching():
@@ -940,7 +939,13 @@ class VLMInterface:
                 or usage.get("cacheWriteInputTokenCount")
                 or 0
             )
-            cached_tokens = cache_read + cache_write
+            # Bedrock's `inputTokens` EXCLUDES cache activity, unlike the
+            # Anthropic API where input covers the full prompt. Normalize to
+            # the Anthropic shape — input = full prompt, cached = reads only —
+            # so downstream `input - cached` display math holds for every
+            # provider.
+            token_count_input += cache_read + cache_write
+            cached_tokens = cache_read
 
             metrics = get_cache_metrics()
             if cache_read > 0:
@@ -964,6 +969,8 @@ class VLMInterface:
                 metrics.record_miss(
                     "bedrock", "cachepoint_vlm", total_tokens=token_count_input
                 )
+
+        total_tokens = token_count_input + token_count_output
 
         self._report_usage_async(
             "vlm_bedrock",

--- a/agent_core/core/session/session.py
+++ b/agent_core/core/session/session.py
@@ -58,6 +58,8 @@ class Session:
             (reset when a new run starts).
         input_tokens/output_tokens/cache_tokens: LLM usage breakdown for
             the current run.
+        total_input_tokens/total_output_tokens/total_cache_tokens: the same
+            breakdown accumulated across every run in this session.
     """
 
     id: str
@@ -83,6 +85,11 @@ class Session:
     input_tokens: int = 0
     output_tokens: int = 0
     cache_tokens: int = 0
+    # Cumulative session totals — deliberately NOT cleared by
+    # reset_run_counters(); they span every run in this session.
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
+    total_cache_tokens: int = 0
 
     def touch(self) -> None:
         """Update last_active_at to now."""
@@ -138,6 +145,9 @@ class Session:
             "input_tokens": self.input_tokens,
             "output_tokens": self.output_tokens,
             "cache_tokens": self.cache_tokens,
+            "total_input_tokens": self.total_input_tokens,
+            "total_output_tokens": self.total_output_tokens,
+            "total_cache_tokens": self.total_cache_tokens,
         }
 
     @classmethod
@@ -165,4 +175,7 @@ class Session:
             input_tokens=data.get("input_tokens", 0),
             output_tokens=data.get("output_tokens", 0),
             cache_tokens=data.get("cache_tokens", 0),
+            total_input_tokens=data.get("total_input_tokens", 0),
+            total_output_tokens=data.get("total_output_tokens", 0),
+            total_cache_tokens=data.get("total_cache_tokens", 0),
         )

--- a/app/ui_layer/browser/frontend/src/pages/Dashboard/DashboardPage.module.css
+++ b/app/ui_layer/browser/frontend/src/pages/Dashboard/DashboardPage.module.css
@@ -235,6 +235,11 @@
   transition: width 0.3s ease;
 }
 
+.tokenCachedBar {
+  background: var(--color-success);
+  transition: width 0.3s ease;
+}
+
 .tokenRatioLabels {
   display: flex;
   justify-content: center;

--- a/app/ui_layer/browser/frontend/src/pages/Dashboard/DashboardPage.tsx
+++ b/app/ui_layer/browser/frontend/src/pages/Dashboard/DashboardPage.tsx
@@ -163,13 +163,16 @@ export function DashboardPage() {
   // Total counts new tokens only. `token.total` from the API is
   // rawInput + output, so it double-counts cache reads — derive instead.
   const totalTokens = inputTokens + outputTokens
+  const totalTokensRatio = inputTokens + outputTokens + cachedTokens
 
   // Calculate token ratios
-  const inputRatio = totalTokens > 0 ? Math.round((inputTokens / totalTokens) * 100) : 0
-  const outputRatio = totalTokens > 0 ? Math.round((outputTokens / totalTokens) * 100) : 0
+  const inputRatio = totalTokensRatio > 0 ? Math.round((inputTokens / totalTokensRatio) * 100) : 0
+  const outputRatio = totalTokensRatio > 0 ? Math.round((outputTokens / totalTokensRatio) * 100) : 0
   // Cache hit rate — share of the prompt served from cache. Denominator is the
   // full prompt, not totalTokens: output tokens are never cacheable.
-  const cachedRatio = rawInputTokens > 0 ? Math.min(100, Math.round((cachedTokens / rawInputTokens) * 100)) : 0
+  //const cachedRatio = rawInputTokens > 0 ? Math.min(100, Math.round((cachedTokens / rawInputTokens) * 100)) : 0 <--- STORAGE ONLY, ABLE TO BE DELETED IF NEEDED
+  const cachedRatio = totalTokensRatio > 0 ? Math.min(100, Math.round((cachedTokens / totalTokensRatio) * 100)) : 0
+
 
   const cpuPercent = metrics?.system.cpuPercent ?? 0
   const memoryPercent = metrics?.system.memoryPercent ?? 0
@@ -311,6 +314,10 @@ export function DashboardPage() {
                 <div
                   className={styles.tokenOutputBar}
                   style={{ width: `${outputRatio}%` }}
+                />
+                <div
+                  className={styles.tokenCachedBar}
+                  style={{ width: `${cachedRatio}%` }}
                 />
               </div>
               <div className={styles.tokenRatioLabels}>

--- a/app/ui_layer/browser/frontend/src/pages/Dashboard/DashboardPage.tsx
+++ b/app/ui_layer/browser/frontend/src/pages/Dashboard/DashboardPage.tsx
@@ -153,15 +153,21 @@ export function DashboardPage() {
 
   // Token metrics - use cached filtered metrics for all periods (including 'total')
   const tokenFilteredData = filteredMetricsCache[tokenPeriod]
-  const inputTokens = tokenFilteredData?.token.input ?? (metrics?.token.input ?? 0)
+  const rawInputTokens = tokenFilteredData?.token.input ?? (metrics?.token.input ?? 0)
   const outputTokens = tokenFilteredData?.token.output ?? (metrics?.token.output ?? 0)
   const totalTokens = tokenFilteredData?.token.total ?? (metrics?.token.total ?? 0)
   const cachedTokens = tokenFilteredData?.token.cached ?? (metrics?.token.cached ?? 0)
 
+  // `token.input` from the API is the full prompt size — cache reads included.
+  // The Input tile shows only the genuinely new tokens; Cached shows the rest.
+  const inputTokens = Math.max(0, rawInputTokens - cachedTokens)
+
   // Calculate token ratios
   const inputRatio = totalTokens > 0 ? Math.round((inputTokens / totalTokens) * 100) : 0
   const outputRatio = totalTokens > 0 ? Math.round((outputTokens / totalTokens) * 100) : 0
-  const cachedRatio = inputTokens > 0 ? Math.min(100, Math.round((cachedTokens / inputTokens) * 100)) : 0
+  // Cache hit rate — share of the prompt served from cache. Denominator is the
+  // full prompt, not totalTokens: output tokens are never cacheable.
+  const cachedRatio = rawInputTokens > 0 ? Math.min(100, Math.round((cachedTokens / rawInputTokens) * 100)) : 0
 
   const cpuPercent = metrics?.system.cpuPercent ?? 0
   const memoryPercent = metrics?.system.memoryPercent ?? 0

--- a/app/ui_layer/browser/frontend/src/pages/Dashboard/DashboardPage.tsx
+++ b/app/ui_layer/browser/frontend/src/pages/Dashboard/DashboardPage.tsx
@@ -155,12 +155,14 @@ export function DashboardPage() {
   const tokenFilteredData = filteredMetricsCache[tokenPeriod]
   const rawInputTokens = tokenFilteredData?.token.input ?? (metrics?.token.input ?? 0)
   const outputTokens = tokenFilteredData?.token.output ?? (metrics?.token.output ?? 0)
-  const totalTokens = tokenFilteredData?.token.total ?? (metrics?.token.total ?? 0)
   const cachedTokens = tokenFilteredData?.token.cached ?? (metrics?.token.cached ?? 0)
 
   // `token.input` from the API is the full prompt size — cache reads included.
   // The Input tile shows only the genuinely new tokens; Cached shows the rest.
   const inputTokens = Math.max(0, rawInputTokens - cachedTokens)
+  // Total counts new tokens only. `token.total` from the API is
+  // rawInput + output, so it double-counts cache reads — derive instead.
+  const totalTokens = inputTokens + outputTokens
 
   // Calculate token ratios
   const inputRatio = totalTokens > 0 ? Math.round((inputTokens / totalTokens) * 100) : 0

--- a/app/ui_layer/commands/builtin/__init__.py
+++ b/app/ui_layer/commands/builtin/__init__.py
@@ -11,6 +11,7 @@ from app.ui_layer.commands.builtin.skill import SkillCommand
 from app.ui_layer.commands.builtin.cred import CredCommand
 from app.ui_layer.commands.builtin.integrations import IntegrationCommand
 from app.ui_layer.commands.builtin.update import UpdateCommand
+from app.ui_layer.commands.builtin.tokens import TokensCommand
 from app.ui_layer.commands.builtin.agent_command import AgentCommandWrapper
 from app.ui_layer.commands.builtin.skill_invoke import SkillInvokeCommand
 
@@ -26,6 +27,7 @@ __all__ = [
     "CredCommand",
     "IntegrationCommand",
     "UpdateCommand",
+    "TokensCommand",
     "AgentCommandWrapper",
     "SkillInvokeCommand",
 ]

--- a/app/ui_layer/commands/builtin/tokens.py
+++ b/app/ui_layer/commands/builtin/tokens.py
@@ -34,8 +34,9 @@ class TokensCommand(Command):
 
         # Providers report input as the full prompt, cache reads included, so
         # `cached` is a subset of `total_input_tokens` — never a sibling.
+        raw_input = getattr(session, "total_input_tokens", 0) or 0
         cached = getattr(session, "total_cache_tokens", 0) or 0
-        new_input = max(0, (getattr(session, "total_input_tokens", 0) or 0) - cached)
+        new_input = max(0, raw_input - cached)
         output = getattr(session, "total_output_tokens", 0) or 0
         total = new_input + output
 
@@ -52,6 +53,7 @@ class TokensCommand(Command):
             data={
                 "session_id": target,
                 "input": new_input,
+                "raw_input": raw_input,
                 "cached": cached,
                 "output": output,
                 "total": total,

--- a/app/ui_layer/commands/builtin/tokens.py
+++ b/app/ui_layer/commands/builtin/tokens.py
@@ -1,0 +1,59 @@
+"""Tokens command implementation — shows this session's token usage."""
+
+from __future__ import annotations
+
+from typing import List
+
+from agent_core.core.session import MAIN_SESSION_ID
+
+from app.ui_layer.commands.base import Command, CommandResult
+
+
+class TokensCommand(Command):
+    """Show cumulative token usage for the session it was typed in."""
+
+    @property
+    def name(self) -> str:
+        return "/tokens"
+
+    @property
+    def description(self) -> str:
+        return "Show this session's token usage"
+
+    async def execute(
+        self,
+        args: List[str],
+        adapter_id: str = "",
+        session_id: str | None = None,
+    ) -> CommandResult:
+        """Report this session's token totals as a chat message."""
+        target = session_id or MAIN_SESSION_ID
+        # Sessions are created lazily on first message, so a brand-new chat
+        # has no session object yet — that reads as zero usage, not an error.
+        session = self._controller.agent.session_manager.get(target)
+
+        # Providers report input as the full prompt, cache reads included, so
+        # `cached` is a subset of `total_input_tokens` — never a sibling.
+        cached = getattr(session, "total_cache_tokens", 0) or 0
+        new_input = max(0, (getattr(session, "total_input_tokens", 0) or 0) - cached)
+        output = getattr(session, "total_output_tokens", 0) or 0
+        total = new_input + output
+
+        message = (
+            "Session token usage\n"
+            f"  Input:  {new_input:,}\n"
+            f"  Cached: {cached:,}\n"
+            f"  Output: {output:,}\n"
+            f"  Total:  {total:,}"
+        )
+        return CommandResult(
+            success=True,
+            message=message,
+            data={
+                "session_id": target,
+                "input": new_input,
+                "cached": cached,
+                "output": output,
+                "total": total,
+            },
+        )

--- a/app/ui_layer/controller/ui_controller.py
+++ b/app/ui_layer/controller/ui_controller.py
@@ -433,6 +433,7 @@ class UIController:
             SkillCommand,
             CredCommand,
             UpdateCommand,
+            TokensCommand,
         )
 
         self._command_registry.register(HelpCommand(self))
@@ -445,6 +446,7 @@ class UIController:
         self._command_registry.register(SkillCommand(self))
         self._command_registry.register(CredCommand(self))
         self._command_registry.register(UpdateCommand(self))
+        self._command_registry.register(TokensCommand(self))
 
         # Register integration commands
         self._register_integration_commands()

--- a/app/usage/task_attribution.py
+++ b/app/usage/task_attribution.py
@@ -44,6 +44,18 @@ def attribute_usage_to_current_task(event: UsageEventData) -> None:
             event.cached_tokens or 0
         )
 
+        # Cumulative session totals — survive reset_run_counters(), which
+        # clears the per-run counters above at the start of every run.
+        session.total_input_tokens = (session.total_input_tokens or 0) + int(
+            event.input_tokens or 0
+        )
+        session.total_output_tokens = (session.total_output_tokens or 0) + int(
+            event.output_tokens or 0
+        )
+        session.total_cache_tokens = (session.total_cache_tokens or 0) + int(
+            event.cached_tokens or 0
+        )
+
         logger.info(
             f"[TOKEN_ATTR] session={session.id} +in={event.input_tokens} "
             f"+out={event.output_tokens} +cached={event.cached_tokens} "

--- a/app/usage/task_attribution.py
+++ b/app/usage/task_attribution.py
@@ -59,8 +59,10 @@ def attribute_usage_to_current_task(event: UsageEventData) -> None:
         logger.info(
             f"[TOKEN_ATTR] session={session.id} +in={event.input_tokens} "
             f"+out={event.output_tokens} +cached={event.cached_tokens} "
-            f"-> totals: in={session.input_tokens} out={session.output_tokens} "
-            f"cache={session.cache_tokens}"
+            f"-> run: in={session.input_tokens} out={session.output_tokens} "
+            f"cache={session.cache_tokens} "
+            f"| session: in={session.total_input_tokens} "
+            f"out={session.total_output_tokens} cache={session.total_cache_tokens}"
         )
 
         bus = STATE.event_bus

--- a/mkdocs/docs/core/commands/builtin.md
+++ b/mkdocs/docs/core/commands/builtin.md
@@ -17,6 +17,7 @@ At a glance:
 | [`/skill <subcommand>`](#skill) | — | Manage skills |
 | [`/cred <subcommand>`](#cred) | — | Credentials and integration status |
 | [`/update [--check]`](#update) | `/upgrade` | Check for and install updates |
+| [`/tokens`](#tokens) | — | Show this session's token usage |
 
 Beyond these, the registry also holds [integration commands](#integration-commands) (`/gmail`, `/slack`, ...) and [skill commands](#skill-commands) (`/pdf`, `/docx`, ...), covered at the end.
 
@@ -140,6 +141,20 @@ Read-only overview of credentials and integrations. Connecting happens with the 
 ```
 
 An update pulls the latest code, installs dependencies, and restarts CraftBot automatically, streaming progress as system messages. If you're already current, it says so.
+
+## /tokens
+
+Prints the cumulative token usage of the chat it's typed in, as a system message:
+
+```
+Session token usage
+  Input:  79,022
+  Cached: 312,455
+  Output: 5,770
+  Total:  84,792
+```
+
+**Input** is genuinely new prompt tokens (cache reads excluded), **Cached** is prompt tokens served from the provider's cache, and **Total** is Input + Output. Totals accumulate across every run in the session and survive restarts and [`/clear`](#clear) (clearing wipes the conversation, not the session's lifetime counters). A brand-new chat that hasn't sent a message yet reports zeros. Sessions created before this command existed start counting from their next run.
 
 ## Integration commands
 

--- a/tests/test_bedrock_token_normalization.py
+++ b/tests/test_bedrock_token_normalization.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+"""Bedrock usage extraction must match the Anthropic shape.
+
+Bedrock's Converse API reports `inputTokens` EXCLUSIVE of cache activity,
+while the Anthropic API path reassembles input as base + creation + read.
+The display layer (dashboard, /tokens) assumes `cached` is a subset of
+`input` for every provider, so the Bedrock paths normalize:
+input = inputTokens + cacheRead + cacheWrite, cached = cacheRead only.
+"""
+
+from typing import Any, Dict
+
+from agent_core.core.impl.llm.interface import LLMInterface
+from agent_core.core.impl.vlm.interface import VLMInterface
+
+
+BEDROCK_USAGE = {
+    "inputTokens": 100,  # new tokens only — AWS excludes cache activity
+    "outputTokens": 50,
+    "cacheReadInputTokens": 900,
+    "cacheWriteInputTokens": 30,
+}
+
+
+class _StubBedrockClient:
+    def converse(self, **kwargs) -> Dict[str, Any]:
+        return {
+            "output": {"message": {"content": [{"text": "hello"}]}},
+            "usage": dict(BEDROCK_USAGE),
+        }
+
+
+def _stub_common(iface) -> Dict[str, Any]:
+    """Set the attributes the bedrock call paths touch; capture usage reports."""
+    reported = {}
+
+    def _capture(call_kind, provider, model, input_tokens, output_tokens, cached, *a, **kw):
+        reported.update(
+            input=input_tokens, output=output_tokens, cached=cached
+        )
+
+    iface._bedrock_client = _StubBedrockClient()
+    iface.model = "anthropic.claude-3-5-sonnet-20241022-v2:0"  # caching-capable
+    iface.provider = "bedrock"
+    iface.temperature = 0.0
+    iface.max_tokens = 1024
+    iface._report_usage_async = _capture
+    return reported
+
+
+def test_llm_bedrock_input_includes_cache_and_cached_is_reads_only():
+    iface = LLMInterface.__new__(LLMInterface)
+    reported = _stub_common(iface)
+    iface._call_log_to_db = lambda *a, **kw: None
+
+    result = iface._generate_bedrock(None, "hi")
+
+    assert "error" not in result
+    # input = 100 + 900 + 30, the full prompt; cached = reads only
+    assert reported == {"input": 1030, "output": 50, "cached": 900}
+    assert result["cached_tokens"] == 900
+    assert result["tokens_used"] == 1080  # 1030 + 50
+    # the display invariant the dashboard and /tokens rely on
+    assert reported["cached"] <= reported["input"]
+
+
+def test_vlm_bedrock_input_includes_cache_and_cached_is_reads_only():
+    iface = VLMInterface.__new__(VLMInterface)
+    reported = _stub_common(iface)
+
+    png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+    result = iface._bedrock_describe_bytes(png, None, "describe")
+
+    assert reported == {"input": 1030, "output": 50, "cached": 900}
+    assert result["cached_tokens"] == 900
+    assert result["tokens_used"] == 1080
+    assert reported["cached"] <= reported["input"]

--- a/tests/test_tokens_command.py
+++ b/tests/test_tokens_command.py
@@ -61,6 +61,7 @@ def test_input_excludes_cached_and_total_excludes_both():
     d = _run(s).data
 
     assert d["input"] == 20  # 100 - 80
+    assert d["raw_input"] == 100  # full prompt, cache reads included
     assert d["cached"] == 80
     assert d["output"] == 20
     assert d["total"] == 40  # 20 + 20, cached excluded
@@ -86,13 +87,3 @@ def test_unsaved_session_reads_as_zero():
     assert result.data["cached"] == 0
     assert result.data["output"] == 0
     assert result.data["total"] == 0
-
-
-if __name__ == "__main__":
-    test_totals_survive_run_reset()
-    test_totals_round_trip_through_dict()
-    test_old_sessions_load_as_zero()
-    test_input_excludes_cached_and_total_excludes_both()
-    test_input_clamps_when_cached_exceeds_input()
-    test_unsaved_session_reads_as_zero()
-    print("ok")

--- a/tests/test_tokens_command.py
+++ b/tests/test_tokens_command.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+"""Checks for /tokens: cumulative counters and the display math."""
+
+import asyncio
+from types import SimpleNamespace
+
+from agent_core.core.session import Session
+from app.ui_layer.commands.builtin.tokens import TokensCommand
+
+
+def _run(session):
+    """Execute /tokens against a stub controller holding `session`."""
+    controller = SimpleNamespace(
+        agent=SimpleNamespace(
+            session_manager=SimpleNamespace(get=lambda _id: session)
+        )
+    )
+    return asyncio.run(TokensCommand(controller).execute([], session_id="s1"))
+
+
+def test_totals_survive_run_reset():
+    """reset_run_counters() clears per-run counters but not the totals."""
+    s = Session(id="s1")
+    s.input_tokens, s.output_tokens, s.cache_tokens = 100, 20, 80
+    s.total_input_tokens, s.total_output_tokens, s.total_cache_tokens = 100, 20, 80
+
+    s.reset_run_counters()
+
+    assert s.input_tokens == 0
+    assert (s.total_input_tokens, s.total_output_tokens, s.total_cache_tokens) == (
+        100,
+        20,
+        80,
+    )
+
+
+def test_totals_round_trip_through_dict():
+    """Persistence goes through session_json, so to_dict/from_dict must carry them."""
+    s = Session(id="s1")
+    s.total_input_tokens, s.total_output_tokens, s.total_cache_tokens = 100, 20, 80
+
+    restored = Session.from_dict(s.to_dict())
+
+    assert restored.total_input_tokens == 100
+    assert restored.total_output_tokens == 20
+    assert restored.total_cache_tokens == 80
+
+
+def test_old_sessions_load_as_zero():
+    """Sessions persisted before this feature have no totals key."""
+    restored = Session.from_dict({"id": "s1"})
+
+    assert restored.total_input_tokens == 0
+
+
+def test_input_excludes_cached_and_total_excludes_both():
+    """cached is a subset of input; total counts new tokens only."""
+    s = Session(id="s1")
+    s.total_input_tokens, s.total_output_tokens, s.total_cache_tokens = 100, 20, 80
+
+    d = _run(s).data
+
+    assert d["input"] == 20  # 100 - 80
+    assert d["cached"] == 80
+    assert d["output"] == 20
+    assert d["total"] == 40  # 20 + 20, cached excluded
+
+
+def test_input_clamps_when_cached_exceeds_input():
+    """A provider over-reporting cache reads must not yield a negative count."""
+    s = Session(id="s1")
+    s.total_input_tokens, s.total_cache_tokens = 50, 80
+
+    d = _run(s).data
+
+    assert d["input"] == 0
+    assert d["total"] == 0
+
+
+def test_unsaved_session_reads_as_zero():
+    """A brand-new chat has no session yet (id is "new") — report zeros."""
+    result = _run(None)
+
+    assert result.success is True
+    assert result.data["input"] == 0
+    assert result.data["cached"] == 0
+    assert result.data["output"] == 0
+    assert result.data["total"] == 0
+
+
+if __name__ == "__main__":
+    test_totals_survive_run_reset()
+    test_totals_round_trip_through_dict()
+    test_old_sessions_load_as_zero()
+    test_input_excludes_cached_and_total_excludes_both()
+    test_input_clamps_when_cached_exceeds_input()
+    test_unsaved_session_reads_as_zero()
+    print("ok")


### PR DESCRIPTION
## What

Two related changes to how token usage is reported.

**1. Fix token display math.** `input_tokens` from every provider is the *full prompt size, cache reads included*. `cached` is a subset of it, never a sibling. The dashboard was rendering both as if they were independent, which read as double-counting.

- Input now shows `input − cached` (genuinely new tokens)
- Total now shows `input + output` with cached excluded, derived client-side instead of using the API's `token.total` (which is `rawInput + output`)
- Cached % now measured against the raw prompt, not the new Input value. It's a cache hit rate, and output tokens are never cacheable so they don't belong in the denominator

**2. Add `/tokens`.** Per-session token breakdown, printed into the chat it was typed in. Deterministic: no LLM call, no agent dispatch, same shape as `/clear`.

Session token usage
  Input:  79,022
  Cached: 312,455
  Output: 5,770
  Total:  84,792

## Why the new Session fields

`Session.input_tokens/output_tokens/cache_tokens` already existed but are **per-run**. `reset_run_counters()` is called from
`session_manager.start_run()` on every fresh run, so tt turn. The `usage_events` table has a `session_id`column but it's never populated (`collector.py:1236` passes `task_id=None`).

So per-chat cumulative totals didn't exist anywhere. This adds `total_input_tokens` / `total_output_tokens` / `total_cache_tokens`, incremented in `attribute_usage_to_current_task` alongdeliberately excluded from `reset_run_counters()`.

No schema migration: `session_storage` persists the wh, and `from_dict` defaults to 0, so existing sessionsload clean and start counting.

## Explicitly not changed

The storage layer is provider truth and other consumers depend on current semantics:

- `interface.py:2588` Anthropic's `base_input + cache_creation + cache_read` reassembly, and every other provider's extraction
- `storage.py:227` `SUM(input_tokens + output_tokens)`
- `token.py:40` `billable_tokens`, already uncached-only and documented as intentionally separate from display (it's the budget limiter)
- WebSocket payload, SQLite schema

This is presentation-only plus the new cumulative coun

## Testing

- `tests/test_tokens_command.py`, 6 checks: totals sur`, round-trip through `to_dict`/`from_dict`,pre-existing sessions load as zero, the subtraction, the clamp when a provider over-reports cache reads, and unsaved sessions reading as
zero
- `tests/test_token_attribution.py`, 6 passed, no regression
- `tsc --noEmit` clean, `npm run build` green
- Verified live: `/tokens` against a real session returned `79,022 / 312,455 / 5,770 / 84,792`, matching `sessions.db`
(`total_input=391,477`, `total_cache=312,455`)

## Reviewer notes

- **Existing sessions start at zero.** No backfill, be were being wiped and `usage_events` never recorded`session_id`. Current chats read `0` until they run again.
- **A brand-new chat reports zeros, not an error.** Seon first message, so an unsent chat sends `sessionId:"new"` and `session_manager.get()` returns `None`. Handled via `getattr(session, ..., 0)`.
- **First LLM call of a session always shows `Cached: e cache rather than reading it (`interface.py:1406`records a miss). Correct, but looks like a bug if you test with a single message.
- The dashboard's Total and `/tokens`' Total now agreet both differ from the raw `token.total` the API stillreturns.

## Follow-up (not in this PR)

Populating `session_id` in `usage_events` would let per-session totals survive a DB rebuild and feed the dashboard, and would remove the
need for counters on the Session object at all.