### PR TITLE
Update api key redaction and model switching hanlding

### DIFF
--- a/agent_core/core/impl/llm/interface.py
+++ b/agent_core/core/impl/llm/interface.py
@@ -195,7 +195,8 @@ class LLMInterface:
         self._initialized = False
         self._deferred = deferred
 
-        # Store for reinitialization
+        # Last-applied api_key/base_url, used by reinitialize() to detect
+        # whether a Settings save actually changed anything.
         self._init_api_key = api_key
         self._init_base_url = base_url
 
@@ -223,7 +224,13 @@ class LLMInterface:
             deferred=deferred,
         )
 
-        logger.info(f"[LLM FACTORY] {ctx}")
+        _safe_ctx = {k: v for k, v in ctx.items() if k != "byteplus"}
+        if ctx.get("byteplus"):
+            _safe_ctx["byteplus"] = {
+                "api_key": "<redacted>",
+                "base_url": ctx["byteplus"].get("base_url"),
+            }
+        logger.info(f"[LLM FACTORY] {_safe_ctx}")
 
         self.provider = ctx["provider"]
         self.model = ctx["model"]
@@ -340,6 +347,33 @@ class LLMInterface:
                 None  # app context not available (e.g. agent_core standalone)
             )
 
+        # Diff against the currently-live config so a Settings save that
+        # didn't actually change anything (or only changed the model within
+        # the same provider) doesn't have to nuke every active task's
+        # accumulated session state. `target_model is not None` guards the
+        # no-op fast path off in the app-context-unavailable edge case above,
+        # where we can't tell what "unchanged" means — fall through to the
+        # full-reset path there, matching prior behavior.
+        old_provider = self.provider
+        old_model = self.model
+        old_api_key = self._init_api_key
+        old_base_url = self._init_base_url
+        provider_unchanged = target_provider == old_provider
+        nothing_changed = (
+            provider_unchanged
+            and target_model is not None
+            and target_model == old_model
+            and target_api_key == old_api_key
+            and target_base_url == old_base_url
+        )
+
+        if nothing_changed:
+            logger.info(
+                "[LLM] Reinitialize no-op — provider/model/credentials "
+                "unchanged, skipping reset"
+            )
+            return self._initialized
+
         try:
             logger.info(
                 f"[LLM] Reinitializing with provider: {target_provider}, model: {target_model or 'registry default'}"
@@ -372,15 +406,21 @@ class LLMInterface:
                     base_url=self.byteplus_base_url,
                     model=self.model,
                 )
-                # Reset session system prompts and multi-turn message histories
-                self._session_system_prompts = {}
-                self._anthropic_session_messages = {}
-                self._bedrock_session_messages = {}
-                self._openrouter_anthropic_session_messages = {}
-                self._gemini_session_messages = {}
-                self._openai_compat_session_messages = {}
             else:
                 self._byteplus_cache_manager = None
+
+            if provider_unchanged:
+                # Model/credentials-only change: the message-history buffers
+                # are provider-agnostic message lists the new model can
+                # consume as-is, so keep them — the prefix cache takes one
+                # miss and re-warms instead of rebuilding from scratch.
+                logger.info(
+                    f"[LLM] Model-only reinit within provider {self.provider}: "
+                    f"preserving session histories"
+                )
+            else:
+                # Real provider change: message formats differ across
+                # providers, so the accumulated histories aren't reusable.
                 self._session_system_prompts = {}
                 self._anthropic_session_messages = {}
                 self._bedrock_session_messages = {}
@@ -406,6 +446,11 @@ class LLMInterface:
                     f"(was {self._consecutive_failures})"
                 )
                 self._consecutive_failures = 0
