### PR TITLE
Add force-stop for in-flight runs

### DIFF
--- a/agent_core/core/impl/action/cancellation.py
+++ b/agent_core/core/impl/action/cancellation.py
@@ -1,0 +1,165 @@
+# -*- coding: utf-8 -*-
+"""
+core.impl.action.cancellation
+
+Per-session registry of kill handles for force-stopping a run.
+
+Cancelling a turn's asyncio task aborts LLM calls and async actions, but it
+cannot reach real OS work already in flight: a shell command spawned by
+``run_shell`` (blocking a pool thread in ``communicate()``) or the python
+child of a sandboxed action (spawned inside a ProcessPoolExecutor worker).
+This module is the one place such work is registered so a user stop can
+kill it.
+
+Two mechanisms, one kill call:
+
+- ``register_process`` / ``unregister_process``: in-process registry of
+  ``subprocess.Popen`` handles, used by actions running in the main process
+  (thread-pool actions like ``run_shell``).
+- ``mark_subprocess`` / ``unmark_subprocess``: pid marker FILES under the
+  system temp dir, used by code running in a DIFFERENT process (the
+  sandboxed-action pool worker) where no in-memory registry can be shared.
+
+``kill_session_processes(session_id)`` kills both kinds, entire process
+trees included, and is safe to call at any time (missing/exited processes
+are ignored). It is blocking (taskkill / killpg) — call it from a worker
+thread, not the event loop.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import threading
+from pathlib import Path
+from typing import Dict
+
+from agent_core.utils.logger import logger
+
+_lock = threading.Lock()
+# session_id -> {pid: Popen}. Popen handles registered by in-process actions.
+_procs: Dict[str, Dict[int, subprocess.Popen]] = {}
+
+
+def _marker_dir(session_id: str) -> Path:
+    return Path(tempfile.gettempdir()) / "craftbot_run_cancel" / session_id
+
+
+# ─────────────────────── In-process Popen registry ───────────────────────
+
+
+def register_process(session_id: str, proc: subprocess.Popen) -> None:
+    """Register a live child process as killable when this session is stopped."""
+    if not session_id or proc is None or proc.pid is None:
+        return
+    with _lock:
+        _procs.setdefault(session_id, {})[proc.pid] = proc
+
+
+def unregister_process(session_id: str, proc: subprocess.Popen) -> None:
+    """Remove a child process from the kill set (it finished normally)."""
+    if not session_id or proc is None or proc.pid is None:
+        return
+    with _lock:
+        session = _procs.get(session_id)
+        if session:
+            session.pop(proc.pid, None)
+            if not session:
+                _procs.pop(session_id, None)
+
+
+# ─────────────────────── Cross-process pid markers ───────────────────────
+
+
+def mark_subprocess(session_id: str, pid: int) -> None:
+    """Record a child pid from ANOTHER process (e.g. a pool worker).
+
+    The main process cannot hold the Popen handle, so the pid is written as
+    a marker file that ``kill_session_processes`` scans.
+    """
+    if not session_id or not pid:
+        return
+    try:
+        d = _marker_dir(session_id)
+        d.mkdir(parents=True, exist_ok=True)
+        (d / f"{pid}.pid").write_text(str(pid), encoding="utf-8")
+    except Exception:
+        pass  # markers are best-effort; never fail the action over them
+
+
+def unmark_subprocess(session_id: str, pid: int) -> None:
+    """Remove a pid marker (the child exited normally)."""
+    if not session_id or not pid:
+        return
+    try:
+        (_marker_dir(session_id) / f"{pid}.pid").unlink(missing_ok=True)
+    except Exception:
+        pass
+
+
+# ─────────────────────── Kill ───────────────────────
+
+
+def _kill_tree(pid: int) -> None:
+    """Kill a process and its descendants. Missing processes are fine."""
+    try:
+        if os.name == "nt":
+            subprocess.run(
+                ["taskkill", "/F", "/T", "/PID", str(pid)],
+                capture_output=True,
+                timeout=10,
+                creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
+            )
+        else:
+            import signal
+
+            try:
+                os.killpg(pid, signal.SIGKILL)
+            except (ProcessLookupError, PermissionError, OSError):
+                os.kill(pid, signal.SIGKILL)
+    except Exception as e:
+        logger.debug(f"[CANCEL] Kill of pid {pid} failed (likely already gone): {e}")
+
+
+def kill_session_processes(session_id: str) -> int:
+    """Force-kill every process registered/marked for a session.
+
+    Returns the number of kill targets attempted. Blocking — run in a
+    worker thread.
+    """
+    if not session_id:
+        return 0
+
+    with _lock:
+        handles = list(_procs.pop(session_id, {}).values())
+
+    killed = 0
+    for proc in handles:
+        if proc.poll() is None:
+            _kill_tree(proc.pid)
+            killed += 1
+            try:
+                proc.wait(timeout=5)
+            except Exception:
+                pass
+
+    # Cross-process markers (sandboxed action children).
+    try:
+        d = _marker_dir(session_id)
+        if d.is_dir():
+            for marker in d.glob("*.pid"):
+                try:
+                    _kill_tree(int(marker.stem))
+                    killed += 1
+                except ValueError:
+                    pass
+                marker.unlink(missing_ok=True)
+    except Exception as e:
+        logger.debug(f"[CANCEL] Marker sweep failed for {session_id}: {e}")
+
+    if killed:
+        logger.info(
+            f"[CANCEL] Force-killed {killed} process tree(s) for session {session_id}"
+        )
+    return killed

--- a/agent_core/core/impl/action/executor.py
+++ b/agent_core/core/impl/action/executor.py
@@ -391,16 +391,35 @@ except Exception as e:
                 encoding="utf-8",
             )
 
-            proc = subprocess.run(
-                [str(python_bin), str(action_file)],
-                capture_output=True,
-                text=True,
-                timeout=timeout,
+            # Popen (not subprocess.run) so the child's pid can be marked in
+            # the cross-process cancel registry: this function runs in a pool
+            # WORKER process, and a user force-stop issued in the main
+            # process kills marked pids by scanning the marker files.
+            from agent_core.core.impl.action.cancellation import (
+                mark_subprocess,
+                unmark_subprocess,
             )
 
+            cancel_session_id = (input_data or {}).get("_session_id") or ""
+            proc = subprocess.Popen(
+                [str(python_bin), str(action_file)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            mark_subprocess(cancel_session_id, proc.pid)
+            try:
+                stdout, stderr = proc.communicate(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.communicate()
+                raise
+            finally:
+                unmark_subprocess(cancel_session_id, proc.pid)
+
             return {
-                "stdout": proc.stdout.strip(),
-                "stderr": proc.stderr.strip(),
+                "stdout": (stdout or "").strip(),
+                "stderr": (stderr or "").strip(),
                 "returncode": proc.returncode,
             }
 
@@ -471,20 +490,35 @@ except Exception as e:
         )
 
         try:
-            proc = subprocess.run(
-                [python_bin, str(action_file)],
-                capture_output=True,
-                text=True,
-                timeout=timeout,
+            from agent_core.core.impl.action.cancellation import (
+                mark_subprocess,
+                unmark_subprocess,
             )
 
-            if proc.returncode != 0:
-                err = (
-                    proc.stderr.strip() or f"Action exited with code {proc.returncode}"
+            cancel_session_id = (input_data or {}).get("_session_id") or ""
+            popen = subprocess.Popen(
+                [python_bin, str(action_file)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            mark_subprocess(cancel_session_id, popen.pid)
+            try:
+                proc_stdout, proc_stderr = popen.communicate(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                popen.kill()
+                popen.communicate()
+                raise
+            finally:
+                unmark_subprocess(cancel_session_id, popen.pid)
+
+            if popen.returncode != 0:
+                err = (proc_stderr or "").strip() or (
+                    f"Action exited with code {popen.returncode}"
                 )
                 return {"status": "error", "message": err}
 
-            stdout = proc.stdout.strip()
+            stdout = (proc_stdout or "").strip()
             if not stdout:
                 return {"status": "success", "output": ""}
 

--- a/agent_core/core/impl/event_stream/event_stream.py
+++ b/agent_core/core/impl/event_stream/event_stream.py
@@ -154,11 +154,11 @@ class EventStream:
         self, *, folded_events: int, folded_tokens: int, summary: str | None
     ) -> None:
         """Append a SYSTEM event announcing that summarization ran, so the UI
