### PR TITLE
Second Error Message Expansion Catalogue: Provider Interfaces

### DIFF
--- a/app/agent_base.py
+++ b/app/agent_base.py
@@ -629,7 +629,23 @@ class AgentBase:
             await self.state_manager.start_turn(session_id)
 
             # ----- The one turn pipeline -----
-            action_decisions, reasoning = await self._select_action(trigger_data)
+            try:
+                action_decisions, reasoning = await self._select_action(trigger_data)
+            except Exception as e:
+                # The LLM call that decides what to do next is what failed —
+                # unlike a downstream action/tool failure, there's no "let the
+                # LLM see the error and adapt" recovery available here, since
+                # reaching the LLM is exactly what just failed. Auto-triggering
+                # RUN_CONTINUATION would just repeat the same doomed call, and
+                # since LLMInterface._consecutive_failures is a shared, cross-
+                # turn counter, that second attempt tends to cross the fatal
+                # threshold moments later — producing a second, differently-
+                # worded message for the same underlying failure. Halt cleanly
+                # instead; the user resumes by sending a new chat message.
+                await self._handle_react_error(
+                    e, session_id, {}, allow_continuation=False
+                )
+                return
 
             prepared_actions = await self._retrieve_and_prepare_actions(
                 action_decisions
@@ -1426,6 +1442,8 @@ class AgentBase:
         error: Exception,
         session_id: str,
         action_output: dict,
+        *,
+        allow_continuation: bool = True,
     ) -> None:
         """Handle errors during react execution.
 
@@ -1437,10 +1455,14 @@ class AgentBase:
           config problem — a genuine bug or crash) — full error detail with
           the red "error" styling.
 
-        This is independent of whether the run halts: only a fatal
-        `LLMConsecutiveFailureError` halts the run (5 failed attempts, or an
-        immediate fail-fast category); everything else lets the react loop
-        continue to the next turn while still telling the user what happened.
+        This is independent of whether the run halts: a fatal
+        `LLMConsecutiveFailureError` (5 failed attempts, or an immediate
+        fail-fast category) always halts the run; everything else lets the
+        react loop continue to the next turn while still telling the user
+        what happened — UNLESS `allow_continuation=False` (set by `react()`
+        when the failure came from the action-decision LLM call itself:
+        auto-continuing would just repeat the same doomed call, which is how
+        a single provider outage used to surface as two separate messages).
         """
         is_fatal, fatal_exc, classified_info = self._classify_react_error(error)
         is_critical = classified_info is None
@@ -1481,15 +1503,21 @@ class AgentBase:
                 task_id=session_id,
             )
             self.state_manager.bump_event_stream()
-            if is_fatal:
+            if is_fatal or not allow_continuation:
                 # Stop the run instead of re-queueing to prevent infinite
                 # retries. The user resumes by sending a normal chat message
                 # — _handle_chat_message already resets the failure counter
                 # on intake, so no separate Retry action is needed.
-                logger.warning(
-                    f"[REACT ERROR] LLMConsecutiveFailureError — halting run for "
-                    f"session {session_id}."
-                )
+                if is_fatal:
+                    logger.warning(
+                        f"[REACT ERROR] LLMConsecutiveFailureError — halting run for "
+                        f"session {session_id}."
+                    )
+                else:
+                    logger.warning(
+                        f"[REACT ERROR] Action-decision call failed — halting run "
+                        f"for session {session_id} instead of auto-continuing."
+                    )
                 self._emit_run_state(session_id, False)
                 await self._display_react_error(session_id, info, critical=is_critical)
             else:

--- a/app/data/action/run_shell.py
+++ b/app/data/action/run_shell.py
@@ -332,6 +332,19 @@ def shell_exec_windows(input_data: dict) -> dict:
     for k, v in env_input.items():
         env[str(k)] = str(v)
 
+    # cmd is dispatched differently from powershell/pwsh: passing a LIST to
+    # Popen on Windows runs it through list2cmdline(), which wraps `command`
+    # in an outer quote pair and backslash-escapes every inner `"`. cmd.exe's
+    # own /S quote-stripping does not understand backslash-escaped quotes, so
+    # any command containing an embedded quoted substring (e.g. `claude -p
+    # "<prompt>"`) gets corrupted — confirmed live: a real R8 handoff launch
+    # was reduced to a single word ("You" out of the whole prompt) by this
+    # exact path. Passing the raw string with shell=True instead lets Python
+    # hand it to `cmd.exe /c <string>` directly with no extra escaping layer,
+    # which round-trips embedded quotes correctly (verified, including an
+    # em-dash, byte-for-byte). powershell/pwsh are unaffected — they receive
+    # `command` as a single argv element via -Command either way.
+    use_shell = shell_choice == "cmd"
     if shell_choice == "powershell":
         args = [
             "powershell.exe",
@@ -353,8 +366,7 @@ def shell_exec_windows(input_data: dict) -> dict:
             command,
         ]
     else:
-        # Use /d and /s to ensure quoted commands (e.g., paths with spaces) are handled consistently.
-        args = ["cmd.exe", "/d", "/s", "/c", command]
+        args = command
 
     creation_flags = getattr(subprocess, "CREATE_NO_WINDOW", 0)
 