+
+            # Track last-applied credentials so the next reinitialize() call
+            # can tell whether anything actually changed.
+            self._init_api_key = target_api_key
+            self._init_base_url = target_base_url
 
             logger.info(
                 f"[LLM] Reinitialized successfully with provider: {self.provider}, model: {self.model}"
@@ -1630,15 +1675,35 @@ class LLMInterface:
 
         try:
             if not self._byteplus_cache_manager.has_session(task_id, call_type):
-                raise ValueError(f"No session cache found for {session_key}")
+                # The cache manager was rebuilt (e.g. a model-only Settings
+                # change recreates it since BytePlus sessions are server-side
+                # and model-bound), emptying its session registry — but the
+                # system prompt survives a model-only reinit, so reseed a
+                # fresh session instead of failing this turn outright.
+                system_prompt = self._session_system_prompts.get(session_key)
+                if not system_prompt:
+                    raise ValueError(f"No session cache found for {session_key}")
 
-            result = self._byteplus_cache_manager.chat_with_session(
-                task_id=task_id,
-                call_type=call_type,
-                user_prompt=user_prompt,
-                temperature=self.temperature,
-                max_tokens=self.max_tokens,
-            )
+                logger.info(
+                    f"[BYTEPLUS] No session cache for {session_key} — "
+                    f"reseeding a fresh session from the stored system prompt"
+                )
+                result = self._byteplus_cache_manager.create_session_cache(
+                    task_id=task_id,
+                    call_type=call_type,
+                    system_prompt=system_prompt,
+                    user_prompt=user_prompt,
+                    temperature=self.temperature,
+                    max_tokens=self.max_tokens,
+                )
+            else:
+                result = self._byteplus_cache_manager.chat_with_session(
+                    task_id=task_id,
+                    call_type=call_type,
+                    user_prompt=user_prompt,
+                    temperature=self.temperature,
+                    max_tokens=self.max_tokens,
+                )
 
             logger.info(f"BYTEPLUS SESSION RESPONSE: {result}")
 

--- a/app/agent_base.py
+++ b/app/agent_base.py
@@ -2857,6 +2857,7 @@ class AgentBase:
 
         llm_provider = provider or get_llm_provider()
         vlm_provider = get_vlm_provider()
+        old_llm_provider = self.llm.provider
         llm_ok = self.llm.reinitialize(llm_provider)
         vlm_ok = self.vlm.reinitialize(vlm_provider)
 
@@ -2865,33 +2866,48 @@ class AgentBase:
                 f"[AGENT] LLM and VLM reinitialized with provider: {self.llm.provider}"
             )
 
-            # Rebuild session caches for every live session so the new
-            # provider sees the current compiled prompt, and reset the
-            # event-stream sync points so the next call re-establishes a
-            # fresh session-cache prefix.
-            try:
-                for session_id in list(self.session_manager.sessions.keys()):
-                    self.session_manager.rebuild_session_caches(session_id)
-                    if self.context_engine:
-                        for call_type in (
-                            LLMCallType.REASONING,
-                            LLMCallType.ACTION_SELECTION,
-                            LLMCallType.GUI_REASONING,
-                            LLMCallType.GUI_ACTION_SELECTION,
-                        ):
-                            self.context_engine.reset_event_stream_sync(
-                                call_type, session_id=session_id
-                            )
+            # Only rebuild session caches when the LLM provider actually
+            # changed. `LLMInterface.reinitialize()` only wipes
+            # `_session_system_prompts` and the per-provider message-history
+            # buffers on a real provider change; a model-only (or no-op)
+            # Settings save preserves them, so `has_session_cache()` still
+            # returns True and no rebuild is needed. Rebuilding anyway would
+            # force every live session's next call to resend the FULL event
+            # stream on top of the already-preserved history, duplicating
+            # context instead of protecting it.
+            if self.llm.provider == old_llm_provider:
                 logger.info(
-                    f"[AGENT] Rebuilt session caches for "
-                    f"{len(self.session_manager.sessions)} session(s) under "
-                    f"provider {self.llm.provider}"
+                    "[AGENT] Skipping session-cache rebuild: provider "
+                    "unchanged, session state preserved"
                 )