-        surfaces it as a system message in the session's chat. The LLM-facing
-        `message` stays a one-liner (the summary itself already lives in
-        head_summary — repeating it in the tail would double its token cost);
-        the full summary rides on `display_message`, which only the UI reads.
-        Caller holds the lock."""
+        surfaces it as a system message in the session's chat. Both the
+        LLM-facing `message` and the UI-facing `display_message` are
+        one-liners: the summary text itself lives only in head_summary
+        (repeating it in the tail would double its token cost, and dumping
+        it into the chat drowns the conversation). Caller holds the lock."""
         line = (
             f"Summarized {folded_events} older events (~{folded_tokens} tokens) "
             "into the running head summary."
@@ -169,16 +169,13 @@ class EventStream:
                 f"(~{folded_tokens} tokens) without a summary."
             )
             display = (
-                "Context summarization was triggered but the summary could not "
-                f"be generated. The {folded_events} oldest events "
-                f"(~{folded_tokens} tokens) were pruned to keep the context lean."
+                f"Event stream summarization failed, {folded_tokens} tokens "
+                "were pruned without a summary"
             )
         else:
             display = (
-                f"Context summarization triggered: the {folded_events} oldest "
-                f"events (~{folded_tokens} tokens) were folded into a running "
-                "summary to keep the context lean.\n\n"
-                f"**Summary of folded events:**\n\n{summary}"
+                f"Summarized event stream, {folded_tokens} tokens were folded "
+                "into summary"
             )
         ev = Event(
             message=line,

--- a/agent_core/core/impl/trigger/session_queue.py
+++ b/agent_core/core/impl/trigger/session_queue.py
@@ -123,6 +123,27 @@ class SessionTriggerQueue:
                 batch.append(heapq.heappop(self._heap))
             return [entry[2] for entry in batch]
 
+    async def purge(self, predicate) -> int:
+        """Remove queued triggers matching ``predicate`` (a Trigger -> bool).
+
+        Used by user force-stop to drop a run's pending continuation rows
+        without touching unrelated triggers (user messages, schedules).
+        Removed triggers are reported to the lifecycle listener so their
+        durable rows settle instead of rehydrating next boot. Returns the
+        number of triggers removed.
+        """
+        async with self._cv:
+            if self._closed or not self._heap:
+                return 0
+            kept = [entry for entry in self._heap if not predicate(entry[2])]
+            removed = [entry[2] for entry in self._heap if predicate(entry[2])]
+            if not removed:
+                return 0
+            self._heap = kept
+            heapq.heapify(self._heap)
+            self._notify_evicted(removed)
+            return len(removed)
+
     async def close(self) -> List[Trigger]:
         """Close the queue (session deletion) and return discarded triggers.
 

--- a/app/agent_base.py
+++ b/app/agent_base.py
@@ -310,6 +310,7 @@ class AgentBase:
 
         # Per-session runtime: one trigger queue + one serial loop per session.
         self.session_runtime = SessionRuntimeManager(react=self.react)
+        self.session_runtime.set_stop_finalizer(self._on_run_stopped)
         self.trigger_store = TriggerStore()
         self.trigger_service = TriggerService(self.trigger_store, self.session_runtime)
 
@@ -641,7 +642,7 @@ class AgentBase:
             # ----- Run-start bookkeeping -----
             if trigger.source in RUN_START_SOURCES:
                 self.session_manager.start_run(session_id)
-                self._emit_run_state(session_id, True)
+                self._emit_run_state(session_id, "running")
                 await self._apply_workflow_capabilities(session, trigger.payload)
 
             # Refresh per-turn state for this session
@@ -897,17 +898,20 @@ class AgentBase:
         except Exception as e:
             logger.debug(f"[REACT] Turn-cause announcement failed: {e}")
 
-    def _emit_run_state(self, session_id: str, busy: bool) -> None:
-        """Track and broadcast a session's run-in-flight state.
+    def _emit_run_state(self, session_id: str, state: str) -> None:
+        """Track and broadcast a session's run state.
 
-        The UI's typing indicator is driven ONLY by these transitions, so it
-        stays steady across turn boundaries instead of flickering whenever
-        no action happens to be executing.
+        ``state`` is one of ``"running"`` | ``"stopping"`` | ``"idle"``.
+        The UI's typing indicator and the send/stop button are driven ONLY
+        by these transitions, so they stay steady across turn boundaries
+        instead of flickering whenever no action happens to be executing.
+        ``"stopping"`` covers the window between a user force-stop request
+        and the run being fully shut (processes killed, turn settled).
         """
-        if busy:
-            self.busy_sessions.add(session_id)
-        else:
+        if state == "idle":
             self.busy_sessions.discard(session_id)
+        else:
+            self.busy_sessions.add(session_id)
         if self.ui_controller:
             try:
                 from app.ui_layer.events import UIEvent, UIEventType
@@ -915,7 +919,13 @@ class AgentBase:
                 self.ui_controller.event_bus.emit(
                     UIEvent(
                         type=UIEventType.RUN_STATE_CHANGED,
-                        data={"session_id": session_id, "busy": busy},
+                        data={
+                            "session_id": session_id,
+                            "state": state,
+                            # Derived boolean kept for consumers that only
+                            # care about in-flight vs idle.
+                            "busy": state != "idle",
+                        },
                     )
                 )
             except Exception:
@@ -1252,7 +1262,7 @@ class AgentBase:
 
         if not await self._check_agent_limits(session.id):
             # Run is paused on the Continue/Stop prompt — not busy anymore.
-            self._emit_run_state(session.id, False)
+            self._emit_run_state(session.id, "idle")
             return
 
         run_ends = bool(action_output.get("run_ends", False))
@@ -1318,7 +1328,7 @@ class AgentBase:
         """A run finished (no continuation): workflow cleanup + housekeeping."""
         run_source = run_payload.get("run_source", "")
 
-        self._emit_run_state(session.id, False)
+        self._emit_run_state(session.id, "idle")
 
         # Unload temporary workflow skills loaded at run start.
         self._remove_workflow_capabilities(session, run_payload)
@@ -1365,6 +1375,74 @@ class AgentBase:
                 pass
 
         logger.info(f"[RUN] Run ended for session {session.id} (source={run_source})")
+
+    # ----- User force-stop -----
+
+    async def request_run_stop(self, session_id: str) -> bool:
+        """Force-stop a session's in-flight run (the chat UI's stop button).
+
+        Broadcasts ``stopping`` immediately (the button's spinner state),
+        then delegates to the session runtime: kill registered child
+        processes, cancel the turn task, purge queued continuations. The
+        runtime calls :meth:`_on_run_stopped` once everything is shut, which
+        emits the terminal ``idle``.
+        """
+        logger.info(f"[RUN] User requested stop for session {session_id}")
+        self._emit_run_state(session_id, "stopping")
+        try:
+            stopped = await self.session_runtime.request_stop(session_id)
+        except Exception:
+            logger.error(
+                f"[RUN] request_stop failed for {session_id}", exc_info=True
+            )
+            stopped = False
+        if not stopped:
+            # Nothing was running (stale UI state) — settle the UI to idle.
+            self._emit_run_state(session_id, "idle")
+        return stopped
+
+    async def _on_run_stopped(self, session_id: str) -> None:
+        """A run was force-stopped by the user: settle state for the session.
+
+        Called by the session runtime after the turn task is cancelled and
+        queued continuations are purged. Deliberately does NOT run the
+        Living UI factory redispatch hook — the user just killed this work;
+        resurrecting it immediately would make the stop button a no-op.
+        """
+        self._lui_run_writes.pop(session_id, None)
+
+        # A force-stopped memory run must not leave the unprocessed buffer
+        # frozen forever.
+        if hasattr(self.event_stream_manager, "set_skip_unprocessed_logging"):
+            try:
+                self.event_stream_manager.set_skip_unprocessed_logging(False)
+            except Exception:
+                pass
+
+        # One event, two audiences: the SYSTEM bubble tells the user the stop
+        # landed; the stream copy tells the next turn's LLM why work halted
+        # mid-task so it doesn't assume completion.
+        if self.event_stream_manager:
+            msg = "User force-stopped the run. The work in progress was halted."
+            try:
+                self.event_stream_manager.log(
+                    "system",
+                    msg,
+                    event_type=EventType.SYSTEM,
+                    display_message="Run stopped.",
+                    task_id=session_id,
+                )
+                self.state_manager.bump_event_stream()
+            except Exception:
+                logger.warning("[RUN] Failed to log run-stopped event", exc_info=True)
+
+        try:
+            self.session_manager.persist(session_id)
+        except Exception:
+            pass
+
+        self._emit_run_state(session_id, "idle")
+        logger.info(f"[RUN] Run force-stopped for session {session_id}")
 
     async def _finish_skill_workflow(self, session: Session, meta: dict) -> None:
         """Post-run hook for skill creation/improvement runs."""
@@ -1644,7 +1722,7 @@ class AgentBase:
                     f"[REACT ERROR] LLMConsecutiveFailureError — halting run for "
                     f"session {session_id}."
                 )