@@ -365,6 +377,7 @@ def shell_exec_windows(input_data: dict) -> dict:
             bg_flags = creation_flags | subprocess.CREATE_NEW_PROCESS_GROUP
             process = subprocess.Popen(
                 args,
+                shell=use_shell,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 stdin=subprocess.DEVNULL,
@@ -396,6 +409,7 @@ def shell_exec_windows(input_data: dict) -> dict:
         fg_flags = creation_flags | subprocess.CREATE_NEW_PROCESS_GROUP
         process = subprocess.Popen(
             args,
+            shell=use_shell,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             stdin=subprocess.DEVNULL,

--- a/app/errors/__init__.py
+++ b/app/errors/__init__.py
@@ -1,5 +1,21 @@
-"""App-layer error catalogue — see app/errors/codebook.py."""
+"""App-layer error catalogue.
 
-from app.errors.codebook import CatalogError, make_error
+`app/errors/codebook.py` — curated codes and `make_error()`/`verbatim()`/
+`error_from_exception()` for building a classified `ErrorInfo`.
+`app/errors/envelope.py` — `error_fields()`, the snake_case wire-tag block
+shared by every non-chat transport (action outputs, browser_adapter WS/REST,
+slash-command events).
+`app/errors/actions.py` — the exec-safe facade `@action` handler bodies
+import from (function-local import required — see that module's docstring).
+`app/errors/web.py` — `error_json_response()` for aiohttp REST handlers.
 
-__all__ = ["CatalogError", "make_error"]
+Naming rule (see envelope.py for the full rationale): new error envelopes
+are snake_case; `ChatMessage.to_dict()`'s camelCase `errorCategory`/
+`errorCode`/`errorSeverity` and `error_json_response`'s snake_case
+`error_category`/`error_code` are both pre-existing, shipped wire contracts
+and are never renamed to "harmonize" them.
+"""
+
+from app.errors.codebook import CatalogError, error_from_exception, make_error, verbatim
+
+__all__ = ["CatalogError", "make_error", "verbatim", "error_from_exception"]

--- a/app/errors/actions.py
+++ b/app/errors/actions.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+"""Error helpers for `@action` handler bodies.
+
+Internal action handlers are not called directly: the registry stores
+`inspect.getsource(handler)` with the `@action` decorator stripped
+(agent_core/core/action_framework/registry.py:247-249), and the executor runs
+`exec(action.code, local_ns, local_ns)` with `local_ns = {input_data, json,
+asyncio}` (agent_core/core/impl/action/executor.py:522 sync, :569 async).
+
+Consequences for every ported action body:
+  - imports must be FUNCTION-LOCAL — `from app.errors.actions import ...` as
+    the first statement, exactly like the existing precedent at
+    app/data/action/web_fetch.py:102 ("must be inside for sandboxed
+    execution").
+  - no second decorator on the handler, and no comment/blank line between
+    `@action` and `def` — `_strip_decorator` slices source, not AST.
+  - no new module-level helper visible to the exec'd body.
+
+This module exists so that discipline is ONE import line per action instead
+of importing `app.errors.codebook` piecemeal, and so `grep -r
+"app.errors.actions" app/data/action` is an exact adoption audit. Keep it
+free of heavy/optional imports (notably aiohttp, which lives in
+app/errors/web.py, never here) since it resolves on every action invocation.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from agent_core.core.errors import ErrorInfoLike
+from app.errors.codebook import (  # noqa: F401 - re-exported for action bodies
+    error_from_exception,
+    make_error,
+    verbatim,
+)
+from app.errors.envelope import error_fields
+
+__all__ = ["action_error", "make_error", "verbatim", "error_from_exception"]
+
+
+def action_error(info: ErrorInfoLike, **passthrough: Any) -> Dict[str, Any]:
+    """Build an action's error return dict.
+
+    `passthrough` re-states the action's success-shape keys with empty
+    values (`content=""`, `return_code=-1`, ...) — the existing convention
+    every hand-rolled error dict already follows, so an action's output
+    schema stays stable across success and failure. It's spread BEFORE the
+    error tags so a caller can never accidentally shadow `error_category`/
+    `error_code`/`error_severity`.
+
+    Emits `message` — the documented, dominant action contract, and the
+    exact text the LLM reads from the <event_stream> block on the next turn
+    (agent_core/core/impl/action/manager.py -> event_stream.py ->
+    context/engine.py). Deliberately omits `error_actions`: nothing on the
+    action path renders buttons, and every extra key here is pretty-printed
+    into the prompt on every turn.
+    """
+    return {
+        "status": "error",
+        "message": info.message,
+        **passthrough,
+        **error_fields(info),
+    }

--- a/app/errors/codebook.py
+++ b/app/errors/codebook.py
@@ -2,16 +2,19 @@
 """
 App-layer error codebook.
 
-Curated, representative entries for the highest-duplication non-LLM call
-sites (see docs/error_handling_report.md and the error-catalogue plan). This
-is deliberately a small proof-of-adoption set, not exhaustive coverage of
-every hand-rolled error string in the app.
+Curated entries for the highest-duplication non-LLM call sites across the
+app: provider/config guards (Phase 1), and action handlers, browser_adapter,
+slash commands, and CLI output (Phase 2 — see docs/error_handling_report.md
+and the error-catalogue plan). This stays curated, not exhaustive: a code
+earns its place here at roughly 5+ call sites, or when it needs an
+`ErrorAction` (a settings-link, etc.) that a one-off `verbatim()` call can't
+carry. Everything below that bar stays a `verbatim()` call at its call site.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, Optional, Type
 
 from agent_core.core.errors import (
     ClassifiedError,
@@ -96,6 +99,105 @@ _CODEBOOK: Dict[str, _Spec] = {
         title="Sub-agent call timed out",
         message_template="The sub-agent LLM call did not respond within {timeout}s.",
     ),
+    # ─── Phase 2: action handlers, browser_adapter, commands, CLI ──────────
+    "VALIDATION_REQUIRED_FIELD": _Spec(
+        category=ErrorCategory.VALIDATION,
+        severity=Severity.ERROR,
+        title="Missing required input",
+        message_template="{field} is required.",
+    ),
+    "VALIDATION_BAD_VALUE": _Spec(
+        category=ErrorCategory.VALIDATION,
+        severity=Severity.ERROR,
+        title="Invalid input",
+        message_template="Invalid {field}: {reason}",
+    ),
+    "NOT_FOUND_PATH": _Spec(
+        category=ErrorCategory.NOT_FOUND,
+        severity=Severity.ERROR,
+        title="File not found",
+        message_template="No such file or directory: {path}",
+    ),
+    "NOT_FOUND_NAMED": _Spec(
+        category=ErrorCategory.NOT_FOUND,
+        severity=Severity.ERROR,
+        title="Not found",
+        message_template="{kind} not found: {name}",
+    ),
+    "PERMISSION_DENIED_PATH": _Spec(
+        category=ErrorCategory.PERMISSION,
+        severity=Severity.ERROR,
+        title="Permission denied",
+        message_template="Permission denied accessing {path}. {detail}",
+    ),
+    "COMPONENT_NOT_INITIALIZED": _Spec(
+        category=ErrorCategory.CONFIG,
+        severity=Severity.ERROR,
+        title="Component unavailable",
+        message_template="{component} is not initialized.",
+        actions=_settings_action,
+    ),
+    "PROVIDER_UNAVAILABLE": _Spec(
+        category=ErrorCategory.CONFIG,
+        severity=Severity.ERROR,
+        title="Provider unavailable",
+        message_template="{provider} is not available. {detail}",
+        actions=_settings_action,
+    ),
+    "SHELL_TIMEOUT": _Spec(
+        category=ErrorCategory.CONNECTION,
+        severity=Severity.ERROR,
+        title="Command timed out",
+        message_template="Command timed out after {timeout}s.",
+    ),
+    "FILE_READ_FAILED": _Spec(
+        category=ErrorCategory.INTERNAL,
+        severity=Severity.ERROR,
+        title="Could not read file",
+        message_template="Could not read {path}. {detail}",
+    ),
+    "FILE_WRITE_FAILED": _Spec(
+        category=ErrorCategory.INTERNAL,
+        severity=Severity.ERROR,
+        title="Could not write file",
+        message_template="Could not write {path}. {detail}",
+    ),
+    "PROCESS_LAUNCH_FAILED": _Spec(
+        category=ErrorCategory.INTERNAL,
+        severity=Severity.ERROR,
+        title="Could not start process",
+        message_template="Could not start {process}. {detail}",
+    ),
+    "INTEGRATION_CALL_FAILED": _Spec(
+        category=ErrorCategory.SERVER,
+        severity=Severity.ERROR,
+        title="Integration request failed",
+        message_template="{integration}: {detail}",
+    ),
+    "SKILL_OP_FAILED": _Spec(
+        category=ErrorCategory.INTERNAL,
+        severity=Severity.ERROR,
+        title="Skill operation failed",
+        message_template="Could not {operation} skill {name}. {detail}",
+    ),
+    "COMMAND_USAGE": _Spec(
+        category=ErrorCategory.VALIDATION,
+        severity=Severity.ERROR,
+        title="Invalid command usage",
+        message_template="Usage: {usage}",
+    ),
+    "COMMAND_UNKNOWN": _Spec(
+        category=ErrorCategory.VALIDATION,
+        severity=Severity.ERROR,
+        title="Unknown command",
+        message_template="Unknown command: {command}. Use /help for available commands.",
+    ),
+    "COMMAND_FAILED": _Spec(
+        category=ErrorCategory.INTERNAL,
+        severity=Severity.ERROR,
+        title="Command failed",
+        message_template="{command} failed. {detail}",
+    ),
 }
 
 
@@ -124,6 +226,92 @@ def make_error(code: str, **fmt_kwargs) -> ErrorInfo:
         severity=spec.severity,
         actions=spec.actions(**fmt_kwargs),
     )
+
+
+def verbatim(
+    message: str,
+    *,
+    category: ErrorCategory,
+    code: str,
+    title: str = "",
+    severity: Severity = Severity.ERROR,
+) -> ErrorInfo:
+    """Classify a message WITHOUT rewording it.
+
+    For one-off strings that are instructions to the model rather than
+    boilerplate — e.g. "old_string appears 3 times in file. Either provide
+    more context..." — retagging must not touch the words, since the agent
+    relies on that exact phrasing to self-correct. Anything reused at 2+
+    call sites should get a real `_CODEBOOK` entry instead, so its wording
+    is locked by tests rather than copy-pasted.
+    """
+    return ErrorInfo(category=category, code=code, title=title, message=message, severity=severity)
+
+
+# Exception type -> category, walked via the exception's MRO in
+# `error_from_exception`. Deliberately small: only stdlib exception types
+# that unambiguously imply a category. Anything else falls back to the
+# caller-supplied `category`, then to UNKNOWN.
+_EXC_CATEGORY: Dict[Type[BaseException], ErrorCategory] = {
+    FileNotFoundError: ErrorCategory.NOT_FOUND,
+    PermissionError: ErrorCategory.PERMISSION,
+    IsADirectoryError: ErrorCategory.VALIDATION,
+    NotADirectoryError: ErrorCategory.VALIDATION,
+    TimeoutError: ErrorCategory.CONNECTION,
+    ConnectionError: ErrorCategory.CONNECTION,
+    ValueError: ErrorCategory.VALIDATION,
+    TypeError: ErrorCategory.VALIDATION,
+    KeyError: ErrorCategory.VALIDATION,
+}
+
+
+def _category_for_exception(exc: BaseException) -> Optional[ErrorCategory]:
+    for exc_type in type(exc).__mro__:
+        category = _EXC_CATEGORY.get(exc_type)
+        if category is not None:
+            return category
+    return None
+
+
+def error_from_exception(
+    exc: BaseException, *, code: str, category: Optional[ErrorCategory] = None, **fmt_kwargs
+) -> ErrorInfo:
+    """Classify + redact a caught exception in one call.
+
+    Replaces the `except Exception as e: ... str(e)` idiom repeated across
+    action handlers, browser_adapter and the command executor. `detail` is
+    filled in from `str(exc)` automatically (and redacted by `make_error`,
+    same as any other `detail` kwarg) unless the caller already supplied one.
+    Semantic kwargs (`path=`, `target=`, `provider=`) are never redacted.
+
+    If `exc` is already a `ClassifiedError`, its own `.info` is returned
+    untouched — never re-classify an error that already knows what it is.
+
+    The category resolution order is: the exception's own type (via
+    `_EXC_CATEGORY`) > the caller-supplied `category` > the codebook code's
+    declared category. A `FileNotFoundError` raised at a call site tagged
+    `FILE_READ_FAILED` (declared INTERNAL) still comes back NOT_FOUND — the
+    exception type is more specific than the code's default.
+    """
+    if isinstance(exc, ClassifiedError):
+        return exc.info  # type: ignore[return-value]
+
+    fmt_kwargs.setdefault("detail", str(exc))
+    info = make_error(code, **fmt_kwargs)
+
+    resolved = _category_for_exception(exc) or category
+    if resolved is not None and resolved is not info.category:
+        info = ErrorInfo(
+            category=resolved,
+            code=info.code,
+            title=info.title,
+            message=info.message,
+            severity=info.severity,
+            actions=info.actions,
+            raw_message=info.raw_message,
+            context=info.context,
+        )
+    return info
 
 
 class CatalogError(ClassifiedError):

--- a/app/errors/envelope.py
+++ b/app/errors/envelope.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+"""Shared wire tags for dict-shaped error envelopes.
+
+`ErrorInfo`/`ErrorInfoLike` (agent_core/core/errors.py) is the in-process
+representation of a classified error. This module is the one place that
+turns it into the flat snake_case tag block every non-chat transport
+(action outputs, browser_adapter WS/REST, slash-command events) uses.
+
+Naming rule: error fields adopt the case convention of the envelope they're
+embedded in, never the convention of `ErrorInfo` itself. `ChatMessage.to_dict()`
+(app/ui_layer/components/types.py) is camelCase (`errorCategory`) because it
+shipped that way in the Phase 1 error-catalogue work; `error_json_response`
+(app/errors/web.py) is snake_case for the same reason. Every NEW envelope in
+Phase 2 is snake_case, matching its neighbouring keys (`return_code`,
+`content_length`, `project_id`). `ErrorInfo.to_dict()` stays snake_case too,
+but it's a logging/debug serializer — never put it on a wire directly, use
+`error_fields()` instead.
+
+No `error_actions` key: nothing on the action, WS, or toast transport renders
+buttons in this phase (chat bubbles get theirs from `build_error_chat_message`
+instead, unchanged). Shipping a field no consumer reads is exactly how
+`errorSeverity` sat dead on the ChatMessage wire after Phase 1 — don't repeat
+that here.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from agent_core.core.errors import ErrorCategory, ErrorInfo, ErrorInfoLike, Severity
+
+# Keys `error_fields()` may emit. `error_category` is the only one guaranteed
+# present; `error_code`/`error_severity` are omitted when absent rather than
+# emitted as null (see module docstring and error_fields' own docstring).
+ERROR_FIELD_KEYS = frozenset({"error_category", "error_code", "error_severity"})
+
+
+def error_fields(info: ErrorInfoLike) -> Dict[str, str]:
+    """Additive snake_case tags for any dict-shaped error envelope.
+
+    `{**payload, **error_fields(info)}` never introduces a null-valued key an
+    existing consumer would have to guard against — a missing `code`/`severity`
+    is simply left out.
+
+    `code` and `severity` are NOT on the `ErrorInfoLike` Protocol (`LLMErrorInfo`
+    satisfies it structurally without them), so both are read with `getattr`,
+    matching the existing precedent in `error_json_response` (app/errors/web.py)
+    and `build_error_chat_message` (app/ui_layer/components/error_message.py).
+    """
+    out: Dict[str, str] = {"error_category": getattr(info.category, "value", str(info.category))}
+
+    code = getattr(info, "code", None)
+    if code:
+        out["error_code"] = code
+
+    severity = getattr(info, "severity", None)
+    severity_value = getattr(severity, "value", None) if severity is not None else None
+    if severity_value:
+        out["error_severity"] = severity_value
+
+    return out
+
+
+def error_info_from_fields(
+    data: Dict[str, Any], *, message_keys: tuple = ("message", "error")
+) -> Optional[ErrorInfo]:
+    """Rebuild an `ErrorInfo` from a dict previously widened by `error_fields()`.
+
+    Returns `None` when `data` carries no `error_category` — the caller should
+    fall back to whatever untagged-payload handling it had before this existed
+    (e.g. `app/ui_layer/adapters/base.py::_handle_error_message`'s legacy path).
+    An unrecognized category value degrades to `ErrorCategory.UNKNOWN` rather
+    than raising, since this runs on data that already crossed a boundary.
+    """
+    raw_category = data.get("error_category")
+    if not raw_category:
+        return None
+
+    try:
+        category = ErrorCategory(raw_category)
+    except ValueError:
+        category = ErrorCategory.UNKNOWN
+
+    try:
+        severity = Severity(data.get("error_severity") or Severity.ERROR.value)
+    except ValueError:
+        severity = Severity.ERROR
+
+    message = ""
+    for key in message_keys:
+        value = data.get(key)
+        if value:
+            message = value
+            break
+
+    return ErrorInfo(
+        category=category,
+        code=data.get("error_code") or "",
+        title=data.get("error_title") or "",
+        message=message,
+        severity=severity,
+    )

--- a/app/errors/web.py
+++ b/app/errors/web.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from aiohttp import web
 
 from agent_core.core.errors import ErrorInfoLike
+from app.errors.envelope import error_fields
 
 
 def error_json_response(info: ErrorInfoLike, status: int) -> web.Response:
@@ -13,14 +14,12 @@ def error_json_response(info: ErrorInfoLike, status: int) -> web.Response:
 
     Keeps the existing `"error"` string key (so current frontend `fetch`
     consumers that only read `.error` keep working unchanged) and adds
-    `error_category`/`error_code` additively.
+    `error_category`/`error_code`/`error_severity` additively via the shared
+    `error_fields()` tag block (app/errors/envelope.py) — the `error_severity`
+    key is new here; `error`/`error_category`/`error_code` are byte-identical
+    to the contract this shipped with in Phase 1.
     """
-    code = getattr(info, "code", None)
     return web.json_response(
-        {
-            "error": info.message,
-            "error_category": info.category.value,
-            **({"error_code": code} if code else {}),
-        },
+        {"error": info.message, **error_fields(info)},
         status=status,
     )

--- a/app/ui_layer/adapters/base.py
+++ b/app/ui_layer/adapters/base.py
@@ -313,7 +313,31 @@ class InterfaceAdapter(ABC):
         )
 
     def _handle_error_message(self, event: UIEvent) -> None:
-        """Handle error message event."""
+        """Handle error message event.
+
+        When `event.data` carries `error_category` (set by CommandExecutor
+        via `error_fields()` — app/ui_layer/commands/executor.py — for a
+        `CommandResult.failure(...)`), route through the shared
+        `build_error_chat_message` factory so the bubble gets the same
+        category icon, code and severity a classified LLM/provider error
+        does. Untagged events (the common case — plain `{"message": ...}`)
+        fall through to the pre-existing rendering unchanged. This is the
+        only place this needs handling: both CLI and browser adapters
+        inherit `_handle_error_message`/`_display_chat_message` from this
+        base class rather than overriding them.
+        """
+        from app.errors.envelope import error_info_from_fields
+
+        info = error_info_from_fields(event.data)
+        if info is not None:
+            from app.ui_layer.components.error_message import build_error_chat_message
+
+            message = build_error_chat_message(
+                info, sender="Error", session_id=event.task_id or "main"
+            )
+            asyncio.create_task(self.chat_component.append_message(message))
+            return
+
         asyncio.create_task(
             self._display_chat_message(
                 "Error",

--- a/app/ui_layer/adapters/browser_adapter.py
+++ b/app/ui_layer/adapters/browser_adapter.py
@@ -6887,6 +6887,42 @@ A quick Q&A will now begin to understand your objectives to serve you better:"""
         # Clean up disconnected clients
         self._ws_clients -= disconnected
 
+    async def _broadcast_error(
+        self, msg_type: str, exc: BaseException, *, code: str, **identity: Any
+    ) -> None:
+        """Classify, log and broadcast a handler failure.
+
+        Replaces the repeated `except Exception as e: await self._broadcast(
+        {"type": X, "data": {"success": False, "error": str(e), ...}})` shape
+        (~83 sites). Always emits `error` — the key every frontend `d.error ||
+        d.message || 'fallback'` chain reads — alongside the snake_case
+        category/code/severity tags from `error_fields()`, so this stays
+        additive to the existing wire contract. `msg_type` should match the
+        handler's success-branch `type`, exactly as the hand-written except
+        blocks do today.
+
+        `identity` fields (e.g. `name=`, `path=`) are NOT redacted — only the
+        exception text is. Pass diagnostic values like a URL or file path as
+        an identity/semantic kwarg to the underlying error code, never folded
+        into `detail`, or `redact()` will strip it (see app/errors/codebook.py).
+        """
+        from app.errors.codebook import error_from_exception
+        from app.errors.envelope import error_fields
+
+        info = error_from_exception(exc, code=code, **identity)
+        logger.error(f"[{msg_type}] {info.message}")
+        await self._broadcast(
+            {
+                "type": msg_type,
+                "data": {
+                    "success": False,
+                    "error": info.message,
+                    **identity,
+                    **error_fields(info),
+                },
+            }
+        )
+
     async def _broadcast_error_to_chat(self, error_message: str) -> None:
         """Broadcast an error message to the chat panel for debugging."""
         import time

--- a/app/ui_layer/browser/frontend/src/contexts/ToastContext.tsx
+++ b/app/ui_layer/browser/frontend/src/contexts/ToastContext.tsx
@@ -4,20 +4,37 @@ import { getErrorCategoryStyle } from '../constants/errorCategories'
 import styles from './ToastContext.module.css'
 
 type ToastType = 'success' | 'error' | 'warning' | 'info'
+// Mirrors Severity in agent_core/core/errors.py / errorSeverity on ChatMessage
+// (src/types/index.ts). Only meaningful on error toasts — success/info/warning
+// toasts don't carry one and keep the fixed 3s duration below.
+export type ToastSeverity = 'info' | 'warning' | 'error' | 'critical'
+
+// How long a toast stays up once its severity is known. A toast with no
+// severity (the vast majority of existing call sites — none pass it) keeps
+// today's flat 3000ms. `critical` never auto-dismisses; the whole toast is
+// still a click-to-dismiss target, so that's not a dead end.
+const SEVERITY_DURATION_MS: Record<ToastSeverity, number> = {
+  info: 3000,
+  warning: 5000,
+  error: 6000,
+  critical: Infinity,
+}
 
 interface Toast {
   id: string
   type: ToastType
   message: string
   category?: string
+  severity?: ToastSeverity
 }
 
 interface ToastContextValue {
   /** `category` (an ErrorCategory value, e.g. "auth"/"rate_limit") is optional —
    * when provided on a type='error' toast, its icon/color from
-   * errorCategories.ts replaces the generic error icon. Existing call sites
-   * that don't pass it keep today's behavior unchanged. */
-  showToast: (type: ToastType, message: string, category?: string) => void
+   * errorCategories.ts replaces the generic error icon. `severity` drives
+   * auto-dismiss duration (see SEVERITY_DURATION_MS). Existing call sites
+   * that pass neither keep today's exact behavior unchanged. */
+  showToast: (type: ToastType, message: string, category?: string, severity?: ToastSeverity) => void
 }
 
 const ToastContext = createContext<ToastContextValue | null>(null)
@@ -34,15 +51,20 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
   const [toasts, setToasts] = useState<Toast[]>([])
   const idCounter = useRef(0)
 
-  const showToast = useCallback((type: ToastType, message: string, category?: string) => {
-    const id = `toast-${++idCounter.current}`
-    setToasts(prev => [...prev, { id, type, message, category }])
+  const showToast = useCallback(
+    (type: ToastType, message: string, category?: string, severity?: ToastSeverity) => {
+      const id = `toast-${++idCounter.current}`
+      setToasts(prev => [...prev, { id, type, message, category, severity }])
 
-    // Auto-dismiss after 3 seconds
-    setTimeout(() => {
-      setToasts(prev => prev.filter(t => t.id !== id))
-    }, 3000)
-  }, [])
+      const duration = severity ? SEVERITY_DURATION_MS[severity] : 3000
+      if (Number.isFinite(duration)) {
+        setTimeout(() => {
+          setToasts(prev => prev.filter(t => t.id !== id))
+        }, duration)
+      }
+    },
+    []
+  )
 
   const dismissToast = useCallback((id: string) => {
     setToasts(prev => prev.filter(t => t.id !== id))

--- a/app/ui_layer/browser/frontend/src/pages/Chat/ChatMessage.tsx
+++ b/app/ui_layer/browser/frontend/src/pages/Chat/ChatMessage.tsx
@@ -87,12 +87,30 @@ export const ChatMessageItem = memo(function ChatMessageItem({
   }
 
   const isAgent = message.style === 'agent'
-  const errorStyle = message.style === 'error' ? getErrorCategoryStyle(message.errorCategory) : null
+  // 'system'-styled messages can carry a category too: build_error_chat_message
+  // (app/ui_layer/components/error_message.py) sends style="system" for the
+  // "minor" presentation tier — recognized, actionable errors (bad key, no
+  // credits) that have action buttons — reserving style="error" for the
+  // critical/unclassified tier. Gating on 'error' alone meant the tier with
+  // actions never got a category icon. Plain (non-error) system messages
+  // have no errorCategory, so getErrorCategoryStyle is only reached when one
+  // is actually present.
+  const errorStyle =
+    message.style === 'error' || (message.style === 'system' && message.errorCategory)
+      ? getErrorCategoryStyle(message.errorCategory)
+      : null
   const ErrorIcon = errorStyle?.icon
 
   const bubbleContainer = (
     <div className={styles.messageBubbleContainer}>
-      <div className={`${styles.message} ${styles[message.style]} ${message.pending ? styles.pending : ''}`}>
+      <div
+        className={`${styles.message} ${styles[message.style]} ${message.pending ? styles.pending : ''}`}
+        // No CSS currently keys off this — it's a hook for later severity
+        // styling (e.g. a distinct treatment for 'critical'), not a rendered
+        // effect today. Kept deliberately narrow: see the errorSeverity note
+        // in ToastContext.tsx for the sibling job this field was given.
+        data-severity={message.errorSeverity}
+      >
         <div className={styles.messageHeader}>
           <span className={styles.sender}>
             {ErrorIcon && (

--- a/app/ui_layer/browser/frontend/src/utils/errorPayload.ts
+++ b/app/ui_layer/browser/frontend/src/utils/errorPayload.ts
@@ -1,0 +1,36 @@
+// Shared shape + hook for the snake_case error tags backend handlers add to
+// WS/REST payloads (app/errors/envelope.py::error_fields, PR1 of the error-
+// catalogue Phase 2 work). All fields optional and additive: any payload
+// that predates this still satisfies WireError, and a call site that never
+// migrates keeps compiling and behaving exactly as before.
+import { useCallback } from 'react'
+import { useToast, type ToastSeverity } from '../contexts/ToastContext'
+
+export interface WireError {
+  success?: boolean
+  error?: string
+  message?: string
+  error_category?: string
+  error_code?: string
+  error_severity?: ToastSeverity
+}
+
+/**
+ * `useErrorToast()` collapses the repeated
+ *   `const d = data as {success: boolean; error?: string}
+ *    if (!d.success) showToast('error', d.error || 'fallback')`
+ * idiom to one line, and — once a backend handler is ported to
+ * `_broadcast_error`/`error_json_response` — starts passing the category and
+ * severity through automatically. Call sites that haven't been ported yet
+ * just see undefined category/severity, matching today's plain toast.
+ */
+export function useErrorToast() {
+  const { showToast } = useToast()
+  return useCallback(
+    (data: unknown, fallback: string) => {
+      const d = (data ?? {}) as WireError
+      showToast('error', d.error || d.message || fallback, d.error_category, d.error_severity)
+    },
+    [showToast]
+  )
+}

--- a/app/ui_layer/commands/base.py
+++ b/app/ui_layer/commands/base.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional, TYPE_CHECKING, Tuple
 
 if TYPE_CHECKING:
     from app.ui_layer.controller.ui_controller import UIController
+    from agent_core.core.errors import ErrorInfoLike
 
 
 @dataclass
@@ -19,11 +20,27 @@ class CommandResult:
         success: Whether the command executed successfully
         message: Optional message to display to the user
         data: Optional additional data from the command
+        info: Optional classified error (category/code/severity) when
+            `success` is False. `message` stays populated independently —
+            existing consumers that only read `.message` (the COMMAND_ERROR
+            event payload, the terminal renderer) are unaffected by this
+            field's presence or absence. Use `CommandResult.failure()` to
+            build both from one `ErrorInfo` at once.
     """
 
     success: bool
     message: Optional[str] = None
     data: Optional[Dict[str, Any]] = field(default_factory=dict)
+    info: Optional["ErrorInfoLike"] = None
+
+    @classmethod
+    def failure(cls, info: "ErrorInfoLike", **data: Any) -> "CommandResult":
+        """Build a failed `CommandResult` from a classified error.
+
+        `data` is passed straight through as the result's `data` dict, same
+        as constructing `CommandResult(success=False, ...)` by hand.
+        """
+        return cls(success=False, message=info.message, info=info, data=data or {})
 
 
 class Command(ABC):

--- a/app/ui_layer/commands/executor.py
+++ b/app/ui_layer/commands/executor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from app.errors.envelope import error_fields
 from app.ui_layer.commands.base import CommandResult
 from app.ui_layer.commands.registry import CommandRegistry
 from app.ui_layer.events import UIEvent, UIEventType
@@ -98,6 +99,11 @@ class CommandExecutor:
                 message=f"Command error: {str(e)}",
             )
 
+        # Additive snake_case category/code/severity tags when the command
+        # built its failure via CommandResult.failure(...). Untagged results
+        # (result.info is None) carry no extra keys, same as before this.
+        error_tags = error_fields(result.info) if result.info is not None else {}
+
         # Emit result event
         event_type = (
             UIEventType.COMMAND_EXECUTED
@@ -114,6 +120,7 @@ class CommandExecutor:
                         "success": result.success,
                         "message": result.message,
                         "data": result.data,
+                        **error_tags,
                     },
                 },
                 source_adapter=adapter_id,
@@ -132,7 +139,7 @@ class CommandExecutor:
             self._controller.event_bus.emit(
                 UIEvent(
                     type=msg_type,
-                    data={"message": result.message},
+                    data={"message": result.message, **error_tags},
                     source_adapter=adapter_id,
                     task_id=session_id,
                 )

--- a/app/ui_layer/events/transformer.py
+++ b/app/ui_layer/events/transformer.py
@@ -207,7 +207,19 @@ class EventTransformer:
         action_id = (
             event.action_id or f"{session_id or 'main'}:{canonical}:{ts.timestamp()}"
         )
-        error_message = output.get("error") if is_error and output else None
+        # The dominant/documented action contract writes "message", not
+        # "error" (see CUSTOM_ACTION_GUIDE.md) — "error" alone left this None
+        # for most action failures, so the panel fell back to dumping raw
+        # output JSON. Prefer "error" when a handler does set it explicitly.
+        error_message = (output.get("error") or output.get("message")) if is_error and output else None
+        # Ported actions (app/errors/actions.py::action_error) additively tag
+        # their output dict with error_category/error_code/error_severity;
+        # unported actions simply don't have these keys.
+        error_tags = (
+            {k: output[k] for k in ("error_category", "error_code", "error_severity") if output.get(k)}
+            if is_error and output
+            else {}
+        )
 
         return UIEvent(
             type=UIEventType.ACTION_END,
@@ -222,6 +234,7 @@ class EventTransformer:
                 # Frontend `ActionItem.output` is typed `string`; serialize
                 # the structured dict to JSON for `parseDict` compatibility.
                 "output": _to_wire_json(output),
+                **error_tags,
             },
             timestamp=ts,
             task_id=session_id,

--- a/tests/test_error_catalog.py
+++ b/tests/test_error_catalog.py
@@ -4,9 +4,12 @@ Backend error-catalogue primitives (agent_core/core/errors.py) and the
 app-layer codebook (app/errors/codebook.py).
 """
 
+import string
+
 import pytest
 
 from agent_core.core.errors import (
+    ClassifiedError,
     ErrorAction,
     ErrorCategory,
     ErrorInfo,
@@ -14,7 +17,8 @@ from agent_core.core.errors import (
     is_transient,
     redact,
 )
-from app.errors import CatalogError, make_error
+from app.errors import CatalogError, error_from_exception, make_error, verbatim
+from app.errors.codebook import _CODEBOOK
 
 
 def test_error_info_to_dict_serializes_enums():
@@ -141,3 +145,109 @@ def test_llm_consecutive_failure_error_auto_derives_immediate_from_count():
     multiple = LLMConsecutiveFailureError(5)
     assert multiple.is_immediate is False
     assert MSG_CONSECUTIVE_FAILURE in str(multiple)
+
+
+# ─── Phase 2: codebook expansion (verbatim / error_from_exception / new codes) ──
+
+
+@pytest.mark.parametrize("code", sorted(_CODEBOOK.keys()))
+def test_every_codebook_entry_formats_without_key_error(code):
+    """Every `_CODEBOOK` template must format cleanly given exactly the
+    fields it declares — derived from the template itself via
+    `string.Formatter`, so this stays correct as codes are added without
+    needing a hand-maintained field list here."""
+    spec = _CODEBOOK[code]
+    formatter = string.Formatter()
+    field_names = {fname for _, fname, _, _ in formatter.parse(spec.message_template) if fname}
+    kwargs = {name: f"<{name}>" for name in field_names}
+
+    info = make_error(code, **kwargs)
+
+    assert info.category is spec.category
+    assert info.code == code
+    for name in field_names:
+        assert f"<{name}>" in info.message
+
+
+def test_verbatim_preserves_exact_message():
+    """`verbatim()` must not reword the text it's given — Tier-1 action
+    sites (model-instructional strings like stream_edit.py's "old_string
+    appears N times...") depend on this to retag without touching wording
+    the agent relies on to self-correct."""
+    text = "old_string appears 3 times in file. Either provide more context to select a unique match."
+    info = verbatim(text, category=ErrorCategory.VALIDATION, code="EDIT_AMBIGUOUS_MATCH")
+    assert info.message == text
+    assert info.category is ErrorCategory.VALIDATION
+    assert info.code == "EDIT_AMBIGUOUS_MATCH"
+    assert info.actions == []
+
+
+def test_verbatim_default_severity_is_error():
+    info = verbatim("m", category=ErrorCategory.NOT_FOUND, code="X")
+    assert info.severity is Severity.ERROR
+
+
+def test_error_from_exception_returns_classified_error_info_untouched():
+    """An already-`ClassifiedError` must never be re-classified — that would
+    demote it toward UNKNOWN via `str(exc)`, discarding the category it
+    already carries."""
+    original = make_error("CONFIG_NO_API_KEY", provider="OpenAI")
+    wrapped = ClassifiedError(original)
+    result = error_from_exception(wrapped, code="COMMAND_FAILED", command="x")
+    assert result is original
+
+
+@pytest.mark.parametrize(
+    "exc,expected_category",
+    [
+        (FileNotFoundError("boom"), ErrorCategory.NOT_FOUND),
+        (PermissionError("boom"), ErrorCategory.PERMISSION),
+        (IsADirectoryError("boom"), ErrorCategory.VALIDATION),
+        (NotADirectoryError("boom"), ErrorCategory.VALIDATION),
+        (TimeoutError("boom"), ErrorCategory.CONNECTION),
+        (ConnectionError("boom"), ErrorCategory.CONNECTION),
+        (ValueError("boom"), ErrorCategory.VALIDATION),
+        (TypeError("boom"), ErrorCategory.VALIDATION),
+        (KeyError("boom"), ErrorCategory.VALIDATION),
+    ],
+)
+def test_error_from_exception_category_from_exception_type(exc, expected_category):
+    """The exception's own type outranks the codebook code's declared
+    category — FILE_READ_FAILED defaults to INTERNAL, but a real
+    FileNotFoundError must still come back NOT_FOUND."""
+    info = error_from_exception(exc, code="FILE_READ_FAILED", path="/some/path.txt")
+    assert info.category is expected_category
+
+
+def test_error_from_exception_falls_back_to_codebook_category_when_unmapped():
+    class _CustomError(Exception):
+        pass
+
+    info = error_from_exception(_CustomError("boom"), code="FILE_READ_FAILED", path="/x")
+    assert info.category is ErrorCategory.INTERNAL  # FILE_READ_FAILED's own declared category
+
+
+def test_error_from_exception_explicit_category_wins_when_exception_type_unmapped():
+    class _CustomError(Exception):
+        pass
+
+    info = error_from_exception(
+        _CustomError("boom"), code="FILE_READ_FAILED", category=ErrorCategory.SERVER, path="/x"
+    )
+    assert info.category is ErrorCategory.SERVER
+
+
+def test_error_from_exception_redacts_detail_not_semantic_kwargs():
+    """`detail` is auto-filled from `str(exc)` and redacted like any other
+    `detail` kwarg; `path` (a semantic, already-user-known value) must
+    survive untouched — the redaction carve-out ported call sites rely on."""
+    exc = FileNotFoundError("/home/user/secret.py")
+    info = error_from_exception(exc, code="FILE_READ_FAILED", path="/keep/this/path.txt")
+    assert "/keep/this/path.txt" in info.message
+    assert "/home/user/secret.py" not in info.message
+
+
+def test_error_from_exception_explicit_detail_not_overwritten():
+    info = error_from_exception(ValueError("raw"), code="FILE_READ_FAILED", path="/x", detail="curated detail")
+    assert "curated detail" in info.message
+    assert "raw" not in info.message

--- a/tests/test_error_envelope.py
+++ b/tests/test_error_envelope.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+"""
+`app/errors/envelope.py` — the shared snake_case wire-tag block used by every
+non-chat error transport (action outputs, browser_adapter WS/REST, slash
+commands). See app/errors/envelope.py's module docstring for the naming rule
+this file exists to lock down: new envelopes are snake_case, and
+`error_json_response`'s existing `error`/`error_category`/`error_code` keys
+(shipped in the Phase 1 error-catalogue work) must never change shape.
+"""
+
+import json
+
+from agent_core.core.errors import ErrorCategory, Severity
+from app.errors import make_error
+from app.errors.envelope import ERROR_FIELD_KEYS, error_fields, error_info_from_fields
+
+
+class _MinimalInfo:
+    """The minimal shape `ErrorInfoLike` requires structurally — no `code`
+    or `severity` attribute at all (unlike `ErrorInfo`/`LLMErrorInfo`, which
+    always have `severity` via a default). Exercises the `getattr` fallback
+    in `error_fields()`."""
+
+    def __init__(self) -> None:
+        self.category = ErrorCategory.UNKNOWN
+        self.title = "t"
+        self.message = "m"
+        self.actions = []
+
+
+def test_error_field_keys_is_exact_literal():
+    assert ERROR_FIELD_KEYS == {"error_category", "error_code", "error_severity"}
+
+
+def test_error_fields_full_info_has_all_three_keys():
+    info = make_error("CONFIG_NO_API_KEY", provider="OpenAI")
+    fields = error_fields(info)
+    assert set(fields) == {"error_category", "error_code", "error_severity"}
+    assert fields["error_category"] == "config"
+    assert fields["error_code"] == "CONFIG_NO_API_KEY"
+    assert fields["error_severity"] == "error"
+
+
+def test_error_fields_omits_missing_code_and_severity_not_null():
+    fields = error_fields(_MinimalInfo())
+    assert fields == {"error_category": "unknown"}
+    assert "error_code" not in fields
+    assert "error_severity" not in fields
+
+
+def test_error_fields_is_always_a_subset_of_error_field_keys():
+    for info in (make_error("CONNECTION_TIMEOUT", target="x"), _MinimalInfo()):
+        assert set(error_fields(info)) <= ERROR_FIELD_KEYS
+
+
+def test_error_info_from_fields_round_trip():
+    info = make_error("VALIDATION_REQUIRED_FIELD", field="path")
+    payload = {"message": info.message, **error_fields(info)}
+    rebuilt = error_info_from_fields(payload)
+    assert rebuilt is not None
+    assert rebuilt.category is info.category
+    assert rebuilt.code == info.code
+    assert rebuilt.severity == info.severity
+    assert rebuilt.message == info.message
+
+
+def test_error_info_from_fields_returns_none_when_untagged():
+    assert error_info_from_fields({"message": "plain message, no category"}) is None
+
+
+def test_error_info_from_fields_prefers_message_over_error_key():
+    payload = {"error_category": "auth", "message": "from message", "error": "from error"}
+    info = error_info_from_fields(payload)
+    assert info.message == "from message"
+
+
+def test_error_info_from_fields_falls_back_to_error_key():
+    payload = {"error_category": "auth", "error": "from error"}
+    info = error_info_from_fields(payload)
+    assert info.message == "from error"
+
+
+def test_error_info_from_fields_unknown_category_degrades_to_unknown():
+    info = error_info_from_fields({"error_category": "not_a_real_category", "message": "m"})
+    assert info is not None
+    assert info.category is ErrorCategory.UNKNOWN
+
+
+def test_error_info_from_fields_bad_severity_falls_back_to_error():
+    info = error_info_from_fields(
+        {"error_category": "auth", "message": "m", "error_severity": "not_a_real_severity"}
+    )
+    assert info.severity is Severity.ERROR
+
+
+def test_error_json_response_shape_unchanged():
+    """Regression lock on the Phase 1 contract: `error`/`error_category`/
+    `error_code` must stay byte-identical after the `error_fields()` refactor;
+    `error_severity` is the one additive new key."""
+    from app.errors.web import error_json_response
+
+    info = make_error("CONNECTION_TIMEOUT", target="example.com")
+    resp = error_json_response(info, status=504)
+    assert resp.status == 504
+    body = json.loads(resp.text)
+    assert body["error"] == info.message
+    assert body["error_category"] == "connection"
+    assert body["error_code"] == "CONNECTION_TIMEOUT"
+    assert body["error_severity"] == "error"

--- a/tests/test_error_presentation_tiers.py
+++ b/tests/test_error_presentation_tiers.py
@@ -31,6 +31,7 @@ from agent_core.core.impl.action.router import ActionRouter
 from agent_core.core.impl.llm.errors import LLMConsecutiveFailureError, LLMErrorInfo
 from app.agent_base import AgentBase
 from app.errors import CatalogError, make_error
+from app.triggers import TriggerSource
 from app.ui_layer.components.error_message import build_error_chat_message
 from app.ui_layer.components.types import ChatMessage, ChatMessageOption
 
@@ -246,3 +247,126 @@ def test_router_wraps_persistent_llm_failure_as_classified_error():
         "Anthropic client was not initialised. Check LLM configuration, "
         "API credentials, and service availability."
     )
+
+
+# ─── AgentBase._handle_react_error: allow_continuation gates auto-retry ────
+#
+# A failure in the action-decision LLM call (react()'s _select_action) used
+# to unconditionally auto-retrigger a full new turn via RUN_CONTINUATION,
+# even though reaching the LLM is exactly what just failed — silently
+# repeating a doomed call and, because LLMInterface._consecutive_failures is
+# a shared cross-turn counter, often crossing the fatal threshold moments
+# later and showing a SECOND, differently-worded message for the same
+# underlying failure. react() now catches _select_action's failures
+# separately and passes allow_continuation=False so _handle_react_error
+# halts instead of re-triggering; every other pipeline stage keeps the
+# default (allow_continuation=True, today's existing behavior).
+
+
+class _FakeEventStreamManager:
+    def __init__(self):
+        self.logged = []
+
+    def log(self, *args, **kwargs):
+        self.logged.append((args, kwargs))
+
+
+class _FakeStateManager:
+    def bump_event_stream(self):
+        pass
+
+
+class _FakeTriggerService:
+    def __init__(self):
+        self.emitted = []
+
+    async def emit(self, spec):
+        self.emitted.append(spec)
+
+
+class _FakeChatComponent:
+    def __init__(self):
+        self.messages = []
+
+    async def append_message(self, message):
+        self.messages.append(message)
+
+
+class _FakeActiveAdapter:
+    def __init__(self):
+        self.chat_component = _FakeChatComponent()
+
+
+class _FakeUIController:
+    def __init__(self):
+        self.active_adapter = _FakeActiveAdapter()
+
+
+class _FakeAgent(AgentBase):
+    """Skips AgentBase.__init__ (which wires up dozens of real subsystems —
+    session/action/trigger managers, DB, etc.) and provides just the
+    attributes `_handle_react_error` touches. Every OTHER method used by
+    `_handle_react_error` (`_classify_react_error`, `_critical_fallback_info`,
+    `_display_react_error`) is the real, inherited `AgentBase` implementation
+    — only the I/O boundary (event stream, triggers, chat, run-state) is
+    faked."""
+
+    def __init__(self):
+        self.event_stream_manager = _FakeEventStreamManager()
+        self.state_manager = _FakeStateManager()
+        self.trigger_service = _FakeTriggerService()
+        self.ui_controller = _FakeUIController()
+        self.run_states = []
+
+    def _emit_run_state(self, session_id, busy):
+        self.run_states.append((session_id, busy))
+
+
+def test_handle_react_error_halts_without_continuation_when_disallowed():
+    """The action-decision-failure path: a non-fatal ClassifiedError with
+    allow_continuation=False must show exactly one message and NOT emit a
+    RUN_CONTINUATION trigger — the fix for the duplicate-message bug."""
+    agent = _FakeAgent()
+    info = ErrorInfo(
+        category=ErrorCategory.UNKNOWN, code="ACTION_DECISION_FAILED", title="t", message="m"
+    )
+    err = ClassifiedError(info)
+
+    asyncio.run(
+        AgentBase._handle_react_error(agent, err, "sess1", {}, allow_continuation=False)
+    )
+
+    assert agent.trigger_service.emitted == []
+    assert agent.run_states == [("sess1", False)]
+    assert len(agent.ui_controller.active_adapter.chat_component.messages) == 1
+
+
+def test_handle_react_error_continues_by_default():
+    """Regression guard: non-fatal errors from every OTHER pipeline stage
+    (allow_continuation defaults to True) keep today's exact behavior —
+    display the message and auto-continue via RUN_CONTINUATION."""
+    agent = _FakeAgent()
+    info = ErrorInfo(category=ErrorCategory.UNKNOWN, code="X", title="t", message="m")
+    err = ClassifiedError(info)
+
+    asyncio.run(AgentBase._handle_react_error(agent, err, "sess1", {}))
+
+    assert len(agent.trigger_service.emitted) == 1
+    assert agent.trigger_service.emitted[0].source == TriggerSource.RUN_CONTINUATION
+    assert agent.run_states == []
+    assert len(agent.ui_controller.active_adapter.chat_component.messages) == 1
+
+
+def test_handle_react_error_fatal_halts_regardless_of_allow_continuation():
+    """A fatal LLMConsecutiveFailureError must halt (no trigger) whether or
+    not allow_continuation is set — is_fatal already implies halting."""
+    agent = _FakeAgent()
+    exc = LLMConsecutiveFailureError(5, last_error=RuntimeError("boom"))
+
+    asyncio.run(
+        AgentBase._handle_react_error(agent, exc, "sess1", {}, allow_continuation=True)
+    )
+
+    assert agent.trigger_service.emitted == []
+    assert agent.run_states == [("sess1", False)]
+    assert len(agent.ui_controller.active_adapter.chat_component.messages) == 1


### PR DESCRIPTION
## What
- Built the shared base (no visible change yet) that WILL let error category/code/severity pass through actions, the browser adapter, slash commands, and toast reactify, instead of each part of the app having its own error text.
- Fixed a bug where most failed actions showed a blank error or a raw JSON dump in the Activity panel instead of a readable message.
- Made the small error-category icon (key icon for login problems, clock icon for rate limits, etc.) also appear on calmer gray "System" bubbles

## Why
Right now, error handling is inconsistent across the app: the same "your API key is wrong" failure might show up as a helpful message in one place and a blank or raw dump in another, because there's no shared way to pass structured error info (what kind of error it is, and what the user can do about it) between the backend and the different UIs. This PR doesn't change how any single error is worded but rather lays the shared base work so that the next PRs can port actions, the browser adapter, and toasts into it one at a time