-            except Exception as e:
-                logger.warning(
-                    f"[AGENT] Failed to rebuild session caches after "
-                    f"provider switch: {e}"
-                )
+            else:
+                # Rebuild session caches for every live session so the new
+                # provider sees the current compiled prompt, and reset the
+                # event-stream sync points so the next call re-establishes a
+                # fresh session-cache prefix.
+                try:
+                    for session_id in list(self.session_manager.sessions.keys()):
+                        self.session_manager.rebuild_session_caches(session_id)
+                        if self.context_engine:
+                            for call_type in (
+                                LLMCallType.REASONING,
+                                LLMCallType.ACTION_SELECTION,
+                                LLMCallType.GUI_REASONING,
+                                LLMCallType.GUI_ACTION_SELECTION,
+                            ):
+                                self.context_engine.reset_event_stream_sync(
+                                    call_type, session_id=session_id
+                                )
+                    logger.info(
+                        f"[AGENT] Rebuilt session caches for "
+                        f"{len(self.session_manager.sessions)} session(s) under "
+                        f"provider {self.llm.provider}"
+                    )
+                except Exception as e:
+                    logger.warning(
+                        f"[AGENT] Failed to rebuild session caches after "
+                        f"provider switch: {e}"
+                    )
 
         return llm_ok and vlm_ok
 

--- a/tests/test_llm_reinitialize.py
+++ b/tests/test_llm_reinitialize.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for LLMInterface.reinitialize() provider/model diffing.
+
+Covers the fix for: a model-only (or no-op) Settings save was
+unconditionally wiping every active task's session-cache state
+(_session_system_prompts + per-provider message histories), even though
+those buffers are only invalidated by an actual *provider* change — the
+message format they hold is provider-specific, not model-specific.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from agent_core.core.impl.llm.interface import LLMInterface
+from app.models.factory import ModelFactory
+
+
+def _make_ctx(provider="anthropic", model="claude-a"):
+    return {
+        "provider": provider,
+        "model": model,
+        "client": object(),
+        "gemini_client": None,
+        "remote_url": None,
+        "byteplus": None,
+        "anthropic_client": object(),
+        "bedrock_client": None,
+        "initialized": True,
+        "auth_mode": "api_key",
+    }
+
+
+@pytest.fixture
+def llm_interface():
+    with patch.object(ModelFactory, "create", return_value=_make_ctx()):
+        interface = LLMInterface(
+            provider="anthropic", model="claude-a", api_key="key-a", base_url=""
+        )
+    # Seed accumulated session state as if a task were mid-flight.
+    interface._session_system_prompts["task-1:reasoning"] = "system prompt"
+    interface._anthropic_session_messages["task-1:reasoning"] = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+    ]
+    return interface
+
+
+def test_reinitialize_noop_preserves_everything(llm_interface):
+    """A Settings save with no actual change must not touch live state."""
+    with patch.object(ModelFactory, "create") as mock_create, patch(
+        "app.config.get_llm_model", return_value="claude-a"
+    ):
+        ok = llm_interface.reinitialize(
+            provider="anthropic", api_key="key-a", base_url=""
+        )
+
+    assert ok is True
+    mock_create.assert_not_called()
+    assert llm_interface._anthropic_session_messages["task-1:reasoning"]
+    assert llm_interface._session_system_prompts["task-1:reasoning"] == "system prompt"
+
+
+def test_reinitialize_model_only_preserves_histories(llm_interface):
+    """Same provider, different model: histories survive, model updates."""
+    with patch.object(
+        ModelFactory, "create", return_value=_make_ctx(model="claude-b")
+    ), patch("app.config.get_llm_model", return_value="claude-b"):
+        ok = llm_interface.reinitialize(
+            provider="anthropic", api_key="key-a", base_url=""
+        )
+
+    assert ok is True
+    assert llm_interface.model == "claude-b"
+    assert llm_interface._anthropic_session_messages["task-1:reasoning"]
+    assert llm_interface._session_system_prompts["task-1:reasoning"] == "system prompt"
+
+
+def test_reinitialize_provider_change_clears_histories(llm_interface):
+    """An actual provider change still fully resets session state."""
+    with patch.object(
+        ModelFactory, "create", return_value=_make_ctx(provider="openai", model="gpt-x")
+    ), patch("app.config.get_llm_model", return_value="gpt-x"):
+        ok = llm_interface.reinitialize(
+            provider="openai", api_key="key-b", base_url=""
+        )
+
+    assert ok is True
+    assert llm_interface.provider == "openai"
+    assert llm_interface._anthropic_session_messages == {}
+    assert llm_interface._session_system_prompts == {}


### PR DESCRIPTION
What and why?
Ports two lost fixes from PR #390 onto V1.4.1: settings saves no longer wipe live session context/KV cache unless the provider actually changes, and the BytePlus API key no longer leaks into logs.