-                self._emit_run_state(session_id, False)
+                self._emit_run_state(session_id, "idle")
                 await self._display_react_error(session_id, info, critical=is_critical)
             else:
                 # Recoverable turn error: still tell the user what happened,
@@ -1849,7 +1927,7 @@ class AgentBase:
                 )
             )
 
-        self._emit_run_state(session_id, True)
+        self._emit_run_state(session_id, "running")
         await self.trigger_service.emit(
             TriggerSpec(
                 source=TriggerSource.RUN_CONTINUATION,

--- a/app/data/action/run_shell.py
+++ b/app/data/action/run_shell.py
@@ -146,6 +146,15 @@ def shell_exec(input_data: dict) -> dict:
 
     # Foreground mode with proper timeout handling
     try:
+        # Register with the run-cancel registry so a user force-stop can
+        # kill this process tree while communicate() blocks the pool thread.
+        from agent_core.core.impl.action.cancellation import (
+            register_process,
+            unregister_process,
+        )
+
+        run_session_id = input_data.get("_session_id") or ""
+
         process = subprocess.Popen(
             command,
             shell=True,
@@ -158,6 +167,7 @@ def shell_exec(input_data: dict) -> dict:
             errors="replace",
             start_new_session=True,  # Create new process group for proper cleanup
         )
+        register_process(run_session_id, process)
 
         try:
             stdout, stderr = process.communicate(timeout=timeout_seconds)
@@ -188,6 +198,8 @@ def shell_exec(input_data: dict) -> dict:
                 "message": f"Timed out after {timeout_seconds}s.",
                 "pid": None,
             }
+        finally:
+            unregister_process(run_session_id, process)
     except Exception as e:
         return {
             "status": "error",
@@ -392,6 +404,15 @@ def shell_exec_windows(input_data: dict) -> dict:
 
     # Foreground mode with proper timeout handling
     try:
+        # Register with the run-cancel registry so a user force-stop can
+        # kill this process tree while communicate() blocks the pool thread.
+        from agent_core.core.impl.action.cancellation import (
+            register_process,
+            unregister_process,
+        )
+
+        run_session_id = input_data.get("_session_id") or ""
+
         # Use CREATE_NEW_PROCESS_GROUP so we can kill the entire process tree
         fg_flags = creation_flags | subprocess.CREATE_NEW_PROCESS_GROUP
         process = subprocess.Popen(
@@ -405,6 +426,7 @@ def shell_exec_windows(input_data: dict) -> dict:
             errors="replace",
             creationflags=fg_flags,
         )
+        register_process(run_session_id, process)
 
         try:
             stdout, stderr = process.communicate(timeout=timeout_seconds)
@@ -436,6 +458,8 @@ def shell_exec_windows(input_data: dict) -> dict:
                 "message": f"Timed out after {timeout_seconds}s.",
                 "pid": None,
             }
+        finally:
+            unregister_process(run_session_id, process)
     except Exception as e:
         return {
             "status": "error",
@@ -598,6 +622,15 @@ def shell_exec_darwin(input_data: dict) -> dict:
 
     # Foreground mode with proper timeout handling
     try:
+        # Register with the run-cancel registry so a user force-stop can
+        # kill this process tree while communicate() blocks the pool thread.
+        from agent_core.core.impl.action.cancellation import (
+            register_process,
+            unregister_process,
+        )
+
+        run_session_id = input_data.get("_session_id") or ""
+
         process = subprocess.Popen(
             args,
             stdout=subprocess.PIPE,
@@ -609,6 +642,7 @@ def shell_exec_darwin(input_data: dict) -> dict:
             errors="replace",
             start_new_session=True,  # Create new process group for proper cleanup
         )
+        register_process(run_session_id, process)
 
         try:
             stdout, stderr = process.communicate(timeout=timeout_seconds)
@@ -639,6 +673,8 @@ def shell_exec_darwin(input_data: dict) -> dict:
                 "message": f"Timed out after {timeout_seconds}s.",
                 "pid": None,
             }
+        finally:
+            unregister_process(run_session_id, process)
     except Exception as e:
         return {
             "status": "error",

--- a/app/triggers/runtime.py
+++ b/app/triggers/runtime.py
@@ -53,7 +53,30 @@ except Exception:
 # cross-session parallelism (LLM rate limits, local resource pressure).
 DEFAULT_MAX_CONCURRENT_TURNS = 3
 
+# How long a user force-stop waits for the cancelled turn to settle before
+# finalizing anyway. Cancellation is normally near-instant (LLM HTTP calls
+# and async actions unwind at the next await); this guard only exists so a
+# stuck await can never leave the UI on "stopping" forever.
+STOP_SETTLE_TIMEOUT_S = 15.0
+
 ReactFn = Callable[[Trigger], Awaitable[None]]
+StopFinalizer = Callable[[str], Awaitable[None]]
+
+
+class _StopSignal:
+    """Marks a session whose in-flight run the user force-stopped.
+
+    ``requested`` distinguishes a user stop from process-shutdown
+    cancellation inside the consumer loop; ``settled`` is set once the
+    cancelled turn has been acked and finalized, so the stop caller can
+    await full shutdown (the UI's stop-spinner ends on this).
+    """
+
+    __slots__ = ("requested", "settled")
+
+    def __init__(self) -> None:
+        self.requested = False
+        self.settled = asyncio.Event()
 
 
 def _merge_triggers(base: Trigger, extras: list[Trigger]) -> Trigger:
@@ -160,6 +183,11 @@ class SessionRuntimeManager:
         self._react = react
         self._queues: Dict[str, SessionTriggerQueue] = {}
         self._loops: Dict[str, asyncio.Task] = {}
+        # In-flight turn task per session, so a user stop can cancel exactly
+        # the current turn without killing the session's consumer loop.
+        self._turns: Dict[str, asyncio.Task] = {}
+        self._stops: Dict[str, _StopSignal] = {}
+        self._on_stopped: Optional[StopFinalizer] = None
         self._turn_semaphore = asyncio.Semaphore(max_concurrent_turns)
         self._running = False
         self._service: Optional["TriggerService"] = None
@@ -167,6 +195,10 @@ class SessionRuntimeManager:
     def bind_service(self, service: "TriggerService") -> None:
         """Attach the durable TriggerService (claim/ack/nack + row settling)."""
         self._service = service
+
+    def set_stop_finalizer(self, finalizer: StopFinalizer) -> None:
+        """Register the run-stopped hook (AgentBase._on_run_stopped)."""
+        self._on_stopped = finalizer
 
     # ─────────────────────── Lifecycle ──────────────────────────────────────
 
@@ -217,6 +249,73 @@ class SessionRuntimeManager:
         queue = self._queues.get(session_id)
         return queue.has_pending() if queue else False
 
+    # ─────────────────────── User force-stop ─────────────────────────────────
+
+    async def request_stop(self, session_id: str) -> bool:
+        """Force-stop a session's in-flight run at the user's request.
+
+        Kills registered child processes, cancels the current turn task
+        (the loop settles it: rows acked, stop finalizer called), and drops
+        queued RUN_CONTINUATION triggers — a run between turns exists only
+        as those rows. User messages and scheduled triggers stay queued.
+
+        Returns True when there was a run to stop. Awaits full settlement
+        (bounded by STOP_SETTLE_TIMEOUT_S) before returning, so the caller
+        can treat the return as "everything is shut".
+        """
+        purged = await self._purge_continuations(session_id)
+        turn = self._turns.get(session_id)
+        turn_inflight = turn is not None and not turn.done()
+
+        if not turn_inflight:
+            if purged and self._on_stopped:
+                # The run lived only as queued continuation rows.
+                await self._on_stopped(session_id)
+            return bool(purged)
+
+        signal = self._stops.setdefault(session_id, _StopSignal())
+        signal.requested = True
+
+        # Kill real OS work first so pool threads blocked on a child process
+        # unblock, then cancel the turn's await chain. Blocking kill runs in
+        # a worker thread to keep the event loop free.
+        try:
+            from agent_core.core.impl.action.cancellation import (
+                kill_session_processes,
+            )
+
+            await asyncio.get_running_loop().run_in_executor(
+                None, kill_session_processes, session_id
+            )
+        except Exception as e:
+            logger.warning(f"[SessionRuntime] Process kill failed: {e}")
+
+        turn.cancel()
+        try:
+            await asyncio.wait_for(signal.settled.wait(), STOP_SETTLE_TIMEOUT_S)
+        except asyncio.TimeoutError:
+            # The turn is stuck in a non-cancellable await. Finalize anyway:
+            # the UI must reach idle, and the abandoned coroutine can no
+            # longer enqueue continuations once its triggers settle.
+            logger.error(
+                f"[SessionRuntime] Stop settlement timed out for {session_id}; "
+                "finalizing forcefully."
+            )
+            self._stops.pop(session_id, None)
+            await self._purge_continuations(session_id)
+            if self._on_stopped:
+                await self._on_stopped(session_id)
+        return True
+
+    async def _purge_continuations(self, session_id: str) -> int:
+        """Drop a session's queued run-continuation triggers."""
+        queue = self._queues.get(session_id)
+        if queue is None:
+            return 0
+        return await queue.purge(
+            lambda t: t.source == TriggerSource.RUN_CONTINUATION.value
+        )
+
     async def remove_session(self, session_id: str) -> None:
         """Tear down a deleted session's queue and loop.
 
@@ -229,6 +328,8 @@ class SessionRuntimeManager:
         queue = self._queues.pop(session_id, None)
         if queue is not None:
             await queue.close()
+        self._turns.pop(session_id, None)
+        self._stops.pop(session_id, None)
         loop_task = self._loops.pop(session_id, None)
         if loop_task is not None:
             loop_task.cancel()
@@ -311,8 +412,47 @@ class SessionRuntimeManager:
 
                 try:
                     async with self._turn_semaphore:
-                        await self._react(trig)
+                        # The turn runs as its own task so request_stop can
+                        # cancel exactly this turn without tearing down the
+                        # session loop.
+                        turn = asyncio.create_task(
+                            self._react(trig), name=f"turn-{session_id}"
+                        )
+                        self._turns[session_id] = turn
+                        try:
+                            await turn
+                        finally:
+                            self._turns.pop(session_id, None)
                 except asyncio.CancelledError:
+                    signal = self._stops.get(session_id)
+                    if signal is not None and signal.requested and self._running:
+                        # User force-stop, not process shutdown: the rows were
+                        # consumed by user intent — ack them (nack would
+                        # redeliver and restart the very work the user
+                        # killed), drop any continuation the dying turn
+                        # managed to enqueue, finalize, and keep looping.
+                        if self._service:
+                            for t in group:
+                                try:
+                                    await self._service.ack(t)
+                                except Exception as e:
+                                    logger.warning(
+                                        f"[SessionRuntime] stop ack failed: {e}"
+                                    )
+                        try:
+                            await self._purge_continuations(session_id)
+                            if self._on_stopped:
+                                await self._on_stopped(session_id)
+                        except Exception as e:
+                            logger.error(
+                                f"[SessionRuntime] Stop finalize failed for "
+                                f"{session_id}: {e}",
+                                exc_info=True,
+                            )
+                        finally:
+                            self._stops.pop(session_id, None)
+                            signal.settled.set()
+                        continue
                     # Shutdown mid-turn: leave the rows CLAIMED — boot-time
                     # rehydration reclaims them (at-least-once delivery).
                     raise

--- a/app/ui_layer/adapters/browser_adapter.py
+++ b/app/ui_layer/adapters/browser_adapter.py
@@ -829,14 +829,19 @@ class BrowserAdapter(InterfaceAdapter):
         )
 
     def _handle_run_state_change(self, event: UIEvent) -> None:
-        """Broadcast a session's run-in-flight flag (typing indicator)."""
+        """Broadcast a session's run state (typing indicator + stop button).
+
+        ``state`` is "running" | "stopping" | "idle"; ``busy`` is the
+        derived boolean kept alongside it for older consumers.
+        """
         session_id = event.data.get("session_id") or "main"
         busy = bool(event.data.get("busy", False))
+        state = event.data.get("state") or ("running" if busy else "idle")
         asyncio.create_task(
             self._broadcast(
                 {
                     "type": "session_busy",
-                    "data": {"sessionId": session_id, "busy": busy},
+                    "data": {"sessionId": session_id, "busy": busy, "state": state},
                 }
             )
         )
@@ -1208,6 +1213,13 @@ A quick Q&A will now begin to understand your objectives to serve you better:"""
                         content, session_id=session_id, client_id=client_id
                     )
                 )
+
+        elif msg_type == "session_stop":
+            # User force-stops the session's in-flight run (the chat input's
+            # stop button). Runs as a background task: stopping awaits full
+            # settlement (process kills) and must not block the WS read loop.
+            session_id = data.get("sessionId") or "main"
+            asyncio.create_task(self._controller.stop_run(session_id))
 
         elif msg_type == "chat_attachment_upload":
             # Upload attachment for chat message

--- a/app/ui_layer/browser/frontend/src/components/Chat/Chat.module.css
+++ b/app/ui_layer/browser/frontend/src/components/Chat/Chat.module.css
@@ -295,6 +295,29 @@
   cursor: not-allowed;
 }
 
+/* Stop variant of the send button: shown while the session's run is in
+   flight and the composer is empty. Same footprint as .sendBtn so the
+   swap never shifts the layout. Background/icon use the text/bg token
+   PAIR so the contrast inverts correctly in both themes (text-primary is
+   near-white in dark mode — a hardcoded #fff icon would vanish on it). */
+.stopBtn {
+  background: var(--text-primary, #1a1a1a);
+  color: var(--bg-primary, #fff);
+}
+
+/* While the backend confirms the force-stop ("stopping" run state) the
+   button keeps the stop look and only spins — not the gray disabled
+   style, which would read as "nothing is happening". */
+.stopBtn:disabled {
+  background: var(--text-primary, #1a1a1a);
+  color: var(--bg-primary, #fff);
+  cursor: wait;
+}
+
+.stopSpinner {
+  animation: spin 1s linear infinite;
+}
+
 /* Reply bar inside the input shell — shows which agent message the next
    send will quote. */
 .replyBar {

--- a/app/ui_layer/browser/frontend/src/components/Chat/Chat.tsx
+++ b/app/ui_layer/browser/frontend/src/components/Chat/Chat.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect, useLayoutEffect, KeyboardEvent, useCallback, ChangeEvent, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { Send, Paperclip, Plus, X, Loader2, File, AlertCircle, Mic, MicOff, ChevronDown, Sparkles, BookOpen, Reply } from 'lucide-react'
+import { Send, Square, Paperclip, Plus, X, Loader2, File, AlertCircle, Mic, MicOff, ChevronDown, Sparkles, BookOpen, Reply } from 'lucide-react'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { useWebSocket } from '../../contexts/WebSocketContext'
 import { useToast } from '../../contexts/ToastContext'
@@ -28,7 +28,7 @@ import {
   selectSessionOldestMessageTimestamp,
 } from '../../store/selectors/messages'
 import { selectSessionActivity } from '../../store/selectors/activity'
-import { selectSessionBusy } from '../../store/selectors/agent'
+import { selectSessionBusy, selectSessionRunState } from '../../store/selectors/agent'
 import type { ActionItem, ChatMessage } from '../../types'
 import styles from './Chat.module.css'
 
@@ -156,6 +156,7 @@ export function Chat({ sessionId, placeholder }: ChatProps) {
     connected,
     sendMessage,
     sendCommand,
+    stopSession,
     sendOptionClick,
     openFile,
     openFolder,
@@ -192,6 +193,7 @@ export function Chat({ sessionId, placeholder }: ChatProps) {
   // send_message is excluded: it isn't rendered as an action row (the chat
   // bubble is its visible form), so "Working…" stays up while it runs.
   const busy = useAppSelector(state => selectSessionBusy(state, sessionId))
+  const runState = useAppSelector(state => selectSessionRunState(state, sessionId))
   const showLiveRow = busy && connected && (!isDraft || messages.length > 0)
   const { showToast } = useToast()
 
@@ -920,6 +922,17 @@ export function Chat({ sessionId, placeholder }: ChatProps) {
     }
   }
 
+  // Send ↔ stop button: pure derivation, no imperative toggling. Stop shows
+  // only while the run is in flight AND the composer is empty — typing flips
+  // it back to send so a message can still go out mid-run; clearing the
+  // input flips it back to stop. 'stopping' pins the button to a spinner
+  // until the backend confirms the run is fully shut (turn cancelled, child
+  // processes killed), which arrives as the terminal session_busy 'idle'.
+  const composerHasContent = !!input.trim() || pendingAttachments.length > 0
+  const stopping = runState === 'stopping'
+  const showStopButton =
+    !isDraft && (stopping || (runState === 'running' && !composerHasContent))
+
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Tab' && !e.shiftKey) {
       if (autocompleteRef.current?.handleTab()) {
@@ -1445,16 +1458,31 @@ export function Chat({ sessionId, placeholder }: ChatProps) {
                   </div>
                 )}
               </div>
-              <button
-                type="button"
-                className={styles.sendBtn}
-                onClick={handleSend}
-                disabled={(!input.trim() && pendingAttachments.length === 0) || !attachmentValidation.valid}
-                title="Send"
-                aria-label="Send message"
-              >
-                <Send size={16} />
-              </button>
+              {showStopButton ? (
+                <button
+                  type="button"
+                  className={`${styles.sendBtn} ${styles.stopBtn}`}
+                  onClick={() => stopSession(sessionId)}
+                  disabled={stopping}
+                  title={stopping ? 'Stopping…' : 'Stop'}
+                  aria-label={stopping ? 'Stopping run' : 'Stop run'}
+                >
+                  {stopping
+                    ? <Loader2 size={16} className={styles.stopSpinner} />
+                    : <Square size={12} fill="currentColor" />}
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  className={styles.sendBtn}
+                  onClick={handleSend}
+                  disabled={(!input.trim() && pendingAttachments.length === 0) || !attachmentValidation.valid}
+                  title="Send"
+                  aria-label="Send message"
+                >
+                  <Send size={16} />
+                </button>
+              )}
             </div>
           </div>
         </div>

--- a/app/ui_layer/browser/frontend/src/components/layout/NavBar.tsx
+++ b/app/ui_layer/browser/frontend/src/components/layout/NavBar.tsx
@@ -150,7 +150,7 @@ export function NavBar({ collapsed = false, onToggleCollapsed }: NavBarProps) {
   const mainSession = useAppSelector(selectMainSession)
   const chatSessions = useAppSelector(selectChatSessions)
   const lastMessageIdBySession = useAppSelector(selectLastMessageIdBySession)
-  const busyBySession = useAppSelector(state => state.agent.busyBySession)
+  const runStateBySession = useAppSelector(state => state.agent.runStateBySession)
 
   const [chatsExpanded, setChatsExpanded] = useState(() => loadGroupExpanded('chats'))
   const [livingUIExpanded, setLivingUIExpanded] = useState(() => loadGroupExpanded('livingui'))
@@ -277,7 +277,7 @@ export function NavBar({ collapsed = false, onToggleCollapsed }: NavBarProps) {
   type SessionDotKind = 'busy' | 'unread' | null
   const sessionDotKind = (sessionId: string | null | undefined): SessionDotKind => {
     if (!sessionId) return null
-    if (busyBySession[sessionId]) return 'busy'
+    if (runStateBySession[sessionId]) return 'busy'
     if (hasUnread(sessionId)) return 'unread'
     return null
   }

--- a/app/ui_layer/browser/frontend/src/contexts/WebSocketContext.tsx
+++ b/app/ui_layer/browser/frontend/src/contexts/WebSocketContext.tsx
@@ -67,7 +67,7 @@ import {
   selectFootageUrl,
   selectSkillMeta,
 } from '../store/selectors/agent'
-import { setStatus, setSessionBusy } from '../store/slices/agentSlice'
+import { setStatus, setSessionRunState } from '../store/slices/agentSlice'
 
 // Module-level reference to the shared SocketClient. The transport (connect,
 // reconnect, outbox, message dispatch) lives there; this context now only
@@ -170,6 +170,8 @@ interface WebSocketContextType extends WebSocketState {
     replyContext?: { originalMessage: string },
   ) => void
   sendCommand: (command: string, sessionId: string) => void
+  // Force-stop a session's in-flight run (send button ↔ stop button)
+  stopSession: (sessionId: string) => void
   // Session management (sessions are created lazily by the backend on the
   // first message sent with sessionId "new" — there is no create sender)
   deleteSession: (sessionId: string) => void
@@ -326,8 +328,8 @@ export function WebSocketProvider({ children }: { children: ReactNode }) {
           dispatch(chatInputTransferDraft({ from: 'new', to: session.id }))
           // Transfer the optimistic busy flag from the draft to the real
           // session so the typing indicator survives the handoff.
-          dispatch(setSessionBusy({ sessionId: 'new', busy: false }))
-          dispatch(setSessionBusy({ sessionId: session.id, busy: true }))
+          dispatch(setSessionRunState({ sessionId: 'new', state: 'idle' }))
+          dispatch(setSessionRunState({ sessionId: session.id, state: 'running' }))
           navigateRef.current(`/session/${session.id}`, { replace: true })
         }
         break
@@ -396,7 +398,7 @@ export function WebSocketProvider({ children }: { children: ReactNode }) {
     if (!isSlashCommand) {
       // Optimistic busy: show the typing indicator instantly; the server's
       // session_busy events take over from the run's first trigger.
-      dispatch(setSessionBusy({ sessionId, busy: true }))
+      dispatch(setSessionRunState({ sessionId, state: 'running' }))
 
       // Optimistic insert: show the user's bubble immediately at reduced
       // opacity. The server echo (chat_message) replaces this entry in place
@@ -430,6 +432,15 @@ export function WebSocketProvider({ children }: { children: ReactNode }) {
   const sendCommand = useCallback((command: string, sessionId: string) => {
     sendOrQueue(JSON.stringify({ type: 'command', command, sessionId }))
   }, [sendOrQueue])
+
+  // Force-stop a session's in-flight run (chat input's stop button).
+  // Optimistically enters 'stopping' so the button spins instantly; the
+  // server's session_busy broadcasts ('stopping' then terminal 'idle')
+  // are authoritative from there.
+  const stopSession = useCallback((sessionId: string) => {
+    dispatch(setSessionRunState({ sessionId, state: 'stopping' }))
+    sendOrQueue(JSON.stringify({ type: 'session_stop', sessionId }))
+  }, [sendOrQueue, dispatch])
 
   // ── Session management ────────────────────────────────────────────
 
@@ -715,6 +726,7 @@ export function WebSocketProvider({ children }: { children: ReactNode }) {
         skillMeta,
         sendMessage,
         sendCommand,
+        stopSession,
         deleteSession,
         renameSession,
         clearSession,

--- a/app/ui_layer/browser/frontend/src/hooks/useDerivedAgentStatus.ts
+++ b/app/ui_layer/browser/frontend/src/hooks/useDerivedAgentStatus.ts
@@ -116,5 +116,5 @@ export function useDerivedAgentStatus(
 }
 
 // NOTE: the chat's typing indicator is NOT derived here — it is run-scoped
-// and driven by the backend's session_busy events (agentSlice.busyBySession),
-// so it stays steady across turn boundaries.
+// and driven by the backend's session_busy events
+// (agentSlice.runStateBySession), so it stays steady across turn boundaries.

--- a/app/ui_layer/browser/frontend/src/store/selectors/agent.ts
+++ b/app/ui_layer/browser/frontend/src/store/selectors/agent.ts
@@ -1,4 +1,5 @@
 import type { RootState } from '../index'
+import type { SessionRunState } from '../slices/agentSlice'
 
 export const selectAgentName = (state: RootState) => state.agent.name
 export const selectAgentProfilePictureUrl = (state: RootState) =>
@@ -9,5 +10,9 @@ export const selectAgentStatus = (state: RootState) => state.agent.status
 export const selectGuiMode = (state: RootState) => state.agent.guiMode
 export const selectFootageUrl = (state: RootState) => state.agent.footageUrl
 export const selectSkillMeta = (state: RootState) => state.agent.skillMeta
+export const selectSessionRunState = (
+  state: RootState,
+  sessionId: string,
+): SessionRunState => state.agent.runStateBySession[sessionId] ?? 'idle'
 export const selectSessionBusy = (state: RootState, sessionId: string) =>
-  !!state.agent.busyBySession[sessionId]
+  state.agent.runStateBySession[sessionId] !== undefined

--- a/app/ui_layer/browser/frontend/src/store/slices/agentSlice.ts
+++ b/app/ui_layer/browser/frontend/src/store/slices/agentSlice.ts
@@ -7,6 +7,11 @@ import type {
 } from '../../types'
 import { register } from '../socket/messageRegistry'
 
+/** A session's run lifecycle as the chat UI sees it. 'stopping' covers the
+ *  window between a user force-stop request and the backend confirming the
+ *  run is fully shut (turn cancelled, child processes killed). */
+export type SessionRunState = 'running' | 'stopping' | 'idle'
+
 interface AgentSliceState {
   name: string
   profilePictureUrl: string
@@ -15,9 +20,10 @@ interface AgentSliceState {
   guiMode: boolean
   footageUrl: string | null
   skillMeta: SkillMeta
-  /** Per-session run-in-flight flags (server-driven; optimistic on send).
-   *  Drives the chat's typing indicator without flickering between turns. */
-  busyBySession: Record<string, boolean>
+  /** Per-session run state (server-driven; optimistic on send/stop).
+   *  Absent = idle. Drives the chat's typing indicator and the send/stop
+   *  button without flickering between turns. */
+  runStateBySession: Record<string, Exclude<SessionRunState, 'idle'>>
 }
 
 const initialState: AgentSliceState = {
@@ -32,7 +38,7 @@ const initialState: AgentSliceState = {
     internalSkillNames: [],
     reservedSkillNames: [],
   },
-  busyBySession: {},
+  runStateBySession: {},
 }
 
 const agentSlice = createSlice({
@@ -62,16 +68,21 @@ const agentSlice = createSlice({
       state.profilePictureUrl = action.payload.url
       state.profilePictureHasCustom = action.payload.hasCustom
     },
-    setSessionBusy(state, action: PayloadAction<{ sessionId: string; busy: boolean }>) {
-      const { sessionId, busy } = action.payload
-      if (busy) {
-        state.busyBySession[sessionId] = true
+    setSessionRunState(
+      state,
+      action: PayloadAction<{ sessionId: string; state: SessionRunState }>,
+    ) {
+      const { sessionId, state: runState } = action.payload
+      if (runState === 'idle') {
+        delete state.runStateBySession[sessionId]
       } else {
-        delete state.busyBySession[sessionId]
+        state.runStateBySession[sessionId] = runState
       }
     },
     seedBusySessions(state, action: PayloadAction<string[]>) {
-      state.busyBySession = Object.fromEntries(action.payload.map(id => [id, true]))
+      state.runStateBySession = Object.fromEntries(
+        action.payload.map(id => [id, 'running' as const]),
+      )
     },
   },
 })
@@ -84,7 +95,7 @@ export const {
   setSkillMeta,
   setName,
   setProfilePicture,
-  setSessionBusy,
+  setSessionRunState,
   seedBusySessions,
 } = agentSlice.actions
 
@@ -109,9 +120,11 @@ register('init', (data, dispatch) => {
 })
 
 register('session_busy', (data, dispatch) => {
-  const d = data as { sessionId?: string; busy?: boolean }
+  const d = data as { sessionId?: string; busy?: boolean; state?: SessionRunState }
   if (d.sessionId) {
-    dispatch(setSessionBusy({ sessionId: d.sessionId, busy: !!d.busy }))
+    // `state` is authoritative; `busy` is the older boolean kept alongside.
+    const runState: SessionRunState = d.state ?? (d.busy ? 'running' : 'idle')
+    dispatch(setSessionRunState({ sessionId: d.sessionId, state: runState }))
   }
 })
 

--- a/app/ui_layer/browser/frontend/src/types/index.ts
+++ b/app/ui_layer/browser/frontend/src/types/index.ts
@@ -116,6 +116,7 @@ export type WSMessageType =
   | 'session_deleted'
   | 'session_cleared'
   | 'session_busy'
+  | 'session_stop'
   | 'agent_state'
   | 'status_update'
   | 'navigate'

--- a/app/ui_layer/controller/ui_controller.py
+++ b/app/ui_layer/controller/ui_controller.py
@@ -290,6 +290,14 @@ class UIController:
 
         await self._agent._handle_chat_message(payload)
 
+    async def stop_run(self, session_id: Optional[str] = None) -> bool:
+        """Force-stop a session's in-flight run (chat stop button).
+
+        Returns True when a run was actually stopped. Run-state broadcasts
+        ("stopping" then "idle") come from the agent, not from here.
+        """
+        return await self._agent.request_run_stop(session_id or "main")
+
     async def notify_session_updated(self, session_id: str) -> None:
         """Tell the active adapter a session's metadata changed (e.g. title)."""
         adapter = self._adapter


### PR DESCRIPTION
What and why?
Need a way to stop actions/tasks mid-session. Otherwise the only way to stop it now is to send another request.

Items added:
- Stop logic
- Stop button recovers to send button when user types
- Improved the event summarization